### PR TITLE
Fix for printing issue in issue #23.

### DIFF
--- a/src/megameklab/com/ui/Mek/Printing/PrintMech.java
+++ b/src/megameklab/com/ui/Mek/Printing/PrintMech.java
@@ -886,7 +886,7 @@ public class PrintMech implements Printable {
         int height = Math.min(200, img.getHeight(null));
         int drawingX = 237 + ((148 - width) / 2);
         int drawingY = 172 + ((200 - height) / 2);
-        g2d.drawImage(img, drawingX + leftMargin, topMargin + drawingY, width, height, Color.BLACK, null);
+        g2d.drawImage(img, drawingX + leftMargin, topMargin + drawingY, width, height, null);
 
     }
 

--- a/src/megameklab/com/ui/Mek/Printing/PrintTripod.java
+++ b/src/megameklab/com/ui/Mek/Printing/PrintTripod.java
@@ -922,7 +922,7 @@ public class PrintTripod implements Printable {
         int height = Math.min(145, img.getHeight(null));
         int drawingX = 245 + ((116 - width) / 2);
         int drawingY = 233 + ((145 - height) / 2);
-        g2d.drawImage(img, drawingX + leftMargin, topMargin + drawingY, width, height, Color.BLACK, null);
+        g2d.drawImage(img, drawingX + leftMargin, topMargin + drawingY, width, height, null);
 
     }
 


### PR DESCRIPTION
This will fix the printing issues on OS X reported in issue #23. There was an issue where trying to print from OS X was causing MML to crash. The problem seems to be that the Graphics2D.drawImage() calls in printMekImage() in both the PrintMech and PrintTripod classes were implemented incorrectly.  They included a parameter for color which was causing issues.  Updating these methods to use the correct method call fixes the issue.