### PR TITLE
Added call to Graphics2D.setColor() before call to Graphics2D.drawIam…

### DIFF
--- a/src/megameklab/com/ui/Mek/Printing/PrintMech.java
+++ b/src/megameklab/com/ui/Mek/Printing/PrintMech.java
@@ -886,6 +886,7 @@ public class PrintMech implements Printable {
         int height = Math.min(200, img.getHeight(null));
         int drawingX = 237 + ((148 - width) / 2);
         int drawingY = 172 + ((200 - height) / 2);
+        g2d.setColor(Color.BLACK);
         g2d.drawImage(img, drawingX + leftMargin, topMargin + drawingY, width, height, null);
 
     }

--- a/src/megameklab/com/ui/Mek/Printing/PrintTripod.java
+++ b/src/megameklab/com/ui/Mek/Printing/PrintTripod.java
@@ -922,6 +922,7 @@ public class PrintTripod implements Printable {
         int height = Math.min(145, img.getHeight(null));
         int drawingX = 245 + ((116 - width) / 2);
         int drawingY = 233 + ((145 - height) / 2);
+        g2d.setColor(Color.BLACK);
         g2d.drawImage(img, drawingX + leftMargin, topMargin + drawingY, width, height, null);
 
     }


### PR DESCRIPTION
…ge().

This is another commit to fix issue #23. According to @beerockxs , the Color parameter was being used on purpose. I've added an explicit call to `Graphics2D.setColor(Color.BLACK)` before the call to `Graphics2D.drawImage(Image, int, int, int, int, ImageObserver)`, this should have the same affect without causing issues with printing on a Mac.