### PR TITLE
Update NC3 FCS tonnage display

### DIFF
--- a/src/megameklab/com/ui/Dropship/views/DropshipCriticalView.java
+++ b/src/megameklab/com/ui/Dropship/views/DropshipCriticalView.java
@@ -194,13 +194,18 @@ public class DropshipCriticalView extends IView {
             aftLeftPanel.setVisible(false);
             aftRightPanel.setVisible(false);
         }
-
+        
+        boolean NC3 = TestSmallCraft.hasNC3(getSmallCraft());
         double[] extra = TestSmallCraft.extraSlotCost(getSmallCraft());
         for (int arc = 0; arc < extra.length; arc++) {
             arcTrees[arc].rebuild();
             arcTrees[arc].repaint();
             lblSlotCount[arc].setText(String.valueOf(arcTrees[arc].getSlotCount()));
-            lblExtraTonnage[arc].setText(String.valueOf(extra[arc]));
+            if (NC3 == true) {
+                lblExtraTonnage[arc].setText(String.valueOf(extra[arc] * 2));
+            } else {
+                lblExtraTonnage[arc].setText(String.valueOf(extra[arc]));
+            }
         }
         
     }


### PR DESCRIPTION
Per the Naval C3 construction rules on TO p332, any FCS tonnage for having more than (12) weapons on a given facing is doubled if a Naval C3 is installed. This is in addition to the 1% of the ship base weight of the system.  This adds the mml side to DropshipCriticalView.java