### PR TITLE
Fix for #136: 'Cargo Space' cannot be removed from canon units

### DIFF
--- a/src/megameklab/com/ui/Dropship/tabs/TransportTab.java
+++ b/src/megameklab/com/ui/Dropship/tabs/TransportTab.java
@@ -53,7 +53,7 @@ import megamek.common.Entity;
 import megamek.common.InfantryBay;
 import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestAero;
-import megamek.common.verifier.TestAero.TransportBay;
+import megamek.common.verifier.BayData;
 import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.IView;
@@ -214,8 +214,8 @@ public class TransportTab extends IView implements ActionListener {
         if (selected < 0) {
             return false;
         }
-        TestAero.TransportBay bayType = modelAvailable.getBayType(tblAvailable.convertRowIndexToModel(selected));
-        return (doorsAvailable() > 0) || (bayType == TestAero.TransportBay.CARGO);
+        BayData bayType = modelAvailable.getBayType(tblAvailable.convertRowIndexToModel(selected));
+        return (doorsAvailable() > 0) || (bayType == BayData.CARGO);
     }
     
     /**
@@ -257,7 +257,7 @@ public class TransportTab extends IView implements ActionListener {
             if (bay.getBayNumber() == bayNum) {
                 newBayList.add(bay);
             } else {
-                TestAero.TransportBay bayType = TestAero.TransportBay.getBayType(bay);
+                BayData bayType = BayData.getBayType(bay);
                 Bay newBay = bayType.newBay(bay.getCapacity(), bayNum);
                 newBay.setDoors(bay.getDoors());
                 newBayList.add(newBay);
@@ -278,7 +278,7 @@ public class TransportTab extends IView implements ActionListener {
         if (ev.getSource() == btnAddBay) {
             int selected = tblAvailable.getSelectedRow();
             if (selected >= 0) {
-                TestAero.TransportBay bayType = modelAvailable.getBayType(tblAvailable.convertRowIndexToModel(selected));
+                BayData bayType = modelAvailable.getBayType(tblAvailable.convertRowIndexToModel(selected));
                 int num = 1;
                 while (getAero().getBayById(num) != null) {
                     num++;
@@ -308,7 +308,7 @@ public class TransportTab extends IView implements ActionListener {
                 Bay bay = null;
                 int bayNum = 1;
                 if ((selected >= 0)
-                        && (modelInstalled.getBayType(tblInstalled.convertRowIndexToModel(selected)) == TestAero.TransportBay.CARGO)) {
+                        && (modelInstalled.getBayType(tblInstalled.convertRowIndexToModel(selected)) == BayData.CARGO)) {
                     bay = modelInstalled.getBay(tblInstalled.convertRowIndexToModel(selected));
                     size += bay.getCapacity();
                     bayNum = bay.getBayNumber();
@@ -318,7 +318,7 @@ public class TransportTab extends IView implements ActionListener {
                         bayNum++;
                     }
                 }
-                bay = TestAero.TransportBay.CARGO.newBay(size, bayNum);
+                bay = BayData.CARGO.newBay(size, bayNum);
                 addBay(bay);
                 refresh();
             }
@@ -340,7 +340,7 @@ public class TransportTab extends IView implements ActionListener {
         private static final int NUM_COLS      = 5;
         
         private final List<Bay> bayList = new ArrayList<>();
-        private final List<TestAero.TransportBay> bayTypeList = new ArrayList<>();
+        private final List<BayData> bayTypeList = new ArrayList<>();
         
         public void refreshBays() {
             bayList.clear();
@@ -354,7 +354,7 @@ public class TransportTab extends IView implements ActionListener {
                     .map(t -> (Bay) t).collect(Collectors.toList());
             Collections.sort(bays, (b1, b2) -> b1.getBayNumber() - b2.getBayNumber());
             for (Bay bay : bays) {
-                TestAero.TransportBay bayType = TestAero.TransportBay.getBayType(bay);
+                BayData bayType = BayData.getBayType(bay);
                 if (null != bayType) {
                     bayList.add(bay);
                     bayTypeList.add(bayType);
@@ -371,7 +371,7 @@ public class TransportTab extends IView implements ActionListener {
             return bayList.iterator();
         }
         
-        public TestAero.TransportBay getBayType(int row) {
+        public BayData getBayType(int row) {
             return bayTypeList.get(row);
         }
 
@@ -436,7 +436,7 @@ public class TransportTab extends IView implements ActionListener {
 
         public void reorder(int from, int to) {
             Bay bay = bayList.remove(from);
-            TestAero.TransportBay bayType = bayTypeList.remove(from);
+            BayData bayType = bayTypeList.remove(from);
             if (to > from) {
                 to--;
             }
@@ -460,11 +460,11 @@ public class TransportTab extends IView implements ActionListener {
         private static final int COL_PERSONNEL = 2;
         private static final int NUM_COLS      = 3;
         
-        private List<TestAero.TransportBay> bayList = new ArrayList<>();
+        private List<BayData> bayList = new ArrayList<>();
         
         public void refreshBays() {
             bayList.clear();
-            for (TestAero.TransportBay bay : TestAero.TransportBay.values()) {
+            for (BayData bay : BayData.values()) {
                 if (eSource.getTechManager().isLegal(bay.getTechAdvancement())) {
                     bayList.add(bay);
                 }
@@ -472,7 +472,7 @@ public class TransportTab extends IView implements ActionListener {
             fireTableDataChanged();
         }
 
-        public TransportBay getBayType(int row) {
+        public BayData getBayType(int row) {
             return bayList.get(row);
         }
 

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -624,12 +624,14 @@ public class StructureTab extends ITab implements CVBuildListener {
         toRemove.forEach(t -> getTank().removeTransporter(t));
         double bayTons = Math
                 .round((fixed) * 2) / 2.0;
+        int lastBay = getTank().getTransportBays().stream().mapToInt(Bay::getBayNumber).max().orElse(0);
         if (bayTons > 0) {
-            getTank().addTransporter(bayType.newBay(bayTons, getTank().getTransports().size()), false);
+            getTank().addTransporter(bayType.newBay(bayTons, lastBay + 1), false);
+            lastBay++;
         }
         bayTons = Math.round(pod * 2) / 2.0;
         if (bayTons > 0) {
-            getTank().addTransporter(bayType.newBay(bayTons, getTank().getTransports().size()), true);
+            getTank().addTransporter(bayType.newBay(bayTons, lastBay + 1), true);
         }
         panSummary.refresh();
         refresh.refreshStatus();

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -601,14 +601,14 @@ public class StructureTab extends ITab implements CVBuildListener {
         List<Transporter> toRemove = getTank().getTransports().stream()
                 .filter(t -> t instanceof TroopSpace).collect(Collectors.toList());
         toRemove.forEach(t -> getTank().removeTransporter(t));
-        if (fixed + pod > 0) {
-            double troopTons = Math
-                    .round((fixed) * 2) / 2.0;
+        double troopTons = Math
+                .round((fixed) * 2) / 2.0;
+        if (troopTons > 0) {
             getTank().addTransporter(new TroopSpace(troopTons), false);
-            if (pod > 0) {
-                troopTons = Math.round(pod * 2) / 2.0;
-                getTank().addTransporter(new TroopSpace(troopTons), true);
-            }
+        }
+        troopTons = Math.round(pod * 2) / 2.0;
+        if (troopTons > 0) {
+            getTank().addTransporter(new TroopSpace(troopTons), true);
         }
         panSummary.refresh();
         refresh.refreshStatus();
@@ -622,14 +622,14 @@ public class StructureTab extends ITab implements CVBuildListener {
                         && (bayType == BayData.getBayType((Bay) t)))
                         .collect(Collectors.toList());
         toRemove.forEach(t -> getTank().removeTransporter(t));
-        if (fixed + pod > 0) {
-            double bayTons = Math
-                    .round((fixed) * 2) / 2.0;
+        double bayTons = Math
+                .round((fixed) * 2) / 2.0;
+        if (bayTons > 0) {
             getTank().addTransporter(bayType.newBay(bayTons, getTank().getTransports().size()), false);
-            if (pod > 0) {
-                bayTons = Math.round(pod * 2) / 2.0;
-                getTank().addTransporter(bayType.newBay(bayTons, getTank().getTransports().size()), true);
-            }
+        }
+        bayTons = Math.round(pod * 2) / 2.0;
+        if (bayTons > 0) {
+            getTank().addTransporter(bayType.newBay(bayTons, getTank().getTransports().size()), true);
         }
         panSummary.refresh();
         refresh.refreshStatus();

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -19,6 +19,8 @@ package megameklab.com.ui.Vehicle.tabs;
 import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -26,6 +28,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import megamek.common.Bay;
 import megamek.common.Engine;
 import megamek.common.Entity;
 import megamek.common.EntityMovementMode;
@@ -38,14 +41,17 @@ import megamek.common.SimpleTechLevel;
 import megamek.common.SuperHeavyTank;
 import megamek.common.Tank;
 import megamek.common.TechConstants;
+import megamek.common.Transporter;
 import megamek.common.TroopSpace;
 import megamek.common.VTOL;
 import megamek.common.verifier.TestEntity;
+import megamek.common.verifier.BayData;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.Vehicle.views.SummaryView;
 import megameklab.com.ui.view.ArmorAllocationView;
 import megameklab.com.ui.view.BasicInfoView;
 import megameklab.com.ui.view.CVChassisView;
+import megameklab.com.ui.view.CVTransportView;
 import megameklab.com.ui.view.MVFArmorView;
 import megameklab.com.ui.view.MovementView;
 import megameklab.com.ui.view.PatchworkArmorView;
@@ -70,6 +76,7 @@ public class StructureTab extends ITab implements CVBuildListener {
     private SummaryView panSummary;
     private ArmorAllocationView panArmorAllocation;
     private PatchworkArmorView panPatchwork;
+    private CVTransportView panTransport;
     
     public StructureTab(EntitySource eSource) {
         super(eSource);
@@ -88,6 +95,7 @@ public class StructureTab extends ITab implements CVBuildListener {
         panArmorAllocation = new ArmorAllocationView(panBasicInfo, Entity.ETYPE_TANK);
         panPatchwork = new PatchworkArmorView(panBasicInfo);
         panSummary = new SummaryView(eSource);
+        panTransport = new CVTransportView();
         if (getTank().hasPatchworkArmor()) {
             panArmorAllocation.showPatchwork(true);
         } else {
@@ -102,6 +110,7 @@ public class StructureTab extends ITab implements CVBuildListener {
         panArmor.setFromEntity(getTank());
         panArmorAllocation.setFromEntity(getTank());
         panPatchwork.setFromEntity(getTank());
+        panTransport.setFromEntity(getTank());
 
         gbc = new GridBagConstraints();
 
@@ -120,6 +129,7 @@ public class StructureTab extends ITab implements CVBuildListener {
         leftPanel.add(Box.createGlue());
         
         midPanel.add(panArmor);
+        midPanel.add(panTransport);
         midPanel.add(panSummary);
         midPanel.add(Box.createVerticalGlue());
         
@@ -146,6 +156,7 @@ public class StructureTab extends ITab implements CVBuildListener {
         panSummary.setBorder(BorderFactory.createTitledBorder("Summary"));
         panArmorAllocation.setBorder(BorderFactory.createTitledBorder("Armor Allocation"));
         panPatchwork.setBorder(BorderFactory.createTitledBorder("Patchwork Armor"));
+        panTransport.setBorder(BorderFactory.createTitledBorder("Transport"));
     }
 
     public void refresh() {
@@ -157,6 +168,7 @@ public class StructureTab extends ITab implements CVBuildListener {
         panArmor.setFromEntity(getTank());
         panArmorAllocation.setFromEntity(getTank());
         panPatchwork.setFromEntity(getTank());
+        panTransport.setFromEntity(getTank());
 
         panSummary.refresh();
 
@@ -181,6 +193,7 @@ public class StructureTab extends ITab implements CVBuildListener {
         panArmor.removeListener(this);
         panArmorAllocation.removeListener(this);
         panPatchwork.removeListener(this);
+        panTransport.removeListener(this);
     }
 
     public void addAllListeners() {
@@ -190,6 +203,7 @@ public class StructureTab extends ITab implements CVBuildListener {
         panArmor.addListener(this);
         panArmorAllocation.addListener(this);
         panPatchwork.addListener(this);
+        panTransport.addListener(this);
     }
 
     public void addRefreshedListener(RefreshListener l) {
@@ -465,11 +479,11 @@ public class StructureTab extends ITab implements CVBuildListener {
         getTank().setOmni(omni);
         if (!omni) {
             getTank().getEngine().setBaseChassisHeatSinks(-1);
-            troopSpaceChanged(getTank().getTroopCarryingSpace(), 0);
         }
         panChassis.removeListener(this);
         panChassis.setFromEntity(getTank());
         panChassis.addListener(this);
+        panTransport.setOmni(omni);
         panSummary.refresh();
         refresh.refreshBuild();
         refresh.refreshStatus();
@@ -584,7 +598,9 @@ public class StructureTab extends ITab implements CVBuildListener {
 
     @Override
     public void troopSpaceChanged(double fixed, double pod) {
-        getTank().removeAllTransporters();
+        List<Transporter> toRemove = getTank().getTransports().stream()
+                .filter(t -> t instanceof TroopSpace).collect(Collectors.toList());
+        toRemove.forEach(t -> getTank().removeTransporter(t));
         if (fixed + pod > 0) {
             double troopTons = Math
                     .round((fixed) * 2) / 2.0;
@@ -596,14 +612,35 @@ public class StructureTab extends ITab implements CVBuildListener {
         }
         panSummary.refresh();
         refresh.refreshStatus();
+        refresh.refreshPreview();
+    }
+    
+    @Override
+    public void cargoSpaceChanged(BayData bayType, double fixed, double pod) {
+        List<Transporter> toRemove = getTank().getTransports().stream()
+                .filter(t -> (t instanceof Bay)
+                        && (bayType == BayData.getBayType((Bay) t)))
+                        .collect(Collectors.toList());
+        toRemove.forEach(t -> getTank().removeTransporter(t));
+        if (fixed + pod > 0) {
+            double bayTons = Math
+                    .round((fixed) * 2) / 2.0;
+            getTank().addTransporter(bayType.newBay(bayTons, getTank().getTransports().size()), false);
+            if (pod > 0) {
+                bayTons = Math.round(pod * 2) / 2.0;
+                getTank().addTransporter(bayType.newBay(bayTons, getTank().getTransports().size()), true);
+            }
+        }
+        panSummary.refresh();
+        refresh.refreshStatus();
+        refresh.refreshPreview();
     }
 
     @Override
     public void resetChassis() {
         UnitUtil.resetBaseChassis(getTank());
-        troopSpaceChanged(getTank().getTroopCarryingSpace()
-                - getTank().getPodMountedTroopCarryingSpace(), 0);
         panChassis.setFromEntity(getTank());
+        panTransport.clearPodSpace();
         panSummary.refresh();
         refresh.refreshEquipment();
         refresh.refreshBuild();

--- a/src/megameklab/com/ui/view/BuildView.java
+++ b/src/megameklab/com/ui/view/BuildView.java
@@ -35,6 +35,7 @@ public abstract class BuildView extends JPanel {
     private static final long serialVersionUID = 8823653930022761924L;
     
     final protected Dimension labelSize = new Dimension(110, 25);
+    final protected Dimension labelSizeLg = new Dimension(180, 25);
     final protected Dimension controlSize = new Dimension(180, 25);
     final protected Dimension spinnerSize = new Dimension(55, 25);
     final protected Dimension spinnerSizeLg = new Dimension(70, 25);

--- a/src/megameklab/com/ui/view/CVChassisView.java
+++ b/src/megameklab/com/ui/view/CVChassisView.java
@@ -92,8 +92,6 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
     private final SpinnerNumberModel spnTonnageModel = new SpinnerNumberModel(20, 1, 100, 1);
     private final SpinnerNumberModel spnTurretWtModel = new SpinnerNumberModel(0.0, 0.0, null, 0.5);
     private final SpinnerNumberModel spnTurret2WtModel = new SpinnerNumberModel(0.0, 0.0, null, 0.5);
-    private final SpinnerNumberModel spnFixedTroopModel = new SpinnerNumberModel(0.0, 0.0, null, 0.5);
-    private final SpinnerNumberModel spnPodTroopModel = new SpinnerNumberModel(0.0, 0.0, null, 0.5);
     private String[] turretNames;
     private final Map<EntityMovementMode,String> motiveNames = new EnumMap<>(EntityMovementMode.class);
 
@@ -106,8 +104,6 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
     private final CustomComboBox<Integer> cbTurrets = new CustomComboBox<>(i -> turretNames[i]);
     private final JSpinner spnChassisTurretWt = new JSpinner(spnTurretWtModel);
     private final JSpinner spnChassisTurret2Wt = new JSpinner(spnTurret2WtModel);
-    private final JSpinner spnFixedTroop = new JSpinner(spnFixedTroopModel);
-    private final JSpinner spnPodTroop = new JSpinner(spnPodTroopModel);
     
     private final List<JComponent> omniComponents = new ArrayList<>();
 
@@ -220,37 +216,10 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
         omniComponents.add(lbl);
         omniComponents.add(spnChassisTurret2Wt);
         
-        gbc.gridx = 0;
-        gbc.gridy = 6;
-        gbc.gridwidth = 3;
-        add(createLabel(resourceMap.getString("CVChassisView.spnFixedTroop.text"), labelSize), gbc); //$NON-NLS-1$
-        gbc.gridx = 3;
-        gbc.gridy = 6;
-        gbc.gridwidth = 1;
-        setFieldSize(spnFixedTroop, spinnerSize);
-        spnFixedTroop.setToolTipText(resourceMap.getString("CVChassisView.spnFixedTroop.tooltip")); //$NON-NLS-1$
-        add(spnFixedTroop, gbc);
-        spnFixedTroop.addChangeListener(this);
-
-        gbc.gridx = 0;
-        gbc.gridy = 7;
-        gbc.gridwidth = 3;
-        lbl = createLabel(resourceMap.getString("CVChassisView.spnPodTroop.text"), labelSize); //$NON-NLS-1$
-        add(lbl, gbc);
-        gbc.gridx = 3;
-        gbc.gridy = 7;
-        gbc.gridwidth = 1;
-        setFieldSize(spnPodTroop, spinnerSize);
-        spnPodTroop.setToolTipText(resourceMap.getString("CVChassisView.spnPodTroop.tooltip")); //$NON-NLS-1$
-        add(spnPodTroop, gbc);
-        spnPodTroop.addChangeListener(this);
-        omniComponents.add(lbl);
-        omniComponents.add(spnPodTroop);
-        
         JButton btnResetChassis = new JButton(resourceMap.getString("CVChassisView.btnResetChassis.text")); //$NON-NLS-1$
         btnResetChassis.setActionCommand(CMD_RESET_CHASSIS);
         gbc.gridx = 1;
-        gbc.gridy = 8;
+        gbc.gridy = 6;
         gbc.gridwidth = 3;
         setFieldSize(btnResetChassis, controlSize);
         btnResetChassis.setToolTipText(resourceMap.getString("CVChassisView.btnResetChassis.tooltip")); //$NON-NLS-1$
@@ -281,11 +250,6 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
         spnTurretWtModel.setValue(Math.max(0, tank.getBaseChassisTurretWeight()));
         spnTurret2WtModel.setValue(Math.max(0, tank.getBaseChassisTurret2Weight()));
         
-        double troops = tank.getTroopCarryingSpace();
-        double podTroops = tank.getPodMountedTroopCarryingSpace();
-        spnFixedTroop.setValue(troops - podTroops);
-        spnPodTroop.setValue(podTroops);
-
         omniComponents.forEach(c -> c.setEnabled(chkOmni.isSelected()));
         spnChassisTurretWt.setEnabled(chkOmni.isSelected() && (cbTurrets.getSelectedIndex() > 0));
         spnChassisTurret2Wt.setEnabled(chkOmni.isSelected() && (cbTurrets.getSelectedIndex() > 1));
@@ -298,19 +262,6 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
         chkOmni.addActionListener(this);
         refreshEngine();
         refreshTurrets();
-        double maxWt = getTonnage();
-        spnFixedTroopModel.setMaximum(maxWt);
-        if (spnFixedTroopModel.getNumber().doubleValue() > maxWt) {
-            spnFixedTroopModel.removeChangeListener(this);
-            spnFixedTroopModel.setValue(maxWt);
-            spnFixedTroopModel.addChangeListener(this);
-        }
-        spnPodTroopModel.setMaximum(maxWt);
-        if (spnFixedTroopModel.getNumber().doubleValue() > maxWt) {
-            spnFixedTroopModel.removeChangeListener(this);
-            spnFixedTroopModel.setValue(maxWt);
-            spnFixedTroopModel.addChangeListener(this);
-        }
         
         omniComponents.forEach(c -> c.setEnabled(chkOmni.isSelected()));
         spnChassisTurretWt.setEnabled(chkOmni.isSelected() && (cbTurrets.getSelectedIndex() > 0));
@@ -503,10 +454,6 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
                 || (e.getSource() == spnChassisTurret2Wt)){
             listeners.forEach(l -> l.turretBaseWtChanged(spnTurretWtModel.getNumber().doubleValue(),
                     spnTurret2WtModel.getNumber().doubleValue()));
-        } else if ((e.getSource() == spnFixedTroop)
-                || (e.getSource() == spnPodTroop)){
-            listeners.forEach(l -> l.troopSpaceChanged(spnFixedTroopModel.getNumber().doubleValue(),
-                    spnPodTroopModel.getNumber().doubleValue()));
         }
     }
 

--- a/src/megameklab/com/ui/view/CVTransportView.java
+++ b/src/megameklab/com/ui/view/CVTransportView.java
@@ -1,0 +1,220 @@
+/*
+ * MegaMekLab - Copyright (C) 2018 - The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ */
+package megameklab.com.ui.view;
+
+import java.awt.Component;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ResourceBundle;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+import megamek.common.Bay;
+import megamek.common.Tank;
+import megamek.common.util.EncodeControl;
+import megamek.common.verifier.BayData;
+import megameklab.com.ui.view.listeners.CVBuildListener;
+
+/**
+ * Panel for combat vehicle cargo and troop space.
+ * 
+ * @author Neoancient
+ *
+ */
+public class CVTransportView extends BuildView implements ChangeListener {
+    
+    /**
+     * 
+     */
+    private static final long serialVersionUID = -3059498307570586741L;
+    
+    List<CVBuildListener> listeners = new CopyOnWriteArrayList<>();
+    public void addListener(CVBuildListener l) {
+        listeners.add(l);
+    }
+    public void removeListener(CVBuildListener l) {
+        listeners.remove(l);
+    }
+
+    private final SpinnerNumberModel spnFixedTroopModel = new SpinnerNumberModel(0.0, 0.0, null, 0.5);
+    private final SpinnerNumberModel spnPodTroopModel = new SpinnerNumberModel(0.0, 0.0, null, 0.5);
+    private final Map<BayData, SpinnerNumberModel> fixedSpinnerModels = new HashMap<>();
+    private final Map<BayData, SpinnerNumberModel> podSpinnerModels = new HashMap<>();
+    
+    private final JSpinner spnFixedTroop = new JSpinner(spnFixedTroopModel);
+    private final JSpinner spnPodTroop = new JSpinner(spnPodTroopModel);
+    private final Map<BayData, JSpinner> fixedSpinners = new HashMap<>();
+    private final Map<BayData, JSpinner> podSpinners = new HashMap<>();
+    
+    // Track unit tonnage to set max allowed carrying space.
+    private double tonnage;
+
+    public CVTransportView() {
+        super();
+        initUI();
+    }
+    
+    private void initUI() {
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl()); //$NON-NLS-1$
+        
+        setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gbc.anchor = GridBagConstraints.WEST;
+        add(createLabel(resourceMap.getString("CVTransportView.lblFixed.text"), labelSize), gbc); //$NON-NLS-1$
+        gbc.gridx = 2;
+        gbc.gridy = 0;
+        add(createLabel(resourceMap.getString("CVTransportView.lblPod.text"), labelSize), gbc); //$NON-NLS-1$
+
+        gbc.gridx = 0;
+        gbc.gridy = 1;
+        add(createLabel(resourceMap.getString("CVTransportView.lblTroopSpace.text"), labelSizeLg), gbc); //$NON-NLS-1$
+        
+        gbc.gridx = 1;
+        setFieldSize(spnFixedTroop, editorSize);
+        add(spnFixedTroop, gbc);
+        spnFixedTroop.addChangeListener(this);
+        
+        gbc.gridx = 2;
+        setFieldSize(spnPodTroop, editorSize);
+        add(spnPodTroop, gbc);
+        spnPodTroop.addChangeListener(this);
+        
+        for (BayData bayType : BayData.values()) {
+            if (!bayType.isCargoBay()) {
+                continue;
+            }
+            String tooltip = String.format(resourceMap.getString("CVTransportView.bay.tooltipFormat"),
+                    1 / bayType.getWeight());
+            gbc.gridx = 0;
+            gbc.gridy++;
+            add(createLabel(bayType.getDisplayName(), labelSizeLg), gbc);
+            
+            gbc.gridx = 1;
+            SpinnerNumberModel model = new SpinnerNumberModel(0.0, 0.0, null, 0.5);
+            JSpinner spinner = new JSpinner(model);
+            spinner.setToolTipText(tooltip);
+            spinner.setName(bayType.toString());
+            setFieldSize(spinner, editorSize);
+            fixedSpinnerModels.put(bayType, model);
+            fixedSpinners.put(bayType, spinner);
+            add(spinner, gbc);
+            spinner.addChangeListener(this);
+            
+            gbc.gridx = 2;
+            model = new SpinnerNumberModel(0.0, 0.0, null, 0.5);
+            spinner = new JSpinner(model);
+            spinner.setToolTipText(tooltip);
+            spinner.setName(bayType.toString());
+            setFieldSize(spinner, editorSize);
+            podSpinnerModels.put(bayType, model);
+            podSpinners.put(bayType, spinner);
+            add(spinner, gbc);
+            spinner.addChangeListener(this);
+        }
+    }
+    
+    public void setFromEntity(Tank tank) {
+        double troops = tank.getTroopCarryingSpace();
+        double podTroops = tank.getPodMountedTroopCarryingSpace();
+        spnFixedTroop.setValue(troops - podTroops);
+        spnPodTroop.setValue(podTroops);
+
+        Map<BayData, Double> fixedCargo = new HashMap<>();
+        Map<BayData, Double> podCargo = new HashMap<>();
+        for (Bay b : tank.getTransportBays()) {
+            BayData bayType = BayData.getBayType(b);
+            if (null != bayType) {
+                if (tank.isPodMountedTransport(b)) {
+                    podCargo.merge(bayType, b.getCapacity(), Double::sum);
+                } else {
+                    fixedCargo.merge(bayType, b.getCapacity(), Double::sum);
+                }
+            }
+        }
+        for (Map.Entry<BayData, JSpinner> entry : fixedSpinners.entrySet()) {
+            entry.getValue().setValue(fixedCargo.getOrDefault(entry.getKey(), 0.0));
+        }
+        for (Map.Entry<BayData, JSpinner> entry : podSpinners.entrySet()) {
+            entry.getValue().setValue(podCargo.getOrDefault(entry.getKey(), 0.0));
+        }
+        setOmni(tank.isOmni());
+    }
+    
+    public void setTonnage(double tonnage) {
+        this.tonnage = tonnage;
+        refresh();
+    }
+    
+    public void setOmni(boolean omni) {
+        spnPodTroop.setEnabled(omni);
+        podSpinners.values().forEach(v -> v.setEnabled(omni));
+        clearPodSpace();
+    }
+    
+    public void clearPodSpace() {
+        spnPodTroop.setValue(0.0);
+        podSpinners.values().forEach(v -> v.setValue(0.0));
+    }
+    
+    public void refresh() {
+        resetMaxSize(spnFixedTroopModel, tonnage);
+        resetMaxSize(spnPodTroopModel, tonnage);
+        fixedSpinnerModels.values().forEach(m -> resetMaxSize(m, tonnage));
+        podSpinnerModels.values().forEach(m -> resetMaxSize(m, tonnage));
+    }
+    
+    private void resetMaxSize(SpinnerNumberModel model, double max) {
+        model.setMaximum(max);
+        if (model.getNumber().doubleValue() > max) {
+            model.removeChangeListener(this);
+            model.setValue(max);
+            model.addChangeListener(this);
+        }
+    }
+
+    @Override
+    public void stateChanged(ChangeEvent e) {
+        if ((e.getSource() == spnFixedTroop)
+                || (e.getSource() == spnPodTroop)) {
+            listeners.forEach(l -> l.troopSpaceChanged(spnFixedTroopModel.getNumber().doubleValue(),
+                    spnPodTroopModel.getNumber().doubleValue()));
+        } else if (e.getSource() instanceof Component) {
+            BayData bayType = null;
+            for (BayData bay : BayData.values()) {
+                if (bay.toString().equals(((Component) e.getSource()).getName())) {
+                    bayType = bay;
+                    break;
+                }
+            }
+            if (null != bayType) {
+                for (CVBuildListener l : listeners) {
+                    l.cargoSpaceChanged(bayType,
+                        fixedSpinnerModels.get(bayType).getNumber().doubleValue(),
+                        podSpinnerModels.get(bayType).getNumber().doubleValue());
+                }
+            }
+        }
+    }
+}

--- a/src/megameklab/com/ui/view/listeners/CVBuildListener.java
+++ b/src/megameklab/com/ui/view/listeners/CVBuildListener.java
@@ -15,6 +15,7 @@ package megameklab.com.ui.view.listeners;
 
 import megamek.common.Engine;
 import megamek.common.EntityMovementMode;
+import megamek.common.verifier.BayData;
 
 /**
  * Listener for views used by combat vehicles.
@@ -32,6 +33,7 @@ public interface CVBuildListener extends BuildListener {
     void turretChanged(int turretConfig);
     void turretBaseWtChanged(double turret1, double turret2);
     void troopSpaceChanged(double fixed, double pod);
+    void cargoSpaceChanged(BayData bayType, double fixed, double pod);
     void resetChassis();
 
 }

--- a/src/megameklab/resources/Views.properties
+++ b/src/megameklab/resources/Views.properties
@@ -96,6 +96,12 @@ CVChassisView.spnPodTroop.tooltip=Pod space devoted to infantry transport.
 CVChassisView.btnResetChassis.text=Reset Chassis
 CVChassisView.btnResetChassis.tooltip=Remove all pod-mounted equipment and troop space to strip unit down to base omni chassis.
 
+CVTransportView.lblFixed.text=Fixed
+CVTransportView.lblPod.text=Pod
+CVTransportView.lblTroopSpace.text=Troop Space
+CVTransportView.troopSpace.tooltip=The tonnage devoted to carrying combat-ready infantry. This does not include crew quarters.
+CVTransportView.bay.tooltipFormat=The tonnage devoted to cargo space. Each ton provides %3.2f tons of capacity.
+
 FighterChassisView.spnTonnage.text=Tonnage:
 FighterChassisView.spnTonnage.tooltip=Value between 5 and 100 in 5 ton increments. Conventional fighters are limited to 50 tons. 
 FighterChassisView.chkOmni.text=Omni


### PR DESCRIPTION
Added panel to vehicle structure tab for designating amount of cargo space, broken down by different cargo bay types. Omni vehicles can split space between fixed and pod-mounted. Moved troop space to transport panel.

This depends on the bay_construction_data branch of MM, in which the transport bay construction data that was part of TestAero was refactored into a separate class and modified for use by non-aerospace units.