### PR TITLE
Fix for #153: Turret disappered

### DIFF
--- a/src/megameklab/com/ui/Vehicle/views/CriticalView.java
+++ b/src/megameklab/com/ui/Vehicle/views/CriticalView.java
@@ -278,6 +278,9 @@ public class CriticalView extends IView {
                         case VTOL.LOC_ROTOR:
                             turretPanel.add(criticalSlotList);
                             break;
+                        case VTOL.LOC_TURRET:
+                            dualTurretPanel.add(criticalSlotList);
+                            break;
                     }
                 } else {
                     switch (location) {


### PR DESCRIPTION
Add a critical panel for assigning equipment to VTOL chin turret. VTOLs use the turret panel for rotor; VTOLs with a chin turret are treated like dual-turret tanks with the chin turret using the second turret position.

It seems to me this used to work, but I didn't see anything in the history that looks like it would have broken it.