### PR TITLE
Fix for #152: Mech Image not printing

### DIFF
--- a/src/megameklab/com/util/ImageHelper.java
+++ b/src/megameklab/com/util/ImageHelper.java
@@ -217,6 +217,10 @@ public class ImageHelper {
         File f = null;
         
         if (unit.getFluff().getMMLImagePath().length() > 0) {
+            f = new File(unit.getFluff().getMMLImagePath());
+            if (f.exists()) {
+                return f;
+            }
             f = new File(path, unit.getFluff().getMMLImagePath());
             if (f.exists()) {
                 return f;


### PR DESCRIPTION
Check for fluff file relative to the installation directory first, then
relative to the fluff image directory, only defaulting to HUD image if
not found in either location.

Fixes #152: Mech Image not printing