### PR TITLE
Infantry fixes

### DIFF
--- a/src/megameklab/com/ui/Infantry/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Infantry/tabs/StructureTab.java
@@ -367,6 +367,11 @@ public class StructureTab extends ITab implements InfantryBuildListener {
         panWeapons.setFromEntity(getInfantry());
         updateSpecializations();
         enableTabs();
+        weaponView.refresh();
+        fieldGunView.refresh();
+        armorView.refresh();
+        specializationView.refresh();
+        augmentationView.refresh();
     }
 
     @Override

--- a/src/megameklab/com/ui/view/BasicInfoView.java
+++ b/src/megameklab/com/ui/view/BasicInfoView.java
@@ -199,11 +199,11 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     public void setFromEntity(Entity en) {
         boolean useTP = CConfig.getBooleanParam(CConfig.TECH_PROGRESSION);
         baseTA = en.getConstructionTechAdvancement();
-        txtYear.setMinimum(baseTA.getIntroductionDate());
+        txtYear.setMinimum(Math.max(baseTA.getIntroductionDate(), ITechnology.DATE_PS));
         refreshTechBase();
         setChassis(en.getChassis());
         setModel(en.getModel());
-        setYear(en.getYear());
+        setYear(Math.max(en.getYear(), txtYear.getMinimum()));
         setSource(en.getSource());
         cbTechBase.removeActionListener(this);
         setTechBase(en.isClan(), en.isMixedTech());


### PR DESCRIPTION
Refreshes equipment tabs when tech parameters change (year, tech level, faction).

I also noticed by accident that loading foot rifle or mg platoons causes problems because the units have intro dates of 1900 and 1940 respectively, and the earliest date given by IO for equipment introduction is early spaceflight (ES), which it defines as 1950. This leaves the units with no available equipment, including no possible movement mode (which results in a thrown exception). I decided that in light of incompatible rules the least meddlesome hack is to set ES as the earliest possible date.