### PR TITLE
Use generic chassis image on RS if specific model not found.

### DIFF
--- a/docs/history.txt
+++ b/docs/history.txt
@@ -1,6 +1,7 @@
 VERSION HISTORY:
 ----------------
 v0.43.12-RC6
++ If no fluff image is found for the model, check for generic chassis image for record sheet.
 
 v0.43.11-RC5 (2018-06-04 0100 UTC)
 + Issue #156: Davy Crockett ammo issue

--- a/src/megameklab/com/util/ImageHelper.java
+++ b/src/megameklab/com/util/ImageHelper.java
@@ -228,21 +228,18 @@ public class ImageHelper {
         }
 
         path = new File(path, dir).getAbsolutePath();
-        f = new File(path, unit.getShortNameRaw() + ".png");
-        if (f.exists()) {
-            return f;
+        final String [] EXTENSIONS = { ".png", ".PNG", ".jpg", ".JPG", ".jpeg", ".JPEG", ".gif", ".GIF" };
+        for (String ext : EXTENSIONS) {
+            f = new File(path, unit.getShortNameRaw() + ext);
+            if (f.exists()) {
+                return f;
+            }
         }
-        f = new File(path, unit.getShortNameRaw() + ".jpg");
-        if (f.exists()) {
-            return f;
-        }
-        f = new File(path, unit.getShortNameRaw() + ".jpeg");
-        if (f.exists()) {
-            return f;
-        }
-        f = new File(path, unit.getShortNameRaw() + ".gif");
-        if (f.exists()) {
-            return f;
+        for (String ext : EXTENSIONS) {
+            f = new File(path, unit.getChassis() + ext);
+            if (f.exists()) {
+                return f;
+            }
         }
         f = new File(path, "hud.png");
         if (f.exists()) {


### PR DESCRIPTION
If no fluff image is found for the model, check for generic chassis image for record sheet.

Issue reported here: https://bg.battletech.com/forums/index.php?topic=61783.msg1418023#msg1418023