### PR TITLE
Include non-fusion in list of available engines for industrialmechs.

### DIFF
--- a/src/megameklab/com/ui/view/MekChassisView.java
+++ b/src/megameklab/com/ui/view/MekChassisView.java
@@ -589,7 +589,8 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
             engineTypes = LAM_ENGINE_TYPES;
         }
         // Non-superheavies can use non-fusion engines under experimental rules
-        boolean allowNonFusion = isPrimitive() || (!isSuperheavy()
+        // industrials and primitives can use non-fusion under standard rules
+        boolean allowNonFusion = isIndustrial() || isPrimitive() || (!isSuperheavy()
                 && techManager.getTechLevel().compareTo(SimpleTechLevel.EXPERIMENTAL) >= 0);
         for (int i : engineTypes) {
             Engine e = new Engine(getEngineRating(), i, flags);


### PR DESCRIPTION
Fixes #160: Industrial Mechs ICE engine Tech Progression Wrong.