### PR TITLE
Do not set selected item if there are no valid items in refreshCockpit

### DIFF
--- a/src/megameklab/com/ui/view/MekChassisView.java
+++ b/src/megameklab/com/ui/view/MekChassisView.java
@@ -531,7 +531,9 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
                 }
             }
         }
-        cbCockpit.setSelectedItem(prev);
+        if (prev != null && prev < cbCockpit.getModel().getSize()) {
+            cbCockpit.setSelectedItem(prev);
+        }
         cbCockpit.addActionListener(this);
         if ((cbCockpit.getSelectedIndex() < 0)
                 && (cbCockpit.getModel().getSize() > 0)) {


### PR DESCRIPTION
Reviewing the exception details from #142 it appears that `cbCockpit.setSelectedItem` was being called when there were no items left in the cockpit combo box.
```
Exception in thread "AWT-EventQueue-0" java.lang.IllegalArgumentException: setSelectedIndex: 0 out of bounds
	at javax.swing.JComboBox.setSelectedIndex(Unknown Source)
	at megameklab.com.ui.view.MekChassisView.refreshCockpit(MekChassisView.java:533)
	at megameklab.com.ui.view.MekChassisView.refresh(MekChassisView.java:392)
	at megameklab.com.ui.view.MekChassisView.setFromEntity(MekChassisView.java:299)
	at megameklab.com.ui.Mek.tabs.StructureTab.refresh(StructureTab.java:168)
	at megameklab.com.ui.Mek.MainUI.refreshAll(MainUI.java:214)
	at megameklab.com.ui.Mek.tabs.BuildTab.compactCrits(BuildTab.java:167)
	at megameklab.com.ui.Mek.tabs.BuildTab.actionPerformed(BuildTab.java:109)
	at javax.swing.AbstractButton.fireActionPerformed(Unknown Source)
	at javax.swing.AbstractButton$Handler.actionPerformed(Unknown Source)
	at javax.swing.DefaultButtonModel.fireActionPerformed(Unknown Source)
	at javax.swing.DefaultButtonModel.setPressed(Unknown Source)
	at javax.swing.plaf.basic.BasicButtonListener.mouseReleased(Unknown Source)
	at java.awt.Component.processMouseEvent(Unknown Source)
	at javax.swing.JComponent.processMouseEvent(Unknown Source)
	at java.awt.Component.processEvent(Unknown Source)
	at java.awt.Container.processEvent(Unknown Source)
	at java.awt.Component.dispatchEventImpl(Unknown Source)
	at java.awt.Container.dispatchEventImpl(Unknown Source)
	at java.awt.Component.dispatchEvent(Unknown Source)
	at java.awt.LightweightDispatcher.retargetMouseEvent(Unknown Source)
	at java.awt.LightweightDispatcher.processMouseEvent(Unknown Source)
	at java.awt.LightweightDispatcher.dispatchEvent(Unknown Source)
	at java.awt.Container.dispatchEventImpl(Unknown Source)
	at java.awt.Window.dispatchEventImpl(Unknown Source)
	at java.awt.Component.dispatchEvent(Unknown Source)
	at java.awt.EventQueue.dispatchEventImpl(Unknown Source)
	at java.awt.EventQueue.access$500(Unknown Source)
	at java.awt.EventQueue$3.run(Unknown Source)
	at java.awt.EventQueue$3.run(Unknown Source)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.awt.EventQueue$4.run(Unknown Source)
	at java.awt.EventQueue$4.run(Unknown Source)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(Unknown Source)
	at java.awt.EventQueue.dispatchEvent(Unknown Source)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(Unknown Source)
	at java.awt.EventDispatchThread.pumpEventsForFilter(Unknown Source)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(Unknown Source)
	at java.awt.EventDispatchThread.pumpEvents(Unknown Source)
	at java.awt.EventDispatchThread.pumpEvents(Unknown Source)
	at java.awt.EventDispatchThread.run(Unknown Source)
```
I'm not sure if this is the only cause of the failures seen, but it is the proximate cause given the exception log.