### PR TITLE
Fix for sorting by damage in equipment tables

### DIFF
--- a/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
@@ -802,14 +802,24 @@ public class EquipmentTab extends ITab implements ActionListener {
             }
         }
 
+        /**
+         * Extracts an integer value from the damage string for use in sorting by damage. If a String
+         * contains any non-digit character, that character and anything after it is ignored. If the string
+         * starts with a non-digit character the return value is 0.
+         * 
+         * @param s A weapon damage string
+         * @return  The value to use for sorting.
+         */
         private int parseDamage(String s) {
-            int damage = 0;
-            if(s.contains("/")) {
-                damage = Integer.parseInt(s.split("/")[0]);
-            } else {
-                damage = Integer.parseInt(s);
+            s = s.replaceAll("[^0-9]+", "/");
+            if (s.contains("/")) {
+                s = s.substring(0, s.indexOf("/"));
             }
-            return damage;
+            if (s.length() > 0) {
+                return Integer.parseInt(s);
+            } else {
+                return 0;
+            }
         }
     }
 

--- a/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
@@ -789,20 +789,30 @@ public class EquipmentTab extends ITab implements ActionListener {
                 return -1;
             } else {
                 //get the numbers associated with each string
-                float r1 = parseDamage(s1);
-                float r0 = parseDamage(s0);
-                return ((Comparable<Float>)r1).compareTo(r0);
+                double r1 = parseDamage(s1);
+                double r0 = parseDamage(s0);
+                return ((Comparable<Double>)r1).compareTo(r0);
             }
         }
 
-        private float parseDamage(String s) {
-            float damage = 0;
-            if(s.contains("/")) {
-                damage = Float.parseFloat(s.split("/")[0]);
-            } else {
-                damage = Float.parseFloat(s);
+        /**
+         * Extracts a numeric value from the damage string for use in sorting by damage. If a String
+         * contains any non-digit character, that character and anything after it is ignored. If the string
+         * starts with a non-digit character the return value is 0.
+         * 
+         * @param s A weapon damage string
+         * @return  The value to use for sorting.
+         */
+        private double parseDamage(String s) {
+            s = s.replaceAll("[^0-9\\.]+", "/");
+            if (s.contains("/")) {
+                s = s.substring(0, s.indexOf("/"));
             }
-            return damage;
+            if (s.length() > 0) {
+                return Double.parseDouble(s);
+            } else {
+                return 0;
+            }
         }
     }
 

--- a/src/megameklab/com/ui/Infantry/views/WeaponView.java
+++ b/src/megameklab/com/ui/Infantry/views/WeaponView.java
@@ -417,10 +417,24 @@ public class WeaponView extends IView implements ActionListener {
             return ((Comparable<Double>)r1).compareTo(r0);
         }
 
+        /**
+         * Extracts a numeric value from the damage string for use in sorting by damage. If a String
+         * contains any non-digit character, that character and anything after it is ignored. If the string
+         * starts with a non-digit character the return value is 0.
+         * 
+         * @param s A weapon damage string
+         * @return  The value to use for sorting.
+         */
         private double parseDamage(String s) {
-            double damage = 0;
-            damage = Double.parseDouble(s);
-            return damage;
+            s = s.replaceAll("[^0-9\\.]+", "/");
+            if (s.contains("/")) {
+                s = s.substring(0, s.indexOf("/"));
+            }
+            if (s.length() > 0) {
+                return Double.parseDouble(s);
+            } else {
+                return 0;
+            }
         }
     }
 

--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -770,14 +770,24 @@ public class EquipmentTab extends ITab implements ActionListener {
             }
         }
 
+        /**
+         * Extracts an integer value from the damage string for use in sorting by damage. If a String
+         * contains any non-digit character, that character and anything after it is ignored. If the string
+         * starts with a non-digit character the return value is 0.
+         * 
+         * @param s A weapon damage string
+         * @return  The value to use for sorting.
+         */
         private int parseDamage(String s) {
-            int damage = 0;
-            if(s.contains("/")) {
-                damage = Integer.parseInt(s.split("/")[0]);
-            } else {
-                damage = Integer.parseInt(s);
+            s = s.replaceAll("[^0-9]+", ".");
+            if (s.contains(".")) {
+                s = s.substring(0, s.indexOf("."));
             }
-            return damage;
+            if (s.length() > 0) {
+                return Integer.parseInt(s);
+            } else {
+                return 0;
+            }
         }
     }
 

--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -779,9 +779,9 @@ public class EquipmentTab extends ITab implements ActionListener {
          * @return  The value to use for sorting.
          */
         private int parseDamage(String s) {
-            s = s.replaceAll("[^0-9]+", ".");
-            if (s.contains(".")) {
-                s = s.substring(0, s.indexOf("."));
+            s = s.replaceAll("[^0-9]+", "/");
+            if (s.contains("/")) {
+                s = s.substring(0, s.indexOf("/"));
             }
             if (s.length() > 0) {
                 return Integer.parseInt(s);

--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -768,14 +768,24 @@ public class EquipmentTab extends ITab implements ActionListener {
             }
         }
 
+        /**
+         * Extracts an integer value from the damage string for use in sorting by damage. If a String
+         * contains any non-digit character, that character and anything after it is ignored. If the string
+         * starts with a non-digit character the return value is 0.
+         * 
+         * @param s A weapon damage string
+         * @return  The value to use for sorting.
+         */
         private int parseDamage(String s) {
-            int damage = 0;
-            if(s.contains("/")) {
-                damage = Integer.parseInt(s.split("/")[0]);
-            } else {
-                damage = Integer.parseInt(s);
+            s = s.replaceAll("[^0-9]+", "/");
+            if (s.contains("/")) {
+                s = s.substring(0, s.indexOf("/"));
             }
-            return damage;
+            if (s.length() > 0) {
+                return Integer.parseInt(s);
+            } else {
+                return 0;
+            }
         }
     }
 


### PR DESCRIPTION
The table sorter converts the string value for weapon damage to an int value (floating point for infantry) but does not account for all the available formats of the damage string. It can handle a numeric value or a set of damages by range separated by a slash.

This change truncates the string when the first non-digit value is reached before parsing. If there is no leading digit, it treats it as damage 0.