### PR TITLE
Unallocated single shot ammo

### DIFF
--- a/src/megameklab/com/ui/Aero/views/BuildView.java
+++ b/src/megameklab/com/ui/Aero/views/BuildView.java
@@ -131,8 +131,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
             if ((mount.getLocation() == Entity.LOC_NONE) && 
                     ((mount.getUsableShotsLeft() > 1)
                             || (((AmmoType)mount.getType()).getAmmoType() == AmmoType.T_COOLANT_POD)
-                            || (((AmmoType) mount.getType()).getMunitionType()
-                                    == AmmoType.M_DAVY_CROCKETT_M))) {
+                            || (((AmmoType) mount.getType()).getShots() == 1))) {
                 masterEquipmentList.add(mount);
             }
         }

--- a/src/megameklab/com/ui/Dropship/views/AerospaceBuildView.java
+++ b/src/megameklab/com/ui/Dropship/views/AerospaceBuildView.java
@@ -123,10 +123,14 @@ public class AerospaceBuildView extends IView implements MouseListener {
                masterEquipmentList.add(mount);
            }
        }
+       // Don't show ammo for one-shot weapons. One-shot ammo is mounted in the location Entity.LOC_NONE
+       // and has a single shot. Exempt weapons that have a single shot/ton (e.g. cruise missiles,
+       // nuclear Arrow IV munitions), which are never one-shot and may just be unallocated.
        for (Mounted mount : getAero().getAmmo()) {
            if ((mount.getLocation() == Entity.LOC_NONE) && 
-                   ((mount.getUsableShotsLeft() > 1) || 
-                           (((AmmoType)mount.getType()).getAmmoType() == 
+                   ((mount.getUsableShotsLeft() > 1)
+                           || (((AmmoType) mount.getType()).getShots() == 1)
+                           || (((AmmoType)mount.getType()).getAmmoType() == 
                                AmmoType.T_COOLANT_POD))) {
                masterEquipmentList.add(mount);
            }

--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -128,8 +128,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
         for (Mounted mount : getMech().getAmmo()) {
             if ((mount.getLocation() == Entity.LOC_NONE) && ((mount.getUsableShotsLeft() > 1)
                     || (((AmmoType)mount.getType()).getAmmoType() == AmmoType.T_COOLANT_POD)
-                    || (((AmmoType) mount.getType()).getMunitionType()
-                            == AmmoType.M_DAVY_CROCKETT_M))) {
+                    || (((AmmoType) mount.getType()).getShots() == 1))) {
                 masterEquipmentList.add(mount);
             }
         }

--- a/src/megameklab/com/ui/Vehicle/views/BuildView.java
+++ b/src/megameklab/com/ui/Vehicle/views/BuildView.java
@@ -111,12 +111,11 @@ public class BuildView extends IView implements ActionListener, MouseListener {
             }
         }
         for (Mounted mount : getTank().getAmmo()) {
-            int ammoType = ((AmmoType)mount.getType()).getAmmoType();
-            if ((mount.getLocation() == Entity.LOC_NONE) &&
-                    (mount.getUsableShotsLeft() > 1
-                            || ammoType == AmmoType.T_CRUISE_MISSILE)
-                    || (((AmmoType) mount.getType()).getMunitionType()
-                            == AmmoType.M_DAVY_CROCKETT_M)) {
+            if ((mount.getLocation() == Entity.LOC_NONE) && 
+                    ((mount.getUsableShotsLeft() > 1)
+                            || (((AmmoType) mount.getType()).getShots() == 1)
+                            || (((AmmoType)mount.getType()).getAmmoType() == 
+                                AmmoType.T_COOLANT_POD))) {
                 masterEquipmentList.add(mount);
             }
         }

--- a/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
+++ b/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
@@ -631,6 +631,10 @@ public class BayWeaponCriticalTree extends JTree {
                         } else {
                             av += 13.5;
                         }
+                    } else if (m.getType().hasFlag(WeaponType.F_ARTILLERY)) {
+                        // No AV since they cannot be used air-to-air, but the ground damage needs
+                        // to count against the bay limit.
+                        av += ((WeaponType) m.getType()).getRackSize();
                     } else {
                         av += ((WeaponType) m.getType()).getShortAV();
                     }
@@ -1211,6 +1215,8 @@ public class BayWeaponCriticalTree extends JTree {
                 if (w.getType().hasFlag(WeaponType.F_PLASMA)) {
                     if (((WeaponType)w.getType()).getDamage() == WeaponType.DAMAGE_VARIABLE) {
                         av += 7;
+                    } else if (w.getType().hasFlag(WeaponType.F_ARTILLERY)) {
+                        av += ((WeaponType) w.getType()).getRackSize();
                     } else {
                         av += 13.5;
                     }


### PR DESCRIPTION
Fix for #182 

When displaying unallocated equipment, any ammo that is unallocated and has a single shot is considered one-shot ammo and not displayed. This fails with Davy Crockett Arrow IV and cruise missile ammo, which have a single shot for a slot. Previously reported in #156 and fixed for fighters, meks, and vees by noting those specific exceptions, but I missed Dropships at the time. This includes Dropships/small craft and generalizes the solution to any ammo with 1 shot/slot rather than trying to make exceptions for all affected ammo types.

I also noticed that the weapons were not counting against the limit of 700 damage points per weapon bay and fixed that.