### PR TITLE
PrintMech: Weapons & Equipment Inventory table linespacing (fixes #186)

### DIFF
--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -327,7 +327,7 @@ public class PrintMech extends PrintEntity {
         int currY = viewY + 10;
         
         float fontSize = FONT_SIZE_MEDIUM;
-        float lineHeight = getFontHeight(fontSize) * 0.8f;
+        float lineHeight = getFontHeight(fontSize) * 1.2f;
         
         addTextElement(canvas, qtyX, currY, "Qty", fontSize, "middle", "bold");
         addTextElement(canvas, nameX + indent, currY, "Type", fontSize, "start", "bold");
@@ -350,7 +350,10 @@ public class PrintMech extends PrintEntity {
                 lines += rows;
             }
         }
-        if (lines > 12) {
+        if (lines > 11) {
+            lineHeight = getFontHeight(fontSize) * 1.0f;
+        }
+        if (lines > 13) {
             lineHeight = getFontHeight(fontSize) * 0.8f;
         }
         if (lines > 16) {


### PR DESCRIPTION
In printed sheets produced by MegaMekLab, the weapon statistic lines below "Weapons & Equipment Inventory" (on the upper left of the sheet) are too close together, as it negatively impacts readability.

Significantly increasing line spacing would make the table much more legible, and it seems there is ample empty white space to allow for it.