### PR TITLE
Make IS and Clan structure available to mixed tech units.

### DIFF
--- a/src/megameklab/com/ui/view/MekChassisView.java
+++ b/src/megameklab/com/ui/view/MekChassisView.java
@@ -448,11 +448,22 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
                 String name = EquipmentType.getStructureTypeName(i, isClan);
                 EquipmentType structure = EquipmentType.get(name);
                 // LAMs cannot use bulky structure
-                if ((getBaseTypeIndex() == BASE_TYPE_LAM) && (structure.getCriticals(null) != 0)) {
-                    continue;
-                }
-                if ((null != structure) && techManager.isLegal(structure)) {
+                if ((null != structure) && techManager.isLegal(structure)
+                        && ((getBaseTypeIndex() != BASE_TYPE_LAM)
+                                || (structure.getCriticals(null) == 0))) {
                     cbStructure.addItem(structure);
+                }
+                name = EquipmentType.getStructureTypeName(i, !isClan);
+                EquipmentType structure2 = EquipmentType.get(name);
+                if ((null != structure2) && (structure2 != structure) 
+                        && techManager.isLegal(structure2)
+                        && ((getBaseTypeIndex() != BASE_TYPE_LAM)
+                                || (structure2.getCriticals(null) == 0))) {
+                    cbStructure.addItem(structure2);
+                    // If we are allowing the opposite tech base it may be because we are using mixed
+                    // tech but it also may be that we are in the transitional early Clan stage when
+                    // IS equipment is available without a mixed base.
+                    cbStructure.showTechBase(true);
                 }
             }
         }


### PR DESCRIPTION
It's not really clear what a Clan or IS tech base means in a mixed tech unit. There are entries in TROs that specify IS/mixed or Clan/mixed, but  the mixed tech rules (TacOps, p. 377) don't really make it clear whether that means anything, or whether they amount to the same thing. For the sake of simplifying the code and the available options, MML uses the IS/Clan tech base to filter the available structure types, but this causes problems when it comes to early Clan units by making IS endo steel unavailable when they should be able to use it. (For that matter, the Clans should be able to construct a mixed tech unit with IS endo steel at any point in their history.)

Given the choice between a hack to deal specifically with IS Endo-Steel and a more general solution that basically ignores the distinction between IS mixed and Clan mixed*, I went with the latter.

*There is actually a distinction between IS mixed and Clan mixed, which is the availability and tech level of mixed tech units based on whether they are built by a Clan faction or an IS faction. But no difference for the unit construction.

Fixes #203: Inner Sphere Endo Steel is unavailable to early clan mechs.