### PR TITLE
One shot reprise

### DIFF
--- a/src/megameklab/com/ui/Aero/views/BuildView.java
+++ b/src/megameklab/com/ui/Aero/views/BuildView.java
@@ -128,10 +128,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
             }
         }
         for (Mounted mount : getAero().getAmmo()) {
-            if ((mount.getLocation() == Entity.LOC_NONE) && 
-                    ((mount.getUsableShotsLeft() > 1)
-                            || (((AmmoType)mount.getType()).getAmmoType() == AmmoType.T_COOLANT_POD)
-                            || (((AmmoType) mount.getType()).getShots() == 1))) {
+            if (!mount.isOneShotAmmo()) {
                 masterEquipmentList.add(mount);
             }
         }

--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -126,9 +126,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
             }
         }
         for (Mounted mount : getMech().getAmmo()) {
-            if ((mount.getLocation() == Entity.LOC_NONE) && ((mount.getUsableShotsLeft() > 1)
-                    || (((AmmoType)mount.getType()).getAmmoType() == AmmoType.T_COOLANT_POD)
-                    || (((AmmoType) mount.getType()).getShots() == 1))) {
+            if (!mount.isOneShotAmmo()) {
                 masterEquipmentList.add(mount);
             }
         }

--- a/src/megameklab/com/ui/Vehicle/views/BuildView.java
+++ b/src/megameklab/com/ui/Vehicle/views/BuildView.java
@@ -111,11 +111,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
             }
         }
         for (Mounted mount : getTank().getAmmo()) {
-            if ((mount.getLocation() == Entity.LOC_NONE) && 
-                    ((mount.getUsableShotsLeft() > 1)
-                            || (((AmmoType) mount.getType()).getShots() == 1)
-                            || (((AmmoType)mount.getType()).getAmmoType() == 
-                                AmmoType.T_COOLANT_POD))) {
+            if (!mount.isOneShotAmmo()) {
                 masterEquipmentList.add(mount);
             }
         }

--- a/src/megameklab/com/ui/aerospace/AerospaceBuildView.java
+++ b/src/megameklab/com/ui/aerospace/AerospaceBuildView.java
@@ -124,10 +124,7 @@ public class AerospaceBuildView extends IView implements MouseListener {
             }
         }
         for (Mounted mount : getAero().getAmmo()) {
-            if ((mount.getLocation() == Entity.LOC_NONE) && 
-                    ((mount.getUsableShotsLeft() > 1) || 
-                            (((AmmoType)mount.getType()).getAmmoType() == 
-                            AmmoType.T_COOLANT_POD))) {
+            if (!mount.isOneShotAmmo()) {
                 masterEquipmentList.add(mount);
             }
         }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -3888,9 +3888,7 @@ public class UnitUtil {
             }
         }
         for (Mounted mount : unit.getAmmo()) {
-            if ((mount.getLocation() == Entity.LOC_NONE)
-                    && ((mount.getUsableShotsLeft() > 1) || (((AmmoType) mount
-                            .getType()).getAmmoType() == AmmoType.T_COOLANT_POD))) {
+            if (!mount.isOneShotAmmo()) {
                 nCrits += UnitUtil.getCritsUsed(unit, mount.getType());
             }
         }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -367,6 +367,18 @@ public class UnitUtil {
                 }
             }
         }
+        // Remove ammo added for a one-shot launcher
+        if ((mount.getType() instanceof WeaponType) && mount.isOneShot()) {
+            List<Mounted> osAmmo = new ArrayList<>();
+            for (Mounted ammo = mount.getLinked(); ammo != null; ammo = ammo.getLinked()) {
+                osAmmo.add(ammo);
+            }
+            osAmmo.forEach(m -> {
+                unit.getEquipment().remove(m);
+                unit.getAmmo().remove(m);
+            });
+        }
+        
         // It's possible that the equipment we are removing was linked to
         // something else, and so the linkedBy state may be set.  We should
         // remove it.  Using getLinked could be unreliable, so we'll brute force
@@ -1351,12 +1363,7 @@ public class UnitUtil {
         double tonnage = 0;
 
         for (Mounted mount : unit.getAmmo()) {
-            // don't add ammo with just one shot, that's OS ammo
-            //  Unless it's a single shot ammo type, like Cruise Missiles
-            if ((mount.getLocation() == Entity.LOC_NONE)
-                    && ((mount.getUsableShotsLeft() > 1)
-                            || (((AmmoType) mount.getType()).getShots() == 1)
-                            || (((AmmoType)mount.getType()).getAmmoType() == AmmoType.T_COOLANT_POD))) {
+            if (!mount.isOneShotAmmo()) {
                 int slots = 1;
                 if (unit.usesWeaponBays()) {
                     slots = (int) Math.ceil(mount.getUsableShotsLeft() / (double) ((AmmoType) mount.getType()).getShots());


### PR DESCRIPTION
I think this is at least the third fix in as many months for issues surrounding one-shot launcher ammo. Previously the check for whether an ammo slot is one-shot is that is located in Entity.LOC_NONE and has a single shot. This ran into problems with ammo that has a single shot when full not showing up because it hasn't been allocated. This fix is prompted by BA popup mines, which fail the one-shot test because they have one shot for each trooper.

This should be the final fix, which avoids all the edge case exceptions by testing whether the ammo mount is linked by a one-shot launcher. 

Fixes #213