### PR TITLE
Set comparator for sorting BA equipment tab by weight.

### DIFF
--- a/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
@@ -181,6 +181,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         equipmentSorter.setComparator(EquipmentTableModel.COL_DAMAGE, new WeaponDamageSorter());
         equipmentSorter.setComparator(EquipmentTableModel.COL_RANGE, new WeaponRangeSorter());
         equipmentSorter.setComparator(EquipmentTableModel.COL_COST, new FormattedNumberSorter());
+        equipmentSorter.setComparator(EquipmentTableModel.COL_TON, new FormattedNumberSorter());
         masterEquipmentTable.setRowSorter(equipmentSorter);
         ArrayList<RowSorter.SortKey> sortKeys = new ArrayList<RowSorter.SortKey>();
         sortKeys.add(new RowSorter.SortKey(EquipmentTableModel.COL_NAME, SortOrder.ASCENDING));

--- a/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
@@ -172,6 +172,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         equipmentSorter.setComparator(EquipmentTableModel.COL_DAMAGE, new WeaponDamageSorter());
         equipmentSorter.setComparator(EquipmentTableModel.COL_RANGE, new WeaponRangeSorter());
         equipmentSorter.setComparator(EquipmentTableModel.COL_COST, new FormattedNumberSorter());
+        equipmentSorter.setComparator(EquipmentTableModel.COL_TON,  new FormattedWeightSorter());
         masterEquipmentTable.setRowSorter(equipmentSorter);
         ArrayList<RowSorter.SortKey> sortKeys = new ArrayList<RowSorter.SortKey>();
         sortKeys.add(new RowSorter.SortKey(EquipmentTableModel.COL_NAME, SortOrder.ASCENDING));
@@ -822,11 +823,11 @@ public class EquipmentTab extends ITab implements ActionListener {
      *
      */
     public class FormattedNumberSorter implements Comparator<String> {
+        DecimalFormat format = new DecimalFormat();
 
         @Override
         public int compare(String s0, String s1) {
             //lets find the weight class integer for each name
-            DecimalFormat format = new DecimalFormat();
             int l0 = 0;
             try {
                 l0 = format.parse(s0).intValue();
@@ -840,6 +841,41 @@ public class EquipmentTab extends ITab implements ActionListener {
                 e.printStackTrace();
             }
             return ((Comparable<Integer>)l0).compareTo(l1);
+        }
+    }
+    
+    /**
+     * A comparator for weights that have been formatted with DecimalFormat
+     * and may require conversion from kg to tons.
+     *
+     */
+    public class FormattedWeightSorter implements Comparator<String> {
+        DecimalFormat format = new DecimalFormat();
+
+        @Override
+        public int compare(String s0, String s1) {
+            //lets find the weight class integer for each name
+            double l0 = 0;
+            try {
+                if (s0.endsWith(" kg")) {
+                    l0 = format.parse(s0.replace(" kg", "")).doubleValue() / 1000;
+                } else {
+                    l0 = format.parse(s0).doubleValue();
+                }
+            } catch (java.text.ParseException e) {
+                e.printStackTrace();
+            }
+            double l1 = 0;
+            try {
+                if (s1.endsWith(" kg")) {
+                    l1 = format.parse(s1.replace(" kg", "")).doubleValue() / 1000;
+                } else {
+                    l1 = format.parse(s1).doubleValue();
+                }
+            } catch (java.text.ParseException e) {
+                e.printStackTrace();
+            }
+            return Double.compare(l0, l1);
         }
     }
     

--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -70,6 +70,7 @@ import megamek.common.QuadVee;
 import megamek.common.WeaponType;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
 import megameklab.com.ui.EntitySource;
+import megameklab.com.ui.Aero.tabs.EquipmentTab.FormattedNumberSorter;
 import megameklab.com.util.CriticalTableModel;
 import megameklab.com.util.EquipmentTableModel;
 import megameklab.com.util.ITab;
@@ -174,6 +175,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         equipmentSorter.setComparator(EquipmentTableModel.COL_DAMAGE, new WeaponDamageSorter());
         equipmentSorter.setComparator(EquipmentTableModel.COL_RANGE, new WeaponRangeSorter());
         equipmentSorter.setComparator(EquipmentTableModel.COL_COST, new FormattedNumberSorter());
+        equipmentSorter.setComparator(EquipmentTableModel.COL_TON, new FormattedNumberSorter());
         masterEquipmentTable.setRowSorter(equipmentSorter);
         ArrayList<RowSorter.SortKey> sortKeys = new ArrayList<RowSorter.SortKey>();
         sortKeys.add(new RowSorter.SortKey(EquipmentTableModel.COL_NAME, SortOrder.ASCENDING));

--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -72,6 +72,7 @@ import megamek.common.VTOL;
 import megamek.common.WeaponType;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
 import megameklab.com.ui.EntitySource;
+import megameklab.com.ui.Aero.tabs.EquipmentTab.FormattedNumberSorter;
 import megameklab.com.util.CriticalTableModel;
 import megameklab.com.util.EquipmentTableModel;
 import megameklab.com.util.ITab;
@@ -173,6 +174,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         equipmentSorter.setComparator(EquipmentTableModel.COL_DAMAGE, new WeaponDamageSorter());
         equipmentSorter.setComparator(EquipmentTableModel.COL_RANGE, new WeaponRangeSorter());
         equipmentSorter.setComparator(EquipmentTableModel.COL_COST, new FormattedNumberSorter());
+        equipmentSorter.setComparator(EquipmentTableModel.COL_TON, new FormattedNumberSorter());
         masterEquipmentTable.setRowSorter(equipmentSorter);
         ArrayList<RowSorter.SortKey> sortKeys = new ArrayList<RowSorter.SortKey>();
         sortKeys.add(new RowSorter.SortKey(EquipmentTableModel.COL_NAME, SortOrder.ASCENDING));

--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -364,9 +364,9 @@ public class EquipmentTableModel extends AbstractTableModel {
             if (type.getTonnage(entity) < 0.1) {
                 return String.format("%.2f kg", type.getTonnage(entity) * 1000);
             } else if ((entity instanceof BattleArmor) && (atype != null)){
-                return (atype.getKgPerShot() * atype.getShots())/1000;
+                return String.valueOf((atype.getKgPerShot() * atype.getShots())/1000);
             } else {
-                return type.getTonnage(entity);
+                return String.valueOf(type.getTonnage(entity));
             }
         } else if (col == COL_CRIT) {
             if (entity instanceof Tank) {


### PR DESCRIPTION
The weight of equipment for BA is shown as tons unless it's below 0.1 in which case it's shown as kg with the units as part of the value. So getValue was returning either a Double or a String, which was causing a ClassCastException when trying to find a natural comparator. I coerced all the values to Strings so that they could be compared, then set explicit sorters for all the unit types so they would sort by numeric value. For the BA equipment tab I added a custom comparator that would convert kg values to tons before comparing.

Fixes #214: Battle Armour Sorting Equipment by Weight