### PR TITLE
Restore qv cockpit when resetting system crits.

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -302,6 +302,10 @@ public class StructureTab extends ITab implements MekBuildListener {
                 getMech().setArmorType(
                         EquipmentType.T_ARMOR_COMMERCIAL);
                 break;
+            case Mech.COCKPIT_QUADVEE:
+                clearCritsForCockpit(false, true);
+                getMech().addQuadVeeCockpit();
+                break;
             default:
                 clearCritsForCockpit(false, false);
                 getMech().addCockpit();


### PR DESCRIPTION
Fixes #215: Quadvees have issues with Quadvee cockpits and XL/XXL
engines.