### PR TITLE
Superheavy split equipment

### DIFF
--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -237,6 +237,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
     private void addAllListeners() {
     }
 
+    @Override
     public void actionPerformed(ActionEvent e) {
         fireTableRefresh();
     }
@@ -254,18 +255,22 @@ public class BuildView extends IView implements ActionListener, MouseListener {
         return equipmentTable;
     }
 
+    @Override
     public void mouseClicked(MouseEvent e) {
 
     }
 
+    @Override
     public void mouseEntered(MouseEvent e) {
 
     }
 
+    @Override
     public void mouseExited(MouseEvent e) {
 
     }
 
+    @Override
     public void mousePressed(MouseEvent e) {
         if (e.getButton() == MouseEvent.BUTTON3) {
             JPopupMenu popup = new JPopupMenu();
@@ -368,6 +373,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
         }
     }
 
+    @Override
     public void mouseReleased(MouseEvent e) {
 
     }

--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -290,7 +290,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
                         item = new JMenuItem(String.format("Add to %1$s", locations[Mech.LOC_RT]));
                         item.addActionListener(new ActionListener() {
                             public void actionPerformed(ActionEvent e) {
-                                jMenuLoadComponent_actionPerformed(Mech.LOC_RT, selectedRow);
+                                jMenuLoadSplitComponent_actionPerformed(Mech.LOC_RT, Mech.LOC_NONE, totalCrits, selectedRow);
                             }
                         });
                         rtMenu.add(item);
@@ -336,7 +336,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
                         item = new JMenuItem(String.format("Add to %1$s", locations[Mech.LOC_LT]));
                         item.addActionListener(new ActionListener() {
                             public void actionPerformed(ActionEvent e) {
-                                jMenuLoadComponent_actionPerformed(Mech.LOC_LT, selectedRow);
+                                jMenuLoadSplitComponent_actionPerformed(Mech.LOC_LT, Mech.LOC_NONE, totalCrits, selectedRow);
                             }
                         });
                         ltMenu.add(item);

--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -288,11 +288,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
 
                     if (critSpace[Mech.LOC_RT] >= totalCrits) {
                         item = new JMenuItem(String.format("Add to %1$s", locations[Mech.LOC_RT]));
-                        item.addActionListener(new ActionListener() {
-                            public void actionPerformed(ActionEvent e) {
-                                jMenuLoadSplitComponent_actionPerformed(Mech.LOC_RT, Mech.LOC_NONE, totalCrits, selectedRow);
-                            }
-                        });
+                        item.addActionListener(ev -> jMenuLoadSplitComponent_actionPerformed(Mech.LOC_RT, Mech.LOC_NONE, totalCrits, selectedRow));
                         rtMenu.add(item);
                     }
 
@@ -307,11 +303,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
                             item = new JMenuItem(String.format("%1$s (%2$s)/%3$s (%4$s)", abbrLocations[Mech.LOC_RT], primarySlots, abbrLocations[splitLocations[location]], slots));
 
                             final int secondaryLocation = splitLocations[location];
-                            item.addActionListener(new ActionListener() {
-                                public void actionPerformed(ActionEvent e) {
-                                    jMenuLoadSplitComponent_actionPerformed(Mech.LOC_RT, secondaryLocation, primarySlots, selectedRow);
-                                }
-                            });
+                            item.addActionListener(ev -> jMenuLoadSplitComponent_actionPerformed(Mech.LOC_RT, secondaryLocation, primarySlots, selectedRow));
                             subMenu.add(item);
                         }
                         rtMenu.add(subMenu);
@@ -321,11 +313,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
 
                 if ((critSpace[Mech.LOC_RARM] >= totalCrits) && UnitUtil.isValidLocation(getMech(), eq.getType(), Mech.LOC_RARM)) {
                     item = new JMenuItem(String.format("Add to %1$s", locations[Mech.LOC_RARM]));
-                    item.addActionListener(new ActionListener() {
-                        public void actionPerformed(ActionEvent e) {
-                            jMenuLoadSplitComponent_actionPerformed(Mech.LOC_RARM, Mech.LOC_RARM, totalCrits, selectedRow);
-                        }
-                    });
+                    item.addActionListener(ev -> jMenuLoadSplitComponent_actionPerformed(Mech.LOC_RARM, Mech.LOC_RARM, totalCrits, selectedRow));
                     popup.add(item);
                 }
 
@@ -334,11 +322,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
 
                     if (critSpace[Mech.LOC_LT] >= totalCrits) {
                         item = new JMenuItem(String.format("Add to %1$s", locations[Mech.LOC_LT]));
-                        item.addActionListener(new ActionListener() {
-                            public void actionPerformed(ActionEvent e) {
-                                jMenuLoadSplitComponent_actionPerformed(Mech.LOC_LT, Mech.LOC_NONE, totalCrits, selectedRow);
-                            }
-                        });
+                        item.addActionListener(ev -> jMenuLoadSplitComponent_actionPerformed(Mech.LOC_LT, Mech.LOC_NONE, totalCrits, selectedRow));
                         ltMenu.add(item);
                     }
 
@@ -353,11 +337,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
                             item = new JMenuItem(String.format("%1$s (%2$s)/%3$s (%4$s)", abbrLocations[Mech.LOC_LT], primarySlots, abbrLocations[splitLocations[location]], slots));
 
                             final int secondaryLocation = splitLocations[location];
-                            item.addActionListener(new ActionListener() {
-                                public void actionPerformed(ActionEvent e) {
-                                    jMenuLoadSplitComponent_actionPerformed(Mech.LOC_LT, secondaryLocation, primarySlots, selectedRow);
-                                }
-                            });
+                            item.addActionListener(ev -> jMenuLoadSplitComponent_actionPerformed(Mech.LOC_LT, secondaryLocation, primarySlots, selectedRow));
                             subMenu.add(item);
                         }
                         ltMenu.add(subMenu);
@@ -368,11 +348,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
 
                 if ((critSpace[Mech.LOC_LARM] >= totalCrits)  && UnitUtil.isValidLocation(getMech(), eq.getType(), Mech.LOC_LARM)) {
                     item = new JMenuItem(String.format("Add to %1$s", locations[Mech.LOC_LARM]));
-                    item.addActionListener(new ActionListener() {
-                        public void actionPerformed(ActionEvent e) {
-                            jMenuLoadSplitComponent_actionPerformed(Mech.LOC_LARM, Mech.LOC_LARM, totalCrits, selectedRow);
-                        }
-                    });
+                    item.addActionListener(ev -> jMenuLoadSplitComponent_actionPerformed(Mech.LOC_LARM, Mech.LOC_LARM, totalCrits, selectedRow));
                     popup.add(item);
                 }
 
@@ -383,11 +359,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
                         item = new JMenuItem("Add to " + locations[location]);
 
                         final int loc = location;
-                        item.addActionListener(new ActionListener() {
-                            public void actionPerformed(ActionEvent e) {
-                                jMenuLoadComponent_actionPerformed(loc, selectedRow);
-                            }
-                        });
+                        item.addActionListener(ev -> jMenuLoadComponent_actionPerformed(loc, selectedRow));
                         popup.add(item);
                     }
                 }

--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -288,6 +288,16 @@ public class BuildView extends IView implements ActionListener, MouseListener {
                     && !((eq.getType() instanceof MiscType) && eq.getType().hasFlag(MiscType.F_TARGCOMP))
                     && !(getMech() instanceof LandAirMech)) {
                 int[] critSpace = UnitUtil.getHighestContinuousNumberOfCritsArray(getMech());
+                // Superheavy mechs may have enough space in the CT for the whole thing.
+                if ((critSpace[Mech.LOC_CT] >= totalCrits) && UnitUtil.isValidLocation(getMech(), eq.getType(), Mech.LOC_CT)) {
+                    JMenu ctMenu = new JMenu(locations[Mech.LOC_CT]);
+
+                    item = new JMenuItem(String.format("Add to %1$s", locations[Mech.LOC_CT]));
+                    item.addActionListener(ev -> jMenuLoadSplitComponent_actionPerformed(Mech.LOC_CT, Mech.LOC_NONE, totalCrits, selectedRow));
+                    ctMenu.add(item);
+                    popup.add(ctMenu);
+                }
+
                 if ((critSpace[Mech.LOC_RT] >= 1) && UnitUtil.isValidLocation(getMech(), eq.getType(), Mech.LOC_RT)) {
                     JMenu rtMenu = new JMenu(locations[Mech.LOC_RT]);
 

--- a/src/megameklab/com/util/Mech/CriticalTransferHandler.java
+++ b/src/megameklab/com/util/Mech/CriticalTransferHandler.java
@@ -151,7 +151,7 @@ public class CriticalTransferHandler extends TransferHandler {
             int nextLocation = getUnit().getTransferLocation(location);
             
             // Determine if we should spread equipment over multiple locations
-            if ((eq.getType().getCriticals(getUnit()) > primaryLocSpace)
+            if ((totalCrits > primaryLocSpace)
                     && !((eq.getType() instanceof MiscType) && eq.getType().hasFlag(MiscType.F_TARGCOMP))
                     && !(getUnit() instanceof LandAirMech)) {
                 if (location == Mech.LOC_RT) {


### PR DESCRIPTION
When assigning splittable equipment using drag and drop it was comparing the number of slots available to the slots normally taken by the equipment instead of the slot taken by the equipment on that unit (which half as many for superheavies).

While troublshooting I also noticed that using the popup menu to place splittable equipment was only allocating a single slot when putting it in a single location and fixed that as well, along with some code cleanup.

Fixes #218