### PR TITLE
Recalculate protomech engine rating after chassis configuration change.

### DIFF
--- a/src/megameklab/com/ui/protomek/ProtomekStructureTab.java
+++ b/src/megameklab/com/ui/protomek/ProtomekStructureTab.java
@@ -434,6 +434,9 @@ public class ProtomekStructureTab extends ITab implements ProtomekBuildListener 
                 .filter(m -> !UnitUtil.isProtomechEquipment(m.getType(), getProtomech(), true))
                 .collect(Collectors.toList());
         toRemove.forEach(m -> UnitUtil.removeMounted(getProtomech(), m));
+        panMovement.setFromEntity(getProtomech());
+        recalculateEngineRating(panMovement.getWalk(), panChassis.getTonnage(),
+                motiveType != ProtomekChassisView.MOTIVE_TYPE_BIPED);
         refresh();
         refresh.refreshBuild();
         refresh.refreshPreview();


### PR DESCRIPTION
Protomech engine rating is tonnage x running MP for bipeds, tonnage x (running MP - 2） for quads and gliders. The engine rating is recalculated after a change in tonnage or MP, but not chassis configuration.

Fixes #223: Quad Protomech engine weight