### PR TITLE
Proto armor

### DIFF
--- a/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
@@ -47,6 +47,8 @@ import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.SimpleTechLevel;
 import megamek.common.templates.TROView;
+import megamek.common.verifier.TestEntity;
+import megamek.common.verifier.TestBattleArmor;
 import megamek.common.verifier.TestBattleArmor.BAManipulator;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.util.CustomComboBox;
@@ -679,5 +681,30 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
         refresh.refreshBuild();
         refresh.refreshStatus();
         refresh.refreshPreview();
+    }
+    
+    @Override
+    public void maximizeArmor() {
+        armorValueChanged(getBattleArmor().getMaximumArmorPoints());
+        panArmor.removeListener(this);
+        panArmor.setFromEntity(getBattleArmor());
+        panArmor.addListener(this);
+    }
+    
+    @Override
+    public void useRemainingTonnageArmor() {
+        final TestBattleArmor testBA = (TestBattleArmor) UnitUtil.getEntityVerifier(getBattleArmor());
+        double currentTonnage = testBA.calculateWeight(BattleArmor.LOC_SQUAD);
+        currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getBattleArmor());
+        double totalTonnage = getBattleArmor().getTrooperWeight();
+        double remainingTonnage = TestEntity.floor(
+                totalTonnage - currentTonnage, TestEntity.Ceil.KILO);
+        int points = (int) UnitUtil.getRawArmorPoints(getBattleArmor(), remainingTonnage);
+        int maxArmor = Math.min(getBattleArmor().getMaximumArmorPoints(),
+                points + getBattleArmor().getOArmor(BattleArmor.LOC_TROOPER_1));
+        armorValueChanged(maxArmor);
+        panArmor.removeListener(this);
+        panArmor.setFromEntity(getBattleArmor());
+        panArmor.addListener(this);
     }
 }

--- a/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
@@ -651,6 +651,7 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
         refresh.refreshSummary();
         refresh.refreshBuild();
         refresh.refreshPreview();
+        refresh.refreshStatus();
     }
 
     @Override

--- a/src/megameklab/com/ui/protomek/ProtomekStructureTab.java
+++ b/src/megameklab/com/ui/protomek/ProtomekStructureTab.java
@@ -484,7 +484,7 @@ public class ProtomekStructureTab extends ITab implements ProtomekBuildListener 
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getProtomech());
         double totalTonnage = getProtomech().getWeight();
         double remainingTonnage = TestEntity.floor(
-                totalTonnage - currentTonnage, TestEntity.Ceil.HALFTON);
+                totalTonnage - currentTonnage, TestEntity.Ceil.KILO);
 
         double maxArmor = Math.min(getProtomech().getArmorWeight() + remainingTonnage,
                 UnitUtil.getMaximumArmorTonnage(getProtomech()));

--- a/src/megameklab/com/ui/protomek/ProtomekStructureTab.java
+++ b/src/megameklab/com/ui/protomek/ProtomekStructureTab.java
@@ -573,10 +573,9 @@ public class ProtomekStructureTab extends ITab implements ProtomekBuildListener 
             pointsToAllocate = maxArmor;
         }
         double percent = pointsToAllocate / maxArmor;
+        final double totalIS = getProtomech().getTotalOInternal();
         for (int location = getProtomech().firstArmorIndex(); location < getProtomech().locations(); location++) {
-            double is = getProtomech().getInternal(location);
-            double allocate = Math.min(is * percent, pointsToAllocate);
-            allocate = Math.min(allocate, UnitUtil.getMaximumArmorPoints(getProtomech(), location));
+            double allocate = Math.min(UnitUtil.getMaximumArmorPoints(getProtomech(), location) * percent, pointsToAllocate);
             getProtomech().initializeArmor((int) allocate, location);
             pointsToAllocate -= (int) allocate;
         }

--- a/src/megameklab/com/ui/view/listeners/BABuildListener.java
+++ b/src/megameklab/com/ui/view/listeners/BABuildListener.java
@@ -30,7 +30,4 @@ public interface BABuildListener extends BuildListener {
     void harjelChanged(boolean harjel);
     void squadSizeChanged(int squadSize);
     void enhancementChanged(EquipmentType eq, boolean selected);
-
-    void armorValueChanged(int points);
-    void armorTypeChanged(EquipmentType armor);
 }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1450,6 +1450,9 @@ public class UnitUtil {
             }
             armorWeight = points / armorPerTon;
             armorWeight = Math.ceil(armorWeight * 2.0) / 2.0;
+        } else if (unit instanceof Protomech) {
+            double points = TestProtomech.maxArmorFactor((Protomech) unit);
+            return points * TestProtomech.ProtomechArmor.getArmor((Protomech) unit).getWtPerPoint();
         } else if (unit instanceof Tank) {
             double points = Math.floor((unit.getWeight() * 3.5) + 40);
             armorWeight = points / armorPerTon;
@@ -1481,8 +1484,8 @@ public class UnitUtil {
      */
     public static double getRawArmorPoints(Entity unit, double armorTons) {
         if (unit.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
-            return armorTons /
-                    EquipmentType.getProtomechArmorWeightPerPoint(unit.getArmorType(Protomech.LOC_TORSO));
+            return Math.round(armorTons /
+                    EquipmentType.getProtomechArmorWeightPerPoint(unit.getArmorType(Protomech.LOC_TORSO)));
         }
         return armorTons * UnitUtil.getArmorPointsPerTon(unit,
                 unit.getArmorType(1), unit.getArmorTechLevel(1));

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1422,6 +1422,8 @@ public class UnitUtil {
             return unit.getInternal(loc) * 2;
         } else if (unit instanceof Tank) {
             return (int) Math.floor((unit.getWeight() * 3.5) + 40);
+        } else if (unit instanceof Protomech) {
+            return TestProtomech.maxArmorFactor((Protomech) unit, loc);
         } else {
             return 0;
         }


### PR DESCRIPTION
Addresses some issues with protomech armor allocation:
1. 43 armor points are rounded down to 42 due to floating point imprecision.
2. Resetting the armor allocation view from the unit sets the current armor value to the number of points allocated to locations rather than the total available. This is due to reusing the BA view, since it allocates by point rather than mass, but not added the additional logic for units that allocate points to specific locations.
3. Auto-allocate button was setting all locations to zero.
Bonus: added maximize armor and use remaining tonnage buttons that are present for other units.

Fixes #222 