### PR TITLE
Bug: Long range for ATM Standard incorrect on printed record sheets

### DIFF
--- a/src/megameklab/com/util/RecordSheetEquipmentLine.java
+++ b/src/megameklab/com/util/RecordSheetEquipmentLine.java
@@ -237,7 +237,7 @@ public class RecordSheetEquipmentLine {
             }
         } else if (eqInfo.isATM) {
             if (row == ATM_STANDARD) {
-                return "4";
+                return "15";
             } else if (row == ATM_ER) {
                 return "27";
             } else if (row == ATM_HE) {


### PR DESCRIPTION
Sets the long range for ATM Standard on printed record sheets to be 15, fixes #240