### PR TITLE
Fix setting of manual BV.

### DIFF
--- a/src/megameklab/com/ui/util/IntRangeTextField.java
+++ b/src/megameklab/com/ui/util/IntRangeTextField.java
@@ -58,18 +58,32 @@ public class IntRangeTextField extends JFormattedTextField {
         setColumns(columns);
     }
     
+    /**
+     * @return The minimum legal value
+     */
     public Integer getMinimum() {
         return minimum;
     }
     
+    /**
+     * Sets the minimum value for the field.
+     * @param min
+     */
     public void setMinimum(Integer min) {
         minimum = min;
     }
     
+    /**
+     * @return The maximum legal value
+     */
     public Integer getMaximum() {
         return maximum;
     }
     
+    /**
+     * Sets the maximum legal value
+     * @param max
+     */
     public void setMaximum(Integer max) {
         maximum = max;
     }
@@ -87,7 +101,7 @@ public class IntRangeTextField extends JFormattedTextField {
 
         @Override
         public boolean shouldYieldFocus(JComponent input) {
-            if (!super.shouldYieldFocus(input)) {
+            if (!verify(input)) {
                 int val = getIntVal();
                 if (minimum != null && val < minimum) {
                     setIntVal(minimum);
@@ -125,15 +139,32 @@ public class IntRangeTextField extends JFormattedTextField {
         }
 
     };
-
+    
+    /**
+     * Parses the text as an {@code int}.
+     * @return The {@code int} value of the text, or zero if the text is not a valid int value
+     */
     public int getIntVal() {
+        return getIntVal(0);
+    }
+
+    /**
+     * Parses the text as an {@code int}.
+     * @param defaultVal The value to return if the text cannot be parsed as an int
+     * @return The {@code int} value of the text, or the indicated default if the text is not a valid int value
+     */
+    public int getIntVal(int defaultVal) {
         try {
             return Integer.parseInt(getText());
         } catch (NumberFormatException ex) {
-            return 0;
+            return defaultVal;
         }
     }
 
+    /**
+     * Sets the text to a string representation of the provided value
+     * @param val
+     */
     public void setIntVal(int val) {
         setText(String.valueOf(val));
     }

--- a/src/megameklab/com/ui/view/BasicInfoView.java
+++ b/src/megameklab/com/ui/view/BasicInfoView.java
@@ -87,7 +87,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     private final IntRangeTextField txtManualBV = new IntRangeTextField(3);
     
     private int prevYear = 3145;
-    private int prevBV = 0;
+    private int prevBV = -1;
     
     public BasicInfoView(TechAdvancement baseTA) {
         this.baseTA = baseTA;
@@ -253,6 +253,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         refreshTechBase();
     }
     
+    @Override
     public int getTechFaction() {
         if (cbFaction.getSelectedIndex() < 0) {
             return -1;
@@ -281,11 +282,15 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     }
 
     public int getManualBV() {
-        return txtManualBV.getIntVal();
+        return txtManualBV.getIntVal(-1);
     }
     
     public void setManualBV(int bv) {
-        txtManualBV.setIntVal(bv);
+        if (bv >= 0) {
+            txtManualBV.setIntVal(bv);
+        } else {
+            txtManualBV.setText("");
+        }
     }
     
     @Override
@@ -321,6 +326,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         refreshFaction();
     }
     
+    @Override
     public SimpleTechLevel getTechLevel() {
         if (cbTechLevel.getSelectedItem() == null) {
             return SimpleTechLevel.STANDARD;
@@ -429,7 +435,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         } else if (e.getSource() == txtManualBV) {
             try {
                 int bv = getManualBV();
-                listeners.forEach(l -> l.yearChanged(bv));
+                listeners.forEach(l -> l.manualBVChanged(bv));
             } catch (NumberFormatException ex) {
                 setManualBV(prevBV);
             }


### PR DESCRIPTION
Copy-paste error results in setting the entity intro year instead of the manual BV.

Also fixes the inability to clear the manual BV other than explicitly setting it to < 0, which is non-obvious.