### PR TITLE
Fixed toggling of armored component slots for split equipment.

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2326,7 +2326,7 @@ public class UnitUtil {
                 && (mount.getSecondLocation() != Entity.LOC_NONE)) {
             for (int position = 0; position < unit.getNumberOfCriticals(mount
                     .getSecondLocation()); position++) {
-                CriticalSlot cs = unit.getCritical(mount.getLocation(),
+                CriticalSlot cs = unit.getCritical(mount.getSecondLocation(),
                         position);
                 if ((cs == null) || (cs.getType() == CriticalSlot.TYPE_SYSTEM)) {
                     continue;


### PR DESCRIPTION
It was checking whether there was a secondary location then iterating through the slots in the primary location again. This also fixes the potential for  an ArrayIndexOutOfBoundsException, if the secondary location has fewer slots than the primary.

Fixes #250: Armouring Split Components Shows and Counts Incorrect
Tonnage