### PR TITLE
Consistent name display for vehicle record sheets.

### DIFF
--- a/src/megameklab/com/ui/Vehicle/Printing/PrintDualTurretVehicle.java
+++ b/src/megameklab/com/ui/Vehicle/Printing/PrintDualTurretVehicle.java
@@ -293,7 +293,7 @@ public class PrintDualTurretVehicle implements Printable {
     }
 
     private void printTank2Data(Graphics2D g2d) {
-        String tankName = tank2.getChassis().toUpperCase() + " " + tank2.getModel().toUpperCase();
+        String tankName = tank2.getChassis() + " " + tank2.getModel();
 
         g2d.setFont(UnitUtil.getNewFont(g2d, tankName, true, 180, 10.0f));
         g2d.drawString(tankName, 49, 493);

--- a/src/megameklab/com/ui/Vehicle/Printing/PrintVehicle.java
+++ b/src/megameklab/com/ui/Vehicle/Printing/PrintVehicle.java
@@ -50,6 +50,7 @@ public class PrintVehicle implements Printable {
         this.tank2 = tank2;
     }
 
+    @Override
     public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
         Graphics2D g2d = (Graphics2D) graphics;
         // f.setPaper(this.paper);
@@ -326,7 +327,7 @@ public class PrintVehicle implements Printable {
     }
 
     private void printTank2Data(Graphics2D g2d) {
-        String tankName = tank2.getChassis().toUpperCase() + " " + tank2.getModel().toUpperCase();
+        String tankName = tank2.getChassis() + " " + tank2.getModel();
 
         g2d.setFont(UnitUtil.getNewFont(g2d, tankName, true, 180, 10.0f));
         g2d.drawString(tankName, 49, 120 + secondPageMargin);

--- a/src/megameklab/com/ui/Vehicle/Printing/PrintWiGE.java
+++ b/src/megameklab/com/ui/Vehicle/Printing/PrintWiGE.java
@@ -304,7 +304,7 @@ public class PrintWiGE implements Printable {
     }
 
     private void printTank2Data(Graphics2D g2d) {
-        String tankName = tank2.getChassis().toUpperCase() + " " + tank2.getModel().toUpperCase();
+        String tankName = tank2.getChassis() + " " + tank2.getModel();
 
         g2d.setFont(UnitUtil.getNewFont(g2d, tankName, true, 180, 10.0f));
         g2d.drawString(tankName, 49, 493);


### PR DESCRIPTION
When printing two sheets per page the second one was being displayed in
all caps.

Fixes #254: Second Printed Vee Name in All Caps