### PR TITLE
Fixed rescaling of heat sink pips to fit in available space.

### DIFF
--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -602,7 +602,7 @@ public class PrintMech extends PrintEntity {
                 size = viewHeight / rows;
             } else {
                 cols++;
-                size = viewWidth / (cols * size);
+                size *= viewWidth / (cols * size);
                 rows = (int) (viewHeight / size);
             }
         }


### PR DESCRIPTION
The new size was being assigned the intended ratio of new : old rather
than being multiplied by it.

Fixes #252: Heat Sink pips not printing properly