### PR TITLE
Aero symmetry

### DIFF
--- a/src/megameklab/com/ui/Aero/views/CriticalView.java
+++ b/src/megameklab/com/ui/Aero/views/CriticalView.java
@@ -23,13 +23,16 @@ import java.util.Vector;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
+import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.ListSelectionModel;
 import javax.swing.border.TitledBorder;
 
 import megamek.common.Aero;
 import megamek.common.CriticalSlot;
+import megamek.common.LocationFullException;
 import megamek.common.Mounted;
 import megamek.common.WeaponType;
 import megamek.common.loaders.MtfFile;
@@ -37,6 +40,7 @@ import megamek.common.verifier.TestAero;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.IView;
 import megameklab.com.util.RefreshListener;
+import megameklab.com.util.UnitUtil;
 import megameklab.com.util.Mech.DropTargetCriticalList;
 
 public class CriticalView extends IView {
@@ -56,6 +60,9 @@ public class CriticalView extends IView {
     private JLabel leftSpace = new JLabel("",JLabel.LEFT);
     private JLabel rightSpace = new JLabel("",JLabel.LEFT);
     private JLabel aftSpace = new JLabel("",JLabel.LEFT);
+    
+    private JButton btnCopyLW = new JButton("Copy Left Wing");
+    private JButton btnCopyRW = new JButton("Copy Right Wing");
     
     private JPanel topPanel = new JPanel();
     private JPanel middlePanel = new JPanel();   
@@ -112,6 +119,9 @@ public class CriticalView extends IView {
         aftPanel.setLayout(new BoxLayout(aftPanel, BoxLayout.Y_AXIS));
         bottomPanel.add(aftPanel);
         mainPanel.add(bottomPanel);
+        
+        btnCopyLW.addActionListener(ev -> copyLocation(Aero.LOC_LWING, Aero.LOC_RWING));
+        btnCopyRW.addActionListener(ev -> copyLocation(Aero.LOC_RWING, Aero.LOC_LWING));
 
         this.add(mainPanel);
     }
@@ -243,8 +253,10 @@ public class CriticalView extends IView {
             }
             
             leftWingPanel.add(leftSpace);
+            leftWingPanel.add(btnCopyRW);
             leftWingPanel.add(Box.createVerticalStrut(8));
             rightWingPanel.add(rightSpace);
+            rightWingPanel.add(btnCopyLW);
             rightWingPanel.add(Box.createVerticalStrut(8));
             nosePanel.add(noseSpace);
             nosePanel.add(Box.createVerticalStrut(8));
@@ -261,5 +273,14 @@ public class CriticalView extends IView {
             rightWingPanel.invalidate();
             aftPanel.invalidate();
         }
+    }
+    
+    private void copyLocation(int from, int to) {
+        try {
+            UnitUtil.copyLocationEquipment(getAero(), from, to);
+        } catch (LocationFullException ex) {
+            JOptionPane.showMessageDialog(this, "Insufficient space", "Location Full", JOptionPane.WARNING_MESSAGE);
+        }
+        refresh.refreshAll();
     }
 }

--- a/src/megameklab/com/ui/Aero/views/CriticalView.java
+++ b/src/megameklab/com/ui/Aero/views/CriticalView.java
@@ -17,6 +17,7 @@
 package megameklab.com.ui.Aero.views;
 
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Font;
 import java.util.Vector;
 
@@ -120,6 +121,8 @@ public class CriticalView extends IView {
         bottomPanel.add(aftPanel);
         mainPanel.add(bottomPanel);
         
+        btnCopyLW.setAlignmentX(Component.CENTER_ALIGNMENT);
+        btnCopyRW.setAlignmentX(Component.CENTER_ALIGNMENT);
         btnCopyLW.addActionListener(ev -> copyLocation(Aero.LOC_LWING, Aero.LOC_RWING));
         btnCopyRW.addActionListener(ev -> copyLocation(Aero.LOC_RWING, Aero.LOC_LWING));
 

--- a/src/megameklab/com/ui/aerospace/LargeCraftCriticalView.java
+++ b/src/megameklab/com/ui/aerospace/LargeCraftCriticalView.java
@@ -130,10 +130,15 @@ public class LargeCraftCriticalView extends IView {
 
         leftColumn.add(Box.createVerticalGlue());
         leftPanel = createArcPanel(TestSmallCraft.ARC_FWD_LEFT, resourceMap, true, btnCopyFRS);
+        btnCopyFRS.setText("Copy from " + (getAero().hasETypeFlag(Entity.ETYPE_JUMPSHIP)?
+                capitalArcNames[TestSmallCraft.ARC_FWD_RIGHT] : spheroidArcNames[TestSmallCraft.ARC_FWD_RIGHT]));
         leftColumn.add(leftPanel);
         bsLeftPanel = createArcPanel(Warship.LOC_LBS, resourceMap, true, btnCopyRBS);
+        btnCopyRBS.setText("Copy from " + capitalArcNames[Warship.LOC_RBS]);
         leftColumn.add(bsLeftPanel);
         aftLeftPanel = createArcPanel(aftLeft, resourceMap, true, btnCopyARS);
+        btnCopyARS.setText("Copy from " + (getAero().hasETypeFlag(Entity.ETYPE_JUMPSHIP)?
+                capitalArcNames[aftRight] : spheroidArcNames[aftRight]));
         leftColumn.add(aftLeftPanel);
         leftColumn.add(Box.createVerticalGlue());
 
@@ -148,10 +153,15 @@ public class LargeCraftCriticalView extends IView {
         
         rightColumn.add(Box.createVerticalGlue());
         rightPanel = createArcPanel(TestSmallCraft.ARC_FWD_RIGHT, resourceMap, true, btnCopyFLS);
+        btnCopyFLS.setText("Copy from " + (getAero().hasETypeFlag(Entity.ETYPE_JUMPSHIP)?
+                capitalArcNames[TestSmallCraft.ARC_FWD_LEFT] : spheroidArcNames[TestSmallCraft.ARC_FWD_LEFT]));
         rightColumn.add(rightPanel);
         bsRightPanel = createArcPanel(Warship.LOC_RBS, resourceMap, true, btnCopyLBS);
+        btnCopyLBS.setText("Copy from " + capitalArcNames[Warship.LOC_LBS]);
         rightColumn.add(bsRightPanel);
         aftRightPanel = createArcPanel(aftRight, resourceMap, true, btnCopyALS);
+        btnCopyALS.setText("Copy from " + (getAero().hasETypeFlag(Entity.ETYPE_JUMPSHIP)?
+                capitalArcNames[aftLeft] : spheroidArcNames[aftLeft]));
         rightColumn.add(aftRightPanel);
         rightColumn.add(Box.createVerticalGlue());
 

--- a/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
+++ b/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
@@ -1199,6 +1199,12 @@ public class BayWeaponCriticalTree extends JTree {
     
     private void moveToArc(Mounted eq) {
         UnitUtil.removeCriticals(eSource.getEntity(), eq);
+        try {
+            eSource.getEntity().addEquipment(eq, location, false);
+        } catch (LocationFullException e) {
+            // We shouldn't be hitting any limits
+            e.printStackTrace();
+        }
         UnitUtil.changeMountStatus(eSource.getEntity(), eq, location,
                 Entity.LOC_NONE, (facing == AFT) || ((facing == BOTH) && eq.isRearMounted()));
     }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -3700,7 +3700,8 @@ public class UnitUtil {
          */
         for (int slot = 0; slot < entity.getNumberOfCriticals(fromLoc); slot++) {
             final CriticalSlot crit = entity.getCritical(fromLoc, slot);
-            if ((null != crit) && (crit.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
+            if ((null != crit) && (crit.getType() == CriticalSlot.TYPE_EQUIPMENT)
+                    && (crit.getMount().isRearMounted() ? includeRear : includeForward)) {
                 Mounted toAdd = removed.stream().filter(m -> m.getType().equals(crit.getMount().getType()))
                         .findFirst().orElse(null);
                 if (null != toAdd) {

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -3775,6 +3775,10 @@ public class UnitUtil {
         } else {
             toAdd = new Mounted(entity, toCopy.getType());
         }
+        if (toCopy.getType() instanceof AmmoType) {
+            toAdd.setAmmoCapacity(toCopy.getAmmoCapacity());
+            toAdd.setShotsLeft(toCopy.getBaseShotsLeft());
+        }
         entity.addEquipment(toAdd, toLoc, toCopy.isRearMounted());
         changeMountStatus(entity, toAdd, toLoc, Entity.LOC_NONE, toCopy.isRearMounted());
         return toAdd;

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -3729,12 +3729,13 @@ public class UnitUtil {
                         newBay.addAmmoToBay(entity.getEquipmentNum(toAdd));
                     }
                 }
-                // Now we copy any other equipment
-                for (Mounted m : entity.getMisc()) {
-                    if ((m.getLocation() == fromLoc)
-                            && (m.isRearMounted() ? includeRear : includeForward)) {
-                        copyEquipment(entity, toLoc, m, removed);
-                    }
+            }
+            // Now we copy any other equipment
+            mountList = new ArrayList<>(entity.getMisc());
+            for (Mounted m : mountList) {
+                if ((m.getLocation() == fromLoc)
+                        && (m.isRearMounted() ? includeRear : includeForward)) {
+                    copyEquipment(entity, toLoc, m, removed);
                 }
             }
         } else {


### PR DESCRIPTION
Adds button to side locations on aerospace units to copy the equipment loadout from the other side. Any equipment already in the side is removed if not needed. Any equipment not already present is created.

Partial implementation of #192 