### PR TITLE
LAM ammo assignments

### DIFF
--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -419,7 +419,10 @@ public class BuildView extends IView implements ActionListener, MouseListener {
     private void jMenuLoadComponent_actionPerformed(int location, int selectedRow) {
         Mounted eq = (Mounted) equipmentTable.getModel().getValueAt(selectedRow, CriticalTableModel.EQUIPMENT);
         if (eq.getType().isSpreadable() || eq.isSplitable()) {
-            if (!(eq.getType() instanceof MiscType) || !eq.getType().hasFlag(MiscType.F_TARGCOMP)) {
+            if (getMech() instanceof LandAirMech) {
+                jMenuLoadSplitComponent_actionPerformed(location, Entity.LOC_NONE, eq.getType().getCriticals(getMech()),
+                        selectedRow);
+            } else if (!(eq.getType() instanceof MiscType) || !eq.getType().hasFlag(MiscType.F_TARGCOMP)) {
                 jMenuLoadSplitComponent_actionPerformed(location, Entity.LOC_NONE, 1,
                         selectedRow);
             } else {

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -3470,7 +3470,7 @@ public class UnitUtil {
                 return false;
             }
             return true;
-        } else if (unit.isFighter()) {
+        } else if ((unit instanceof Aero) && unit.isFighter()) {
             // Weapons must have a firing arc. Mostly we don't want them going into the fuselage.
             if ((eq instanceof WeaponType) || (UnitUtil.isWeaponEnhancement(eq))) {
                 return location < Aero.LOC_WINGS;


### PR DESCRIPTION
Fixes bug that only allow LAMs to place ammo in left arm. This comes from it being identified as a fighter and restricting the ammo to the fuselage (Aero.LOC_FUSELAGE == Mech.LOC_LARM).

Also fixes a bug in assigning splittable equipment on LAMs, which I noticed while troubleshooting. Because LAMs are not allowed to split equipment between locations, the assignment follows a different path and misses the logic for assigning additional slots past the first one.

Fixes #260: Some issue to allocate the components of LAM