### PR TITLE
Adjustment to fighter nose armor pip layout.

### DIFF
--- a/src/megameklab/com/ui/Aero/Printing/PrintAero.java
+++ b/src/megameklab/com/ui/Aero/Printing/PrintAero.java
@@ -276,10 +276,11 @@ public class PrintAero implements Printable {
     }
 
     private void printFrontArmor(Graphics2D g2d, int totalArmor) {
-        // Positions pips symmetrically from the centerline to the edges, forward to aft
-        final int[] pipsPerHalfRow = { 4, 6, 13, 14, 14, 14, 14, 14, 13, 12, 9, 6 };
-        final int[] rowOffset = { 35, 42, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-        final int maxPips = Arrays.stream(pipsPerHalfRow).sum() * 2;
+        // The number of pips in each row, forward to aft
+        final int[] pipsPerRow = { 8, 12, 26, 28, 28, 28, 28, 28, 24, 22, 16, 12 };
+        // The number of pips to skip in the middle of the row
+        final int[] gap = { 10, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        final int maxPips = Arrays.stream(pipsPerRow).sum();
         
         float centerx = 393;
         float ypos = 157;
@@ -287,12 +288,14 @@ public class PrintAero implements Printable {
         
         // Calculate possible positions
         List<float[]> pipPlotter = new ArrayList<>();
-        for (int row = 0; row < pipsPerHalfRow.length; row++) {
-            int xOffset = rowOffset[row];
-            for (int i = 0; i < pipsPerHalfRow[row]; i++) {
-                pipPlotter.add(new float[] { centerx + xOffset, ypos});
-                pipPlotter.add(new float[] { centerx - xOffset - pipShift[0], ypos});
-                xOffset += pipShift[0];
+        for (int row = 0; row < pipsPerRow.length; row++) {
+            float xpos = centerx - pipShift[0] * ((pipsPerRow[row] + gap[row]) / 2.0f);
+            for (int i = 0; i < pipsPerRow[row]; i++) {
+                if (i == pipsPerRow[row] / 2) {
+                    xpos += pipShift[0] * gap[row];
+                }
+                pipPlotter.add(new float[] { xpos, ypos });
+                xpos += pipShift[0];
             }
             ypos += pipShift[1];
         }


### PR DESCRIPTION
Fixes some unusual pip patterns from the changes in asf printing a few weeks ago that increases the maximum.

The algorithm that selects which of the possible pips to print spaces them somewhat proportionally along each row, assuming that the pips are ordered from one side to another. My recent change alternated them left and right from the centerline out,. If the selection algorithm determines that every other pip should be used (or every fourth, sixth, etc), all the pips are on the same side of the fighter. This reworks the layout to keep the larger maximum but lays each row out in a single direction.