### PR TITLE
Aero pilot/crew data on record sheets

### DIFF
--- a/src/megameklab/com/ui/Aero/Printing/PrintAero.java
+++ b/src/megameklab/com/ui/Aero/Printing/PrintAero.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Vector;
 
 import megamek.common.Aero;
+import megamek.common.Crew;
 // TODO: uncomment when print issue is fixed and pilot data is ready to position
 // import megamek.common.Crew;
 import megamek.common.TechConstants;
@@ -96,18 +97,13 @@ public class PrintAero implements Printable {
         Font font = UnitUtil.deriveFont(8.0f);
         g2d.setFont(font);
 
-		//TODO: Pilot Data: Fix coords. Below coords are pasted from Mech code.
-        //if ((aero.getCrew() != null) && !aero.getCrew().getName().equalsIgnoreCase("unnamed")) {
-        //	Crew pilot = aero.getCrew();		
-		//	g2d.drawString(pilot.getName(), 270 + leftMargin, topMargin + 119);
-		//	g2d.drawString(String.valueOf(pilot.getGunnery()), 295 + leftMargin, topMargin + 132);
-		//  g2d.drawString(String.valueOf(pilot.getPiloting()), 365 + leftMargin, topMargin + 132);
-        //}
-        // Test strings
-		//    g2d.drawString("Test Pilot", 270 + leftMargin, topMargin + 119);
-		//	g2d.drawString("5", 295 + leftMargin, topMargin + 132);
-		//    g2d.drawString("5", 365 + leftMargin, topMargin + 132);
-		
+        if ((aero.getCrew() != null)
+                && !aero.getCrew().getName().equalsIgnoreCase("unnamed")) {
+            Crew pilot = aero.getCrew();
+            g2d.drawString(pilot.getName(), 270, 524);
+            g2d.drawString(String.valueOf(pilot.getGunnery()), 295, 536);
+            g2d.drawString(String.valueOf(pilot.getPiloting()), 365, 536);
+        }
 
         g2d.drawString(Integer.toString(aero.getWalkMP()), 99, 143);
         g2d.drawString(Integer.toString(aero.getRunMP()), 99, 154);

--- a/src/megameklab/com/ui/Aero/Printing/PrintConventionalFighter.java
+++ b/src/megameklab/com/ui/Aero/Printing/PrintConventionalFighter.java
@@ -45,6 +45,7 @@ public class PrintConventionalFighter implements Printable {
 
     }
 
+    @Override
     public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
         Graphics2D g2d = (Graphics2D) graphics;
         // f.setPaper(this.paper);
@@ -93,11 +94,12 @@ public class PrintConventionalFighter implements Printable {
         font = UnitUtil.deriveFont(8.0f);
         g2d.setFont(font);
 
-        if ((convFighter.getCrew() != null) && !convFighter.getCrew().getName().equalsIgnoreCase("unnamed")) {
+        if ((convFighter.getCrew() != null)
+                && !convFighter.getCrew().getName().equalsIgnoreCase("unnamed")) {
             Crew pilot = convFighter.getCrew();
-            g2d.drawString(pilot.getName(), 270, 120);
-            g2d.drawString(String.valueOf(pilot.getGunnery()), 295, 132);
-            g2d.drawString(String.valueOf(pilot.getPiloting()), 365, 132);
+            g2d.drawString(pilot.getName(), 270, 524);
+            g2d.drawString(String.valueOf(pilot.getGunnery()), 295, 536);
+            g2d.drawString(String.valueOf(pilot.getPiloting()), 365, 536);
         }
 
         g2d.drawString(Integer.toString(convFighter.getWalkMP()), 99, 143);

--- a/src/megameklab/com/ui/Aero/Printing/PrintFixedWingSupport.java
+++ b/src/megameklab/com/ui/Aero/Printing/PrintFixedWingSupport.java
@@ -44,6 +44,7 @@ public class PrintFixedWingSupport implements Printable {
         this.fixedWingSupport = fixedWingSupport;
     }
 
+    @Override
     public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
         Graphics2D g2d = (Graphics2D) graphics;
         // f.setPaper(this.paper);
@@ -91,11 +92,12 @@ public class PrintFixedWingSupport implements Printable {
 
         font = UnitUtil.deriveFont(8.0f);
         g2d.setFont(font);
-        if ((fixedWingSupport.getCrew() != null) && !fixedWingSupport.getCrew().getName().equalsIgnoreCase("unnamed")) {
+        if ((fixedWingSupport.getCrew() != null)
+                && !fixedWingSupport.getCrew().getName().equalsIgnoreCase("unnamed")) {
             Crew pilot = fixedWingSupport.getCrew();
-            g2d.drawString(pilot.getName(), 270, 120);
-            g2d.drawString(String.valueOf(pilot.getGunnery()), 295, 132);
-            g2d.drawString(String.valueOf(pilot.getPiloting()), 365, 132);
+            g2d.drawString(pilot.getName(), 270, 524);
+            g2d.drawString(String.valueOf(pilot.getGunnery()), 295, 536);
+            g2d.drawString(String.valueOf(pilot.getPiloting()), 365, 536);
         }
 
         g2d.drawString(Integer.toString(fixedWingSupport.getWalkMP()), 99, 143);

--- a/src/megameklab/com/ui/Aero/Printing/PrintSmallCraftAerodyne.java
+++ b/src/megameklab/com/ui/Aero/Printing/PrintSmallCraftAerodyne.java
@@ -1,5 +1,5 @@
 /*
- * MegaMekLab - Copyright (C) 2008
++++rr * MegaMekLab - Copyright (C) 2008
  *
  * Original author - jtighe (torren@users.sourceforge.net)
  *
@@ -45,6 +45,7 @@ public class PrintSmallCraftAerodyne implements Printable {
 
     }
 
+    @Override
     public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
         Graphics2D g2d = (Graphics2D) graphics;
         // f.setPaper(this.paper);
@@ -91,9 +92,9 @@ public class PrintSmallCraftAerodyne implements Printable {
 
         if ((smallCraft.getCrew() != null) && !smallCraft.getCrew().getName().equalsIgnoreCase("unnamed")) {
             Crew pilot = smallCraft.getCrew();
-            g2d.drawString(pilot.getName(), 270, 120);
-            g2d.drawString(String.valueOf(pilot.getGunnery()), 295, 132);
-            g2d.drawString(String.valueOf(pilot.getPiloting()), 365, 132);
+            g2d.drawString(pilot.getName(), 270, 524);
+            g2d.drawString(String.valueOf(pilot.getGunnery()), 295, 536);
+            g2d.drawString(String.valueOf(pilot.getPiloting()), 365, 536);
         }
 
         g2d.drawString(Integer.toString(smallCraft.getWalkMP()), 99, 143);

--- a/src/megameklab/com/ui/Aero/Printing/PrintSmallCraftAerodyne.java
+++ b/src/megameklab/com/ui/Aero/Printing/PrintSmallCraftAerodyne.java
@@ -1,5 +1,5 @@
 /*
-+++rr * MegaMekLab - Copyright (C) 2008
+ * MegaMekLab - Copyright (C) 2008
  *
  * Original author - jtighe (torren@users.sourceforge.net)
  *

--- a/src/megameklab/com/ui/Aero/Printing/PrintSmallCraftSpheroid.java
+++ b/src/megameklab/com/ui/Aero/Printing/PrintSmallCraftSpheroid.java
@@ -32,6 +32,7 @@ import java.util.Vector;
 import com.kitfox.svg.SVGException;
 
 import megamek.common.Aero;
+import megamek.common.Crew;
 import megamek.common.SmallCraft;
 //TODO: uncomment when print issue is fixed and pilot data is ready to position
 //import megamek.common.Crew;
@@ -51,6 +52,7 @@ public class PrintSmallCraftSpheroid implements Printable {
         this.smallCraft = smallCraft;
     }
 
+    @Override
     public int print(Graphics graphics, PageFormat pageFormat, int pageIndex)
             throws PrinterException {
         Graphics2D g2d = (Graphics2D) graphics;
@@ -106,17 +108,12 @@ public class PrintSmallCraftSpheroid implements Printable {
         Font font = UnitUtil.deriveFont(8.0f);
         g2d.setFont(font);
 
-        //TODO: Pilot Data: Fix coords. Below coords are pasted from Mech code.
-        //if ((aero.getCrew() != null) && !aero.getCrew().getName().equalsIgnoreCase("unnamed")) {
-        //	Crew pilot = aero.getCrew();		
-		//	g2d.drawString(pilot.getName(), 270 + leftMargin, topMargin + 119);
-		//	g2d.drawString(String.valueOf(pilot.getGunnery()), 295 + leftMargin, topMargin + 132);
-		//  g2d.drawString(String.valueOf(pilot.getPiloting()), 365 + leftMargin, topMargin + 132);
-        //}
-        // Test strings
-		//    g2d.drawString("Test Pilot", 270 + leftMargin, topMargin + 119);
-		//	g2d.drawString("5", 295 + leftMargin, topMargin + 132);
-		//    g2d.drawString("5", 365 + leftMargin, topMargin + 132);
+        if ((smallCraft.getCrew() != null) && !smallCraft.getCrew().getName().equalsIgnoreCase("unnamed")) {
+            Crew pilot = smallCraft.getCrew();
+            g2d.drawString(pilot.getName(), 274, 534);
+            g2d.drawString(String.valueOf(pilot.getGunnery()), 302, 547);
+            g2d.drawString(String.valueOf(pilot.getPiloting()), 373, 547);
+        }
 
         g2d.drawString(Integer.toString(smallCraft.getWalkMP()), 102, 142);
         g2d.drawString(Integer.toString(smallCraft.getRunMP()), 102, 152.5f);

--- a/src/megameklab/com/ui/Dropship/Printing/PrintAerodyne.java
+++ b/src/megameklab/com/ui/Dropship/Printing/PrintAerodyne.java
@@ -47,6 +47,7 @@ public class PrintAerodyne implements Printable {
         this.dropship = dropship;
     }
 
+    @Override
     public int print(Graphics graphics, PageFormat pageFormat, int pageIndex)
             throws PrinterException {
         Graphics2D g2d = (Graphics2D) graphics;
@@ -99,9 +100,8 @@ public class PrintAerodyne implements Printable {
         if ((dropship.getCrew() != null)
                 && !dropship.getCrew().getName().equalsIgnoreCase("unnamed")) {
             Crew pilot = dropship.getCrew();
-            g2d.drawString(pilot.getName(), 270, 120);
-            g2d.drawString(String.valueOf(pilot.getGunnery()), 295, 132);
-            g2d.drawString(String.valueOf(pilot.getPiloting()), 365, 132);
+            g2d.drawString(String.valueOf(pilot.getGunnery()), 297, 524);
+            g2d.drawString(String.valueOf(pilot.getPiloting()), 363, 524);
         }
 
         g2d.drawString(Integer.toString(dropship.getWalkMP()), 99, 156);

--- a/src/megameklab/com/ui/Dropship/Printing/PrintSpheroid.java
+++ b/src/megameklab/com/ui/Dropship/Printing/PrintSpheroid.java
@@ -47,6 +47,7 @@ public class PrintSpheroid implements Printable {
         this.dropship = dropship;
     }
 
+    @Override
     public int print(Graphics graphics, PageFormat pageFormat, int pageIndex)
             throws PrinterException {
         Graphics2D g2d = (Graphics2D) graphics;
@@ -99,9 +100,8 @@ public class PrintSpheroid implements Printable {
         if ((dropship.getCrew() != null)
                 && !dropship.getCrew().getName().equalsIgnoreCase("unnamed")) {
             Crew pilot = dropship.getCrew();
-            g2d.drawString(pilot.getName(), 270, 125);
-            g2d.drawString(String.valueOf(pilot.getGunnery()), 295, 137);
-            g2d.drawString(String.valueOf(pilot.getPiloting()), 365, 137);
+            g2d.drawString(String.valueOf(pilot.getGunnery()), 297, 524);
+            g2d.drawString(String.valueOf(pilot.getPiloting()), 363, 524);
         }
 
         g2d.drawString(Integer.toString(dropship.getWalkMP()), 99, 163);


### PR DESCRIPTION
Fixes #7: Pilot name printing on RSs

Aerospace record sheets (dropships, small craft, aerospace/conventional fighters, fixed wing support) all had the code that prints the pilot/crew name and skills copied from the old mech printing code, which has the wrong coordinates:

![image](https://user-images.githubusercontent.com/16927464/53315162-86834100-3887-11e9-8938-1d2285ceab1b.png)


Fixed the coordinates to write the text in the correct location:

![image](https://user-images.githubusercontent.com/16927464/53315206-b2062b80-3887-11e9-8b00-abe252552ac3.png)