### PR TITLE
Large craft auto-allocate

### DIFF
--- a/docs/history.txt
+++ b/docs/history.txt
@@ -12,6 +12,8 @@ v0.45.4-SNAPSHOT
 + Issue #261: LAM's motive type doesn't change the weight of its conversion equipment.
 + Issue #7: Pilot name printing on RSs
 + Issue #271: Bug of interaction with Partial Wing, Improved Jump Jet and Hardened Armor
++ Issue #267: Dropship armor values calculating and auto-allocating incorrectly
++ Issue #276: Auto allocate skips advanced aerospace side rear locations
 
 v0.45.3 (2019-02-12 0500 UTC)
 + Issue #223: Quad Protomech engine weight

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
@@ -517,12 +517,13 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
 
     @Override
     public void autoAllocateArmor() {
-        for (int loc = 0; loc < getJumpship().locations() - 1; loc++) {
+        final int ARMOR_FACINGS = getJumpship().locations() - 1;
+        for (int loc = 0; loc < ARMOR_FACINGS; loc++) {
             getJumpship().initializeArmor(0, loc);
         }
         
         // divide armor (in excess of bonus from SI) among positions, with more toward the front
-        int bonusPerFacing = (int) Math.floor(UnitUtil.getSIBonusArmorPoints(getJumpship()) / 6.0);
+        int bonusPerFacing = (int) Math.floor(UnitUtil.getSIBonusArmorPoints(getJumpship()) / ARMOR_FACINGS);
         int points = UnitUtil.getArmorPoints(getJumpship(), getJumpship().getLabArmorTonnage())
                 - bonusPerFacing * 6;
         int nose = (int)Math.floor(points * 0.22);

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
@@ -521,30 +521,43 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
             getJumpship().initializeArmor(0, loc);
         }
         
-        // divide armor among positions, with more toward the front
-        int points = UnitUtil.getArmorPoints(getJumpship(), getJumpship().getLabArmorTonnage());
-        int nose = (int)Math.floor(points * 0.3);
-        int wing = (int)Math.floor(points * 0.25);
-        int aft = (int)Math.floor(points * 0.2);
-        int remainder = points - nose - wing - wing - aft;
+        // divide armor (in excess of bonus from SI) among positions, with more toward the front
+        int bonusPerFacing = (int) Math.floor(UnitUtil.getSIBonusArmorPoints(getJumpship()) / 6.0);
+        int points = UnitUtil.getArmorPoints(getJumpship(), getJumpship().getLabArmorTonnage())
+                - bonusPerFacing * 6;
+        int nose = (int)Math.floor(points * 0.22);
+        int foresides = (int)Math.floor(points * 0.18);
+        int aftsides = (int) Math.floor(points * 0.16);
+        int aft = (int)Math.floor(points * 0.10);
+        int remainder = points - nose - foresides * 2 - aftsides * 2 - aft;
         
-        // spread remainder among nose and wings
-        switch(remainder % 4) {
+        // spread remainder among nose and fore sides
+        switch(remainder % 6) {
             case 1:
                 nose++;
                 break;
+            case 2:
+                foresides++;
+                break;
             case 3:
                 nose++;
-                wing++;
+                foresides++;
                 break;
-            case 2:
-                wing++;
+            case 4:
+                nose += 2;
+                foresides++;
+                break;
+            case 5:
+                nose += 3;
+                foresides++;
                 break;
         }
-        getJumpship().initializeArmor(nose, Aero.LOC_NOSE);
-        getJumpship().initializeArmor(wing, Aero.LOC_LWING);
-        getJumpship().initializeArmor(wing, Aero.LOC_RWING);
-        getJumpship().initializeArmor(aft, Aero.LOC_AFT);
+        getJumpship().initializeArmor(nose + bonusPerFacing, Jumpship.LOC_NOSE);
+        getJumpship().initializeArmor(foresides + bonusPerFacing, Jumpship.LOC_FRS);
+        getJumpship().initializeArmor(foresides + bonusPerFacing, Jumpship.LOC_FLS);
+        getJumpship().initializeArmor(aftsides + bonusPerFacing, Jumpship.LOC_ARS);
+        getJumpship().initializeArmor(aftsides + bonusPerFacing, Jumpship.LOC_ALS);
+        getJumpship().initializeArmor(aft + bonusPerFacing, Jumpship.LOC_AFT);
         getJumpship().autoSetThresh();
 
         panArmorAllocation.setFromEntity(getJumpship());

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
@@ -517,6 +517,7 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
 
     @Override
     public void autoAllocateArmor() {
+        // ignore unarmored system-wide location
         final int ARMOR_FACINGS = getJumpship().locations() - 1;
         for (int loc = 0; loc < ARMOR_FACINGS; loc++) {
             getJumpship().initializeArmor(0, loc);

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
@@ -31,6 +31,7 @@ import megamek.common.ITechManager;
 import megamek.common.Jumpship;
 import megamek.common.SimpleTechLevel;
 import megamek.common.SpaceStation;
+import megamek.common.Warship;
 import megamek.common.verifier.TestEntity;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.view.AdvancedAeroChassisView;
@@ -517,8 +518,9 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
 
     @Override
     public void autoAllocateArmor() {
-        // ignore unarmored system-wide location
-        final int ARMOR_FACINGS = getJumpship().locations() - 1;
+        // ignore unarmored system-wide location and warship broadsides
+        final int ARMOR_FACINGS = getJumpship() instanceof Warship ?
+                getJumpship().locations() - 3 : getJumpship().locations() - 1;
         for (int loc = 0; loc < ARMOR_FACINGS; loc++) {
             getJumpship().initializeArmor(0, loc);
         }

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
@@ -517,13 +517,12 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
 
     @Override
     public void autoAllocateArmor() {
-        for (int loc = 0; loc < getJumpship().locations(); loc++) {
+        for (int loc = 0; loc < getJumpship().locations() - 1; loc++) {
             getJumpship().initializeArmor(0, loc);
         }
         
         // divide armor among positions, with more toward the front
-        int points = UnitUtil.getArmorPoints(getJumpship(), getJumpship().getLabArmorTonnage())
-                + getAero().getSI() * getAero().locations();
+        int points = UnitUtil.getArmorPoints(getJumpship(), getJumpship().getLabArmorTonnage());
         int nose = (int)Math.floor(points * 0.3);
         int wing = (int)Math.floor(points * 0.25);
         int aft = (int)Math.floor(points * 0.2);

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroUI.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroUI.java
@@ -156,7 +156,7 @@ public class AdvancedAeroUI extends MegaMekLabMainUI {
         ship.initializeKFIntegrity();
         ship.initializeSailIntegrity();
         for (int loc = 0; loc < getEntity().locations(); loc++) {
-            if (loc == Jumpship.LOC_HULL) {
+            if (loc >= Jumpship.LOC_HULL) {
                 ship.initializeArmor(IArmorState.ARMOR_NA, loc);
             } else {
                 ship.initializeArmor((int) Math.round(ship.get0SI() / 10.0), loc);

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroUI.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroUI.java
@@ -25,6 +25,7 @@ import javax.swing.SwingConstants;
 import megamek.common.Aero;
 import megamek.common.Entity;
 import megamek.common.EquipmentType;
+import megamek.common.IArmorState;
 import megamek.common.ITechManager;
 import megamek.common.Jumpship;
 import megamek.common.MechSummaryCache;
@@ -155,7 +156,11 @@ public class AdvancedAeroUI extends MegaMekLabMainUI {
         ship.initializeKFIntegrity();
         ship.initializeSailIntegrity();
         for (int loc = 0; loc < getEntity().locations(); loc++) {
-            ship.initializeArmor((int) Math.round(ship.get0SI() / 10.0), loc);
+            if (loc == Jumpship.LOC_HULL) {
+                ship.initializeArmor(IArmorState.ARMOR_NA, loc);
+            } else {
+                ship.initializeArmor((int) Math.round(ship.get0SI() / 10.0), loc);
+            }
         }
 
         if (null == oldUnit) {

--- a/src/megameklab/com/ui/aerospace/DropshipMainUI.java
+++ b/src/megameklab/com/ui/aerospace/DropshipMainUI.java
@@ -27,6 +27,7 @@ import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.EntityMovementMode;
 import megamek.common.EquipmentType;
+import megamek.common.IArmorState;
 import megamek.common.ITechManager;
 import megamek.common.MechSummaryCache;
 import megamek.common.SimpleTechLevel;
@@ -135,7 +136,11 @@ public class DropshipMainUI extends MegaMekLabMainUI {
 
         smallCraft.autoSetInternal();
         for (int loc = 0; loc < getEntity().locations(); loc++) {
-            smallCraft.initializeArmor(smallCraft.get0SI(), loc);
+            if (loc == SmallCraft.LOC_HULL) {
+                smallCraft.initializeArmor(IArmorState.ARMOR_NA, loc);
+            } else {
+                smallCraft.initializeArmor(smallCraft.get0SI(), loc);
+            }
         }
 
         if (null == oldUnit) {

--- a/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
@@ -476,13 +476,12 @@ public class DropshipStructureTab extends ITab implements DropshipBuildListener 
 
     @Override
     public void autoAllocateArmor() {
-        for (int loc = 0; loc < getSmallCraft().locations(); loc++) {
+        for (int loc = 0; loc < getSmallCraft().locations() - 1; loc++) {
             getSmallCraft().initializeArmor(0, loc);
         }
         
         // divide armor among positions, with more toward the front
-        int points = UnitUtil.getArmorPoints(getSmallCraft(), getSmallCraft().getLabArmorTonnage())
-                + getAero().getSI() * getAero().locations();
+        int points = UnitUtil.getArmorPoints(getSmallCraft(), getSmallCraft().getLabArmorTonnage());
         int nose = (int)Math.floor(points * 0.3);
         int wing = (int)Math.floor(points * 0.25);
         int aft = (int)Math.floor(points * 0.2);

--- a/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
@@ -476,12 +476,13 @@ public class DropshipStructureTab extends ITab implements DropshipBuildListener 
 
     @Override
     public void autoAllocateArmor() {
-        for (int loc = 0; loc < getSmallCraft().locations() - 1; loc++) {
+        final int ARMOR_FACINGS = getSmallCraft().locations() - 1;
+        for (int loc = 0; loc < ARMOR_FACINGS; loc++) {
             getSmallCraft().initializeArmor(0, loc);
         }
         
         // divide armor (in excess of bonus from SI) among positions, with more toward the front
-        int bonusPerFacing = (int) UnitUtil.getSIBonusArmorPoints(getSmallCraft()) / 4;
+        int bonusPerFacing = (int) UnitUtil.getSIBonusArmorPoints(getSmallCraft()) / ARMOR_FACINGS;
         int points = UnitUtil.getArmorPoints(getSmallCraft(), getSmallCraft().getLabArmorTonnage())
                 - bonusPerFacing * 4;
         int nose = (int)Math.floor(points * 0.3);

--- a/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
@@ -476,6 +476,7 @@ public class DropshipStructureTab extends ITab implements DropshipBuildListener 
 
     @Override
     public void autoAllocateArmor() {
+        // Ignore unarmored system-wide location
         final int ARMOR_FACINGS = getSmallCraft().locations() - 1;
         for (int loc = 0; loc < ARMOR_FACINGS; loc++) {
             getSmallCraft().initializeArmor(0, loc);

--- a/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
@@ -480,8 +480,10 @@ public class DropshipStructureTab extends ITab implements DropshipBuildListener 
             getSmallCraft().initializeArmor(0, loc);
         }
         
-        // divide armor among positions, with more toward the front
-        int points = UnitUtil.getArmorPoints(getSmallCraft(), getSmallCraft().getLabArmorTonnage());
+        // divide armor (in excess of bonus from SI) among positions, with more toward the front
+        int bonusPerFacing = (int) UnitUtil.getSIBonusArmorPoints(getSmallCraft()) / 4;
+        int points = UnitUtil.getArmorPoints(getSmallCraft(), getSmallCraft().getLabArmorTonnage())
+                - bonusPerFacing * 4;
         int nose = (int)Math.floor(points * 0.3);
         int wing = (int)Math.floor(points * 0.25);
         int aft = (int)Math.floor(points * 0.2);
@@ -500,10 +502,10 @@ public class DropshipStructureTab extends ITab implements DropshipBuildListener 
                 wing++;
                 break;
         }
-        getSmallCraft().initializeArmor(nose, Aero.LOC_NOSE);
-        getSmallCraft().initializeArmor(wing, Aero.LOC_LWING);
-        getSmallCraft().initializeArmor(wing, Aero.LOC_RWING);
-        getSmallCraft().initializeArmor(aft, Aero.LOC_AFT);
+        getSmallCraft().initializeArmor(nose + bonusPerFacing, Aero.LOC_NOSE);
+        getSmallCraft().initializeArmor(wing + bonusPerFacing, Aero.LOC_LWING);
+        getSmallCraft().initializeArmor(wing + bonusPerFacing, Aero.LOC_RWING);
+        getSmallCraft().initializeArmor(aft + bonusPerFacing, Aero.LOC_AFT);
         getSmallCraft().autoSetThresh();
 
         panArmorAllocation.setFromEntity(getSmallCraft());

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1508,7 +1508,7 @@ public class UnitUtil {
      */
     public static double getSIBonusArmorPoints(Entity entity) {
         if (entity.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)) {
-            return ((SmallCraft)entity).getSI() * entity.locations();
+            return ((SmallCraft)entity).getSI() * (entity.locations() - 1);
         } else if (entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
             double points = Math.round(((Jumpship) entity).getSI() / 10.0) * 6;
             if (((Jumpship) entity).isPrimitive()) {


### PR DESCRIPTION
Fixes three closely-related issues:
1. Dropships and small craft get bonus armor from their SI to each location. This was including the non-armored system-wide location.
2. The above units as well as advanced aerospace units were having the number of bonus armor points added in twice when apportioning armor points using auto-allocate.
3. The auto-allocate code for JS/WS/SS was copied from SC/DS without being modified for the two extra armor locations, so side rear locations were not getting any armor beyond the bonus from SI.

Bonus issue, previously unreported: added logic to make sure that auto-allocate does not assign any values less than the minimum, which is the bonus provided by SI.

Fixes #267 
Fixes #276 