### PR TITLE
Fix for #281

### DIFF
--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -147,7 +147,10 @@ public abstract class PrintEntity extends PrintRecordSheet {
         setTextField("rulesLevel", formatRulesLevel());
         setTextField("era", formatEra(getEntity().getYear()));
         setTextField("cost", formatCost());
-        setTextField("bv", NumberFormat.getInstance().format(getEntity().calculateBattleValue()));
+        // If we're using a MUL to print generic sheets we also want to ignore any BV adjustments
+        // for C3 networks or pilot skills.
+        setTextField("bv", NumberFormat.getInstance().format(getEntity()
+                .calculateBattleValue(!showPilotInfo(), !showPilotInfo())));
         UnitRole role = UnitRoleHandler.getRoleFor(getEntity());
         if (!options.showRole() || (role == UnitRole.UNDETERMINED)) {
             hideElement("lblRole", true);


### PR DESCRIPTION
When printing record sheets, ignoring pilot data should also extend to
calculating BV.