### PR TITLE
Refresh equipment tab when new Entity is instantiated.

### DIFF
--- a/src/megameklab/com/ui/Aero/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/StructureTab.java
@@ -532,6 +532,7 @@ public class StructureTab extends ITab implements AeroBuildListener {
             eSource.createNewUnit(Entity.ETYPE_CONV_FIGHTER, getAero());
         }
         refresh();
+        refresh.refreshEquipment();
         refresh.refreshBuild();
         refresh.refreshPreview();
         refresh.refreshStatus();

--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -770,6 +770,7 @@ public class StructureTab extends ITab implements MekBuildListener {
         }
 
         refresh();
+        refresh.refreshEquipment();
         refresh.refreshBuild();
         refresh.refreshPreview();
         refresh.refreshStatus();

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -508,6 +508,7 @@ public class StructureTab extends ITab implements CVBuildListener {
         panChassis.refresh();
         panSummary.refresh();
         panArmorAllocation.setFromEntity(getTank());
+        refresh.refreshEquipment();
         refresh.refreshPreview();
         refresh.refreshBuild();
         refresh.refreshStatus();
@@ -544,6 +545,7 @@ public class StructureTab extends ITab implements CVBuildListener {
         panArmorAllocation.setFromEntity(getTank());
         panPatchwork.setFromEntity(getTank());
         panSummary.refresh();
+        refresh.refreshEquipment();
         refresh.refreshBuild();
         refresh.refreshStatus();
         refresh.refreshPreview();

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
@@ -473,7 +473,7 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
                 break;
         }
         refresh();
-        refresh.refreshEquipmentTable();
+        refresh.refreshEquipment();
         refresh.refreshBuild();
         refresh.refreshPreview();
         refresh.refreshStatus();

--- a/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
@@ -423,7 +423,7 @@ public class DropshipStructureTab extends ITab implements DropshipBuildListener 
             eSource.createNewUnit(Entity.ETYPE_DROPSHIP, getSmallCraft());
         }
         refresh();
-        refresh.refreshEquipmentTable();
+        refresh.refreshEquipment();
         refresh.refreshBuild();
         refresh.refreshPreview();
         refresh.refreshStatus();

--- a/src/megameklab/com/ui/view/MovementView.java
+++ b/src/megameklab/com/ui/view/MovementView.java
@@ -367,6 +367,8 @@ public class MovementView extends BuildView implements ActionListener, ChangeLis
             }
             if (lgShields > 0) {
                 jumpTooltip.add("No Jump (Large Shield)");
+            } else if (medShields > 0) {
+                jumpTooltip.add(String.format("-%d (Shield)", medShields));
             }
         } else if (en.hasWorkingMisc(MiscType.F_MASC)) {
             runTooltip.add("Supercharger");


### PR DESCRIPTION
When a change in unit type requires instantiating a new `Entity` the equipment tab does not refresh, so any equipment that might previously have been installed is not cleared from the table.

Fixes #299: Equipment tab does not refresh when unit type changes.