### PR TITLE
Set BA armor tech level before armor type.

### DIFF
--- a/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
@@ -667,9 +667,9 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
     public void armorTypeChanged(EquipmentType armor) {
         UnitUtil.removeISorArmorMounts(getBattleArmor(), false);
         int armorCount = armor.getCriticals(getBattleArmor());
-        getBattleArmor().setArmorType(armor.getInternalName());
         getBattleArmor().setArmorTechLevel(
                 armor.getTechLevel(getBattleArmor().getYear()));
+        getBattleArmor().setArmorType(armor.getInternalName());
 
         for (; armorCount > 0; armorCount--) {
             try {


### PR DESCRIPTION
The armor type lookup method used by `BattleArmor#setArmorType(String)` prepends "IS" or
"Clan" to the armor name if not already present based on the armor tech
level. This makes it impossible to switch between IS and Clan armor, and
results in all kinds of problems if the selected armor type does not
exist for the previous tech base. Assigning the tech level first
resolves it.

Fixes #305: Mixed IS techbase & Clan BA Fire Resistant