### PR TITLE
Report heat generation for non-weapon equipment.

### DIFF
--- a/src/megameklab/com/ui/Aero/StatusBar.java
+++ b/src/megameklab/com/ui/Aero/StatusBar.java
@@ -178,6 +178,12 @@ public class StatusBar extends ITab {
             }
             heat += weaponHeat;
         }
+        if (getAero().hasStealth()) {
+            heat += 10;
+        }
+        for (Mounted m : getAero().getMisc()) {
+            heat += m.getType().getHeat();
+        }
         return heat;
     }
 

--- a/src/megameklab/com/ui/Mek/StatusBar.java
+++ b/src/megameklab/com/ui/Mek/StatusBar.java
@@ -179,14 +179,6 @@ public class StatusBar extends ITab {
             heat += 2;
         }
 
-        if (getMech().hasNullSig()) {
-            heat += 10;
-        }
-
-        if (getMech().hasChameleonShield()) {
-            heat += 6;
-        }
-
         for (Mounted mounted : getMech().getWeaponList()) {
             WeaponType wtype = (WeaponType) mounted.getType();
             double weaponHeat = wtype.getHeat();
@@ -216,6 +208,12 @@ public class StatusBar extends ITab {
                 weaponHeat *= 0.5;
             }
             heat += weaponHeat;
+        }
+        if (getMech().hasStealth()) {
+            heat += 10;
+        }
+        for (Mounted m : getMech().getMisc()) {
+            heat += m.getType().getHeat();
         }
         return heat;
     }

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
@@ -178,6 +178,9 @@ public class AdvancedAeroStatusBar extends ITab {
             }
             heat += weaponHeat;
         }
+        for (Mounted m : getJumpship().getMisc()) {
+            heat += m.getType().getHeat();
+        }
         return heat;
     }
 

--- a/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
@@ -172,6 +172,9 @@ public class DropshipStatusBar extends ITab {
             }
             heat += weaponHeat;
         }
+        for (Mounted m : getSmallCraft().getMisc()) {
+            heat += m.getType().getHeat();
+        }
         return heat;
     }
 

--- a/src/megameklab/com/util/EquipmentInfo.java
+++ b/src/megameklab/com/util/EquipmentInfo.java
@@ -195,6 +195,7 @@ public class EquipmentInfo {
             } else {
                 longRange = 6;
             }
+            heat = mount.getType().getHeat();
         } else if ((mount.getType() instanceof MiscType) && mount.getType().hasFlag(MiscType.F_BAP)) {
             if (mount.getType().getInternalName().equals(Sensor.BAP)) {
                 longRange = 4;
@@ -209,6 +210,8 @@ public class EquipmentInfo {
             longRange = 170;
         } else if ((mount.getType() instanceof MiscType) && mount.getType().hasFlag(MiscType.F_PPC_CAPACITOR)) {
             heat = 5;
+        } else {
+            heat = mount.getType().getHeat();
         }
     }
 
@@ -311,7 +314,6 @@ public class EquipmentInfo {
             if (weapon.maxRange >= WeaponType.RANGE_EXT) {
                 erRange = (int) weapon.extAV + bonus;
             }
-            heat = weapon.getHeat();
             if (mount.getSecondLocation() != -1) {
                 loc = String.format("%1$s/%2$s", dropship.getLocationAbbr(mount.getLocation()), dropship.getLocationAbbr(mount.getSecondLocation()));
             }
@@ -342,6 +344,7 @@ public class EquipmentInfo {
             medRange = 0;
             longRange = 170;
         }
+        heat = mount.getType().getHeat();
 
         hasApollo = hasLinkedEquipment(mount, MiscType.F_APOLLO);
         isMashCore = (mount.getType() instanceof MiscType) && mount.getType().hasFlag(MiscType.F_MASH);
@@ -420,7 +423,6 @@ public class EquipmentInfo {
                 longRange = 1;
             }
 
-            heat = weapon.getHeat();
             if (mount.getSecondLocation() != -1) {
                 loc = String.format("%1$s/%2$s", unit.getLocationAbbr(mount.getLocation()), unit.getLocationAbbr(mount.getSecondLocation()));
             }
@@ -473,7 +475,7 @@ public class EquipmentInfo {
         } else if ((mount.getType() instanceof MiscType) && (mount.getType().hasFlag(MiscType.F_VOIDSIG) || mount.getType().hasFlag(MiscType.F_CHAMELEON_SHIELD) || mount.getType().hasFlag(MiscType.F_NULLSIG) || mount.getType().hasFlag(MiscType.F_BLUE_SHIELD))) {
             loc = "*";
         }
-
+        heat = mount.getType().getHeat();
         isBAMineLayer = (mount.getType() instanceof MiscType) && mount.getType().hasFlag(MiscType.F_MINE) && mount.getType().hasFlag(MiscType.F_BA_EQUIPMENT);
         hasArtemis = hasLinkedEquipment(mount, MiscType.F_ARTEMIS);
         hasArtemisV = hasLinkedEquipment(mount, MiscType.F_ARTEMIS_V);

--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -312,15 +312,14 @@ public class EquipmentTableModel extends AbstractTableModel {
             }
             return special;
         } else if (col == COL_HEAT) {
-            if (null != wtype) {
-                if (entity instanceof Aero) {
-                    return Integer.toString(wtype.getHeat()
-                            * Mounted.getNumShots(wtype, null, true));
-                } else {
-                    return Integer.toString(wtype.getHeat());
-                }
-            } else {
+            int heat = type.getHeat();
+            if ((null != wtype) && (entity instanceof Aero)) {
+                heat *= Mounted.getNumShots(wtype,  null,  true);
+            }
+            if (heat == 0) {
                 return "-";
+            } else {
+                return Integer.toString(heat);
             }
         } else if (col == COL_SHOTS) {
             if (null != atype) {

--- a/src/megameklab/com/util/RecordSheetEquipmentLine.java
+++ b/src/megameklab/com/util/RecordSheetEquipmentLine.java
@@ -92,7 +92,7 @@ public class RecordSheetEquipmentLine {
     
     public String getHeatField(int row) {
         if (row == 0) {
-            if (eqInfo.isWeapon) {
+            if (eqInfo.heat > 0) {
                 return Integer.toString(eqInfo.heat);
             } else {
                 return DASH;


### PR DESCRIPTION
Requires MegaMek/megamek#1390.

1. Adds heat values for non-weapon equipment to the master equipment table.
2. Includes non-weapon equipment in the heat calculation in the status bar.
3. Adds heat value for non-weapon equipment to the equipment table on the record sheet.

Fixes #311

Best viewed with whitespace changes hidden.