### PR TITLE
Adjust heat sink count when required by engine change.

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -801,8 +801,14 @@ public class StructureTab extends ITab implements MekBuildListener {
                     .getBaseChassisHeatSinks(getMech().hasCompactHeatSinks()));
             getMech().setEngine(engine);
             resetSystemCrits();
+            // If the new engine has more weight-free heat sinks than are currently installed, add the extras.
+            int newHS = engine.getWeightFreeEngineHeatSinks() - getMech().heatSinks();
+            if (newHS > 0) {
+                UnitUtil.addHeatSinkMounts(getMech(), newHS, panHeat.getHeatSinkType());
+            }
             UnitUtil.updateAutoSinks(getMech(), getMech().hasCompactHeatSinks());
             panMovement.setFromEntity(getMech());
+            panHeat.setFromMech(getMech());
             refreshSummary();
             refresh.refreshPreview();
             refresh.refreshStatus();


### PR DESCRIPTION
When the number of weight-free heat sinks increases due to an engine change, add the additional heat sinks to the mech. This only affects mechs because aerospace fighters are all required to have fusion engines and the weight-free value doesn't change.

The reported bug stems from the value in the spinner being below the minimum.

Fixes #319: Cannot add heat sinks after changing engine type