### PR TITLE
Refresh transport tab after tonnage or type change.

### DIFF
--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
@@ -224,6 +224,7 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
         panChassis.setAsCustomization();
     }
 
+    @Override
     public void refreshSummary() {
         panSummary.refresh();
         // We're going to cheat and recalculate minimum crew values here in case the number of gunners changed.
@@ -401,6 +402,7 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
         panCrew.setFromEntity(getJumpship());
         getJumpship().autoSetInternal();
         refresh();
+        refresh.refreshTransport();
         refresh.refreshPreview();
         refresh.refreshStatus();
     }
@@ -475,6 +477,7 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
         refresh();
         refresh.refreshEquipment();
         refresh.refreshBuild();
+        refresh.refreshTransport();
         refresh.refreshPreview();
         refresh.refreshStatus();
     }


### PR DESCRIPTION
The max number of docking hardpoints may have changed and needs to be updated.