### PR TITLE
Prevent placing heavy gauss in arm locations

### DIFF
--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -309,6 +309,9 @@ public class BuildView extends IView implements ActionListener, MouseListener {
                         { Mech.LOC_CT, Mech.LOC_RARM, Mech.LOC_RLEG };
 
                     for (int location = 0; location < 3; location++) {
+                        if (!UnitUtil.isValidLocation(getMech(), eq.getType(), splitLocations[location])) {
+                            continue;
+                        }
                         JMenu subMenu = new JMenu(String.format("%1$s/%2$s", abbrLocations[Mech.LOC_RT], abbrLocations[splitLocations[location]]));
                         int subCrits = critSpace[splitLocations[location]];
                         for (int slots = 1; slots <= subCrits; slots++) {
@@ -343,6 +346,9 @@ public class BuildView extends IView implements ActionListener, MouseListener {
                         { Mech.LOC_CT, Mech.LOC_LARM, Mech.LOC_LLEG };
 
                     for (int location = 0; location < 3; location++) {
+                        if (!UnitUtil.isValidLocation(getMech(), eq.getType(), splitLocations[location])) {
+                            continue;
+                        }
                         JMenu subMenu = new JMenu(String.format("%1$s/%2$s", abbrLocations[Mech.LOC_LT], abbrLocations[splitLocations[location]]));
                         int subCrits = critSpace[splitLocations[location]];
                         for (int slots = 1; slots <= subCrits; slots++) {
@@ -367,7 +373,9 @@ public class BuildView extends IView implements ActionListener, MouseListener {
 
             } else {
                 for (int location = 0; location < getMech().locations(); location++) {
-
+                    if (!UnitUtil.isValidLocation(getMech(), eq.getType(), location)) {
+                        continue;
+                    }
                     if ((UnitUtil.getHighestContinuousNumberOfCrits(getMech(), location) >= totalCrits)  && UnitUtil.isValidLocation(getMech(), eq.getType(), location)) {
                         item = new JMenuItem("Add to " + locations[location]);
 

--- a/src/megameklab/com/util/Mech/CriticalTransferHandler.java
+++ b/src/megameklab/com/util/Mech/CriticalTransferHandler.java
@@ -155,57 +155,63 @@ public class CriticalTransferHandler extends TransferHandler {
                     && !((eq.getType() instanceof MiscType) && eq.getType().hasFlag(MiscType.F_TARGCOMP))
                     && !(getUnit() instanceof LandAirMech)) {
                 if (location == Mech.LOC_RT) {
-                    String[] locations =
-                        { "Center Torso", "Right Leg", "Right Arm" };
-                    JComboBox<String> combo = new JComboBox<String>(locations);
-                    JOptionPane jop = new JOptionPane(combo,
-                            JOptionPane.QUESTION_MESSAGE,
-                            JOptionPane.OK_CANCEL_OPTION);
-
-                    JDialog dlg = jop.createDialog("Select secondary location.");
-                    combo.grabFocus();
-                    combo.getEditor().selectAll();
-
-                    dlg.setVisible(true);
-
-                    int value = ((Integer) jop.getValue()).intValue();
-
-                    if (value == JOptionPane.CANCEL_OPTION) {
-                        return false;
+                    // Catch torso-only equipment (e.g. heavy gauss)
+                    if (!UnitUtil.isValidLocation(getUnit(), eq.getType(), Mech.LOC_RARM)) {
+                        nextLocation = Mech.LOC_CT;
+                    } else {
+                        JComboBox<String> combo = new JComboBox<String>();
+                        JOptionPane jop = new JOptionPane(combo,
+                                JOptionPane.QUESTION_MESSAGE,
+                                JOptionPane.OK_CANCEL_OPTION);
+    
+                        JDialog dlg = jop.createDialog("Select secondary location.");
+                        combo.grabFocus();
+                        combo.getEditor().selectAll();
+    
+                        dlg.setVisible(true);
+    
+                        int value = ((Integer) jop.getValue()).intValue();
+    
+                        if (value == JOptionPane.CANCEL_OPTION) {
+                            return false;
+                        }
+    
+                        if (combo.getSelectedIndex() == 1) {
+                            nextLocation = Mech.LOC_RLEG;
+                        } else if (combo.getSelectedIndex() == 2) {
+                            nextLocation = Mech.LOC_RARM;
+                        }
                     }
-
-                    if (combo.getSelectedIndex() == 1) {
-                        nextLocation = Mech.LOC_RLEG;
-                    } else if (combo.getSelectedIndex() == 2) {
-                        nextLocation = Mech.LOC_RARM;
-                    }
-
                 } else if (location == Mech.LOC_LT) {
-                    String[] locations =
-                        { "Center Torso", "Left Leg", "Left Arm" };
-                    JComboBox<String> combo = new JComboBox<String>(locations);
-                    JOptionPane jop = new JOptionPane(combo,
-                            JOptionPane.QUESTION_MESSAGE,
-                            JOptionPane.OK_CANCEL_OPTION);
-
-                    JDialog dlg = jop.createDialog("Select secondary location.");
-                    combo.grabFocus();
-                    combo.getEditor().selectAll();
-
-                    dlg.setVisible(true);
-
-                    int value = ((Integer) jop.getValue()).intValue();
-
-                    if (value == JOptionPane.CANCEL_OPTION) {
-                        return false;
+                    // Catch torso-only equipment (e.g. heavy gauss)
+                    if (!UnitUtil.isValidLocation(getUnit(), eq.getType(), Mech.LOC_LARM)) {
+                        nextLocation = Mech.LOC_CT;
+                    } else {
+                        String[] locations =
+                            { "Center Torso", "Left Leg", "Left Arm" };
+                        JComboBox<String> combo = new JComboBox<String>(locations);
+                        JOptionPane jop = new JOptionPane(combo,
+                                JOptionPane.QUESTION_MESSAGE,
+                                JOptionPane.OK_CANCEL_OPTION);
+    
+                        JDialog dlg = jop.createDialog("Select secondary location.");
+                        combo.grabFocus();
+                        combo.getEditor().selectAll();
+    
+                        dlg.setVisible(true);
+    
+                        int value = ((Integer) jop.getValue()).intValue();
+    
+                        if (value == JOptionPane.CANCEL_OPTION) {
+                            return false;
+                        }
+    
+                        if (combo.getSelectedIndex() == 1) {
+                            nextLocation = Mech.LOC_LLEG;
+                        } else if (combo.getSelectedIndex() == 2) {
+                            nextLocation = Mech.LOC_LARM;
+                        }
                     }
-
-                    if (combo.getSelectedIndex() == 1) {
-                        nextLocation = Mech.LOC_LLEG;
-                    } else if (combo.getSelectedIndex() == 2) {
-                        nextLocation = Mech.LOC_LARM;
-                    }
-
                 } else if (location == Mech.LOC_CT) {
                     String[] locations =
                         { "Left Torso", "Right Torso" };

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -67,6 +67,7 @@ import megamek.common.Mounted;
 import megamek.common.Protomech;
 import megamek.common.QuadMech;
 import megamek.common.SmallCraft;
+import megamek.common.SuperHeavyTank;
 import megamek.common.Tank;
 import megamek.common.TechConstants;
 import megamek.common.TripodMech;
@@ -3614,6 +3615,19 @@ public class UnitUtil {
                                 && (location != Mech.LOC_RT) && (location != Mech.LOC_LT))) {
                     return false;
                 }
+            }
+            if ((((WeaponType) eq).getAmmoType() == AmmoType.T_GAUSS_HEAVY)
+                    || ((WeaponType) eq).getAmmoType() == AmmoType.T_IGAUSS_HEAVY) {
+                if (unit instanceof Mech) {
+                    return unit.isSuperHeavy() || ((Mech) unit).locationIsTorso(location);
+                } else if (unit instanceof SuperHeavyTank) {
+                    return location == SuperHeavyTank.LOC_FRONT || location == SuperHeavyTank.LOC_REAR;
+                } else if (unit instanceof Tank) {
+                    return location == Tank.LOC_FRONT || location == Tank.LOC_REAR;
+                } else if (unit.isFighter()) {
+                    return location == Aero.LOC_NOSE || location == Aero.LOC_AFT;
+                }
+                return true;
             }
             if (unit instanceof Tank) {
             	if (location == Tank.LOC_BODY) {


### PR DESCRIPTION
Heavy Gauss and Improved Heavy Gauss rifles can only be mounted in torso locations on 'Mechs (unless superheavy), front/rear on vehicles, and nose/aft on fighters. I've added these checks to UnitUtil#isValidLocation and added calls to check location validity when placing equipment both via popup menu and via drag and drop.

Fix for #324 