### PR TITLE
Maintain base chassis heat sink count when tonnage changes.

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -683,7 +683,10 @@ public class StructureTab extends ITab implements MekBuildListener {
         }
         getMech().setWeight(tonnage);
         // Force recalculation of walk MP. Set from chassis panel in case superheavy flag changed
-        getMech().setEngine(panChassis.getEngine());
+        final Engine engine = panChassis.getEngine();
+        engine.setBaseChassisHeatSinks(getMech().getEngine()
+                .getBaseChassisHeatSinks(getMech().hasCompactHeatSinks()));
+        getMech().setEngine(engine);
         getMech().autoSetInternal();
         if (getMech().isSuperHeavy()) {
             getMech().setOriginalJumpMP(0);


### PR DESCRIPTION
The number of heat sinks in an omni's base chassis that don't have to be assigned critical slots is stored in the engine. This has to be tracked because pod-mounted heat sinks always have to be assigned critical slots, even if the engine rating is large enough they wouldn't have to in a non-omni.

When the engine changes due to engine type change (e.g. standard -> XL) or change in MP, the base chassis heat sink value is copied over. This has not been happening when the tonnage changes.

Fixes #325