### PR TITLE
Native dialogs

### DIFF
--- a/resources/megameklab/resources/Menu.properties
+++ b/resources/megameklab/resources/Menu.properties
@@ -1,0 +1,90 @@
+menu.file=File
+menu.file.resetCurrentUnit=Reset Current Unit
+menu.file.switchUnitType=Switch Unit Type
+menu.file.unitType.mech=Mech
+menu.file.unitType.fighter=Aero/Conv Fighter
+menu.file.unitType.dropshipSmallCraft=Dropship/Small Craft
+menu.file.unitType.advancedAero=Jumpship/Warship/Space Station
+menu.file.unitType.combatVehicle=Combat Vehicle
+menu.file.unitType.battleArmor=BattleArmor
+menu.file.unitType.infantry=Infantry
+menu.file.unitType.protomech=Protomech
+menu.file.unitType.primitive=Primitive/Retro
+menu.file.unitType.aero=Aero
+menu.file.unitType.jumpship=Jumpship
+menu.file.load=Load
+menu.file.load.fromCache=From Cache...
+menu.file.load.fromFile=From File...
+menu.file.print.currentUnit=Current Unit
+menu.file.save=Save
+menu.file.saveAs=Save As...
+menu.file.export=Export
+menu.file.export.toHTML=to HTML
+menu.file.export.toText=to Text
+menu.file.export.toClipboard=to Clipboard (text)
+menu.file.configuration=Configuration...
+menu.file.themes=Themes
+menu.file.exit=Exit
+
+menu.validate=Unit Validation
+menu.validate.currentUnit=Validate Current Unit
+menu.validate.fromFile=Validate Unit From File
+menu.validate.fromCache=Validate Unit From Cache
+menu.validate.bv=BV Calculations
+menu.validate.bv.currentUnit=Current Unit BV Calculations
+menu.validate.bv.fromFile=BV Calculations From File
+menu.validate.bv.fromCache=BV Calculations From Cache
+menu.validate.cost=Unit Cost Breakdown
+menu.validate.cost.currentUnit=Breakdown Current Unit
+menu.validate.cost.fromFile=Unit Breakdown From File
+menu.validate.cost.fromCache=Unit Breakdown From Cache
+menu.validate.weight=Unit Weight Breakdown
+menu.validate.weight.currentUnit=Breakdown Current Unit
+menu.validate.weight.fromFile=Unit Breakdown From File
+menu.validate.weight.fromCache=Unit Breakdown From Cache
+menu.validate.specs=Unit Specs
+menu.validate.specs.currentUnit=Current Unit Specs
+menu.validate.specs.fromFile=Unit Specs From File
+menu.validate.specs.fromCache=Unit Specs From Cache
+
+menu.help=Help
+menu.help.about=About...
+menu.help.recordSheetImages=Record Sheet Images...
+menu.help.insertImage=Insert Image...
+
+menu.help.about.title=MegaMekLab Info
+menu.help.about.version.format=MegaMekLab Version: %s
+menu.help.about.license.1=MegaMekLab software is under GPL. See
+menu.help.about.license.2=license.txt in ./Docs/licenses for details.
+menu.help.about.info.1=Project Info:
+menu.help.about.info.2=https://github.com/MegaMek/megameklab
+
+menu.help.imageHelp.title=Image Help
+menu.help.imageHelp.text=To add a fluff image to a record sheet the following steps need to be taken\n\
+Please Note that currently only 'Mechs use fluff Images\n\
+Place the image you want to use in the data/images/fluff folder\n\
+MegaMekLab will attempt to match the name of the 'Mech your are printing\n\
+with the images in the fluff folder.\n\
+The following is an example of how MegaMekLab look for the image\n\
+Example\n\
+Your 'Mech is called Archer ARC-7Q\n\
+MegaMekLab would look for the following\n\
+\n\
+Archer ARC-7Q.jpg/png/gif\n\
+ARC-7Q.jpg/png/gif\n\
+Archer.jpg/png/gif\n\
+hud.png
+
+dialog.chooseUnit.title=Choose Unit
+dialog.loadUnit.title=Load Unit
+dialog.imagePath.title=Image Path
+dialog.saveAs.title=Save As
+dialog.saveAs.message.format=%s %s saved to %s
+dialog.filter.unitFiles=Unit Files (*.mtf; *.blk; *.hmp)
+
+message.invalidUnit.format=Warning: Invalid unit, it might load incorrectly!\n%1$s
+message.invalidUnit.text=Warning: Invalid unit, it might load incorrectly!
+message.savingInvalidUnit.text=Warning: Saving an invalid unit, it might load incorrectly!
+message.exportingInvalidUnit.text=Warning: Exporting an invalid unit!
+message.abortUnitLoad.text=Warning: Could not create new UI, aborting unit load!\
+Probable cause: Unsupported unit type.

--- a/src/megameklab/com/util/MenuBarCreator.java
+++ b/src/megameklab/com/util/MenuBarCreator.java
@@ -1290,7 +1290,10 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private final FilenameFilter unitFilesFilter =
-            (dir, filename) -> filename.endsWith(".mtf")
-                    || filename.endsWith(".blk")
-                    || filename.endsWith(".hmp");
+            (dir, filename) -> {
+                String fn = filename.toLowerCase();
+                return fn.endsWith(".mtf")
+                        || fn.endsWith(".blk")
+                        || fn.endsWith(".hmp");
+            };
 }

--- a/src/megameklab/com/util/MenuBarCreator.java
+++ b/src/megameklab/com/util/MenuBarCreator.java
@@ -28,6 +28,7 @@ import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.util.ResourceBundle;
 
 import javax.swing.BoxLayout;
 import javax.swing.JCheckBoxMenuItem;
@@ -45,24 +46,12 @@ import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
-import megamek.MegaMek;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.UnitSelectorDialog;
-import megamek.common.Aero;
-import megamek.common.BattleArmor;
-import megamek.common.Entity;
-import megamek.common.FixedWingSupport;
-import megamek.common.GunEmplacement;
-import megamek.common.Infantry;
-import megamek.common.Jumpship;
-import megamek.common.Mech;
-import megamek.common.MechFileParser;
-import megamek.common.MechView;
-import megamek.common.Protomech;
-import megamek.common.SmallCraft;
-import megamek.common.Tank;
+import megamek.common.*;
 import megamek.common.loaders.BLKFile;
 import megamek.common.templates.TROView;
+import megamek.common.util.EncodeControl;
 import megameklab.com.MegaMekLab;
 import megameklab.com.ui.MegaMekLabMainUI;
 
@@ -72,6 +61,8 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     private final JMenu themeMenu;
     private final MegaMekLabMainUI parentFrame;
 
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Menu", new EncodeControl());
+
     public MenuBarCreator(MegaMekLabMainUI parent) {
 
         parentFrame = parent;
@@ -80,25 +71,25 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         JMenu fileMenu = createFileMenu();
 
         JMenuItem item = new JMenuItem();
-        item.setText("About");
+        item.setText(resourceMap.getString("menu.help.about"));
         item.setMnemonic(KeyEvent.VK_A);
         item.addActionListener(e -> jMenuHelpAbout_actionPerformed());
-        JMenu help = new JMenu("Help");
+        JMenu help = new JMenu(resourceMap.getString("menu.help"));
         help.add(item);
 
         item = new JMenuItem();
-        item.setText("Record Sheet Images");
+        item.setText(resourceMap.getString("menu.help.recordSheetImages"));
         item.setMnemonic(KeyEvent.VK_R);
         item.addActionListener(e -> jMenuHelpFluff_actionPerformed());
         help.add(item);
 
         item = new JMenuItem();
-        item.setText("Insert Image To File");
+        item.setText(resourceMap.getString("menu.help.insertImage"));
         item.setMnemonic(KeyEvent.VK_I);
         item.addActionListener(e -> jMenuInsertImageFile_actionPerformed());
         help.add(item);
 
-        JMenu validate = new JMenu("Validate");
+        JMenu validate = new JMenu(resourceMap.getString("menu.validate"));
         validate.add(loadBVMenuOptions());
 
         validate.add(loadValidateMenuOptions());
@@ -116,21 +107,21 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private JMenu loadBVMenuOptions() {
-        JMenu bv = new JMenu("BV Calculations");
+        JMenu bv = new JMenu(resourceMap.getString("menu.validate.bv"));
         JMenuItem item = new JMenuItem();
-        item.setText("Current Units BV Calculations");
+        item.setText(resourceMap.getString("menu.validate.bv.currentUnit"));
         item.setMnemonic(KeyEvent.VK_B);
         item.addActionListener(e -> jMenuBVCalculations_actionPerformed());
         bv.add(item);
 
         item = new JMenuItem();
-        item.setText("BV Calculations From File");
+        item.setText(resourceMap.getString("menu.validate.bv.fromFile"));
         item.setMnemonic(KeyEvent.VK_F);
         item.addActionListener(e -> jMenuGetUnitBVFromFile_actionPerformed());
         bv.add(item);
 
         item = new JMenuItem();
-        item.setText("BV Calculations From Cache");
+        item.setText(resourceMap.getString("menu.validate.bv.fromCache"));
         item.setMnemonic(KeyEvent.VK_C);
         item.addActionListener(e -> jMenuGetUnitBVFromCache_actionPerformed());
         bv.add(item);
@@ -138,21 +129,21 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private JMenu loadValidateMenuOptions() {
-        JMenu entityValidation = new JMenu("Unit Validation");
+        JMenu entityValidation = new JMenu(resourceMap.getString("menu.validate"));
         JMenuItem item = new JMenuItem();
-        item.setText("Validate Current Unit");
+        item.setText(resourceMap.getString("menu.validate.currentUnit"));
         item.setMnemonic(KeyEvent.VK_V);
         item.addActionListener(e -> jMenuValidateUnit_actionPerformed());
         entityValidation.add(item);
 
         item = new JMenuItem();
-        item.setText("Validate Unit From File");
+        item.setText(resourceMap.getString("menu.validate.fromFile"));
         item.setMnemonic(KeyEvent.VK_F);
         item.addActionListener(e -> jMenuGetUnitValidationFromFile_actionPerformed());
         entityValidation.add(item);
 
         item = new JMenuItem();
-        item.setText("Validate Unit From Cache");
+        item.setText(resourceMap.getString("menu.validate.fromCache"));
         item.setMnemonic(KeyEvent.VK_C);
         item.addActionListener(e -> jMenuGetUnitValidationFromCache_actionPerformed());
         entityValidation.add(item);
@@ -160,21 +151,21 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private JMenu loadUnitCostBreakdownMenuOptions() {
-        JMenu entityBreakdown = new JMenu("Unit Cost Breakdown");
+        JMenu entityBreakdown = new JMenu(resourceMap.getString("menu.validate.cost"));
         JMenuItem item = new JMenuItem();
-        item.setText("Breakdown Current Unit");
+        item.setText(resourceMap.getString("menu.validate.cost.currentUnit"));
         item.setMnemonic(KeyEvent.VK_V);
         item.addActionListener(e -> jMenuUnitCostBreakdown_actionPerformed());
         entityBreakdown.add(item);
 
         item = new JMenuItem();
-        item.setText("Unit Breakdown From File");
+        item.setText(resourceMap.getString("menu.validate.cost.fromFile"));
         item.setMnemonic(KeyEvent.VK_F);
         item.addActionListener(e -> jMenuGetUnitBreakdownFromFile_actionPerformed());
         entityBreakdown.add(item);
 
         item = new JMenuItem();
-        item.setText("Unit Breakdown From Cache");
+        item.setText(resourceMap.getString("menu.validate.cost.fromCache"));
         item.setMnemonic(KeyEvent.VK_C);
         item.addActionListener(e -> jMenuGetUnitBreakdownFromCache_actionPerformed());
         entityBreakdown.add(item);
@@ -182,40 +173,40 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
     
     private JMenu loadUnitWeightBreakdownMenuOptions() {
-        JMenu entityBreakdown = new JMenu("Unit Weight Breakdown");
+        JMenu entityBreakdown = new JMenu(resourceMap.getString("menu.validate.weight"));
         JMenuItem item = new JMenuItem();
-        item.setText("Breakdown Current Unit");
+        item.setText(resourceMap.getString("menu.validate.weight.currentUnit"));
         item.addActionListener(e -> jMenuUnitWeightBreakdown_actionPerformed());
         entityBreakdown.add(item);
 
         item = new JMenuItem();
-        item.setText("Unit Breakdown From File");
+        item.setText(resourceMap.getString("menu.validate.weight.fromFile"));
         item.addActionListener(e -> jMenuGetUnitWeightBreakdownFromFile_actionPerformed());
         entityBreakdown.add(item);
 
         item = new JMenuItem();
-        item.setText("Unit Breakdown From Cache");
+        item.setText(resourceMap.getString("menu.validate.weight.fromCache"));
         item.addActionListener(e -> jMenuGetUnitWeightBreakdownFromCache_actionPerformed());
         entityBreakdown.add(item);
         return entityBreakdown;
     }
 
     private JMenu loadSpecsMenuOptions() {
-        JMenu unitSpecs = new JMenu("Unit Specs");
+        JMenu unitSpecs = new JMenu(resourceMap.getString("menu.validate.specs"));
         JMenuItem item = new JMenuItem();
-        item.setText("Current Unit Specs");
+        item.setText(resourceMap.getString("menu.validate.specs.currentUnit"));
         item.setMnemonic(KeyEvent.VK_V);
         item.addActionListener(e -> jMenuUnitSpecs_actionPerformed());
         unitSpecs.add(item);
 
         item = new JMenuItem();
-        item.setText("Unit Specs From File");
+        item.setText(resourceMap.getString("menu.validate.specs.fromFile"));
         item.setMnemonic(KeyEvent.VK_F);
         item.addActionListener(e -> jMenuGetUnitSpecsFromFile_actionPerformed());
         unitSpecs.add(item);
 
         item = new JMenuItem();
-        item.setText("Unit Specs From Cache");
+        item.setText(resourceMap.getString("menu.validate.specs.fromCache"));
         item.setMnemonic(KeyEvent.VK_C);
         item.addActionListener(e -> jMenuGetUnitSpecsFromCache_actionPerformed());
         unitSpecs.add(item);
@@ -223,23 +214,23 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private JMenu createFileMenu() {
-        JMenu fileMenu = new JMenu("File");
+        JMenu fileMenu = new JMenu(resourceMap.getString("menu.file"));
 
         fileMenu.setMnemonic(KeyEvent.VK_F);
-        JMenuItem item = new JMenuItem("Reset Current Unit");
+        JMenuItem item = new JMenuItem(resourceMap.getString("menu.file.resetCurrentUnit"));
         item.setMnemonic(KeyEvent.VK_R);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
         item.addActionListener(this::jMenuResetEntity_actionPerformed);
         fileMenu.add(item);
 
-        JMenu unitMenu = new JMenu("Switch Unit Type");
+        JMenu unitMenu = new JMenu(resourceMap.getString("menu.file.switchUnitType"));
         unitMenu.setMnemonic(KeyEvent.VK_S);
         Entity en = parentFrame.getEntity();
 
         if (!(en instanceof Mech)
                 || ((Mech)en).isPrimitive()) {
             item = new JMenuItem();
-            item.setText("Mech");
+            item.setText(resourceMap.getString("menu.file.unitType.mech"));
             item.setMnemonic(KeyEvent.VK_M);
             item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M,
                     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -250,7 +241,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         if (!en.isFighter()
                 || ((en instanceof Aero) && ((Aero)en).isPrimitive())) {
             item = new JMenuItem();
-            item.setText("Aero/Conv Fighter");
+            item.setText(resourceMap.getString("menu.file.unitType.fighter"));
             item.setMnemonic(KeyEvent.VK_A);
             item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A,
                     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -261,7 +252,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         if (!(en instanceof SmallCraft)
                 || ((Aero)en).isPrimitive()) {
             item = new JMenuItem();
-            item.setText("Dropship/Small Craft");
+            item.setText(resourceMap.getString("menu.file.unitType.dropshipSmallCraft"));
             item.setMnemonic(KeyEvent.VK_D);
             item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_D,
                     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -272,7 +263,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         if (!(en instanceof Jumpship)
                 || ((Aero)en).isPrimitive()) {
             item = new JMenuItem();
-            item.setText("Jumpship/Warship/Space Station");
+            item.setText(resourceMap.getString("menu.file.unitType.advancedAero"));
             item.setMnemonic(KeyEvent.VK_J);
             item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_J,
                     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -282,7 +273,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         if (!(parentFrame.getEntity() instanceof Tank)) {
             item = new JMenuItem();
-            item.setText("Combat Vehicle");
+            item.setText(resourceMap.getString("menu.file.unitType.combatVehicle"));
             item.setMnemonic(KeyEvent.VK_T);
             item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_T,
                     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -292,7 +283,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         if (!(parentFrame.getEntity() instanceof BattleArmor)) {
             item = new JMenuItem();
-            item.setText("BattleArmor");
+            item.setText(resourceMap.getString("menu.file.unitType.battleArmor"));
             item.setMnemonic(KeyEvent.VK_B);
             item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_B,
                     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -302,7 +293,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         if (!(parentFrame.getEntity() instanceof Infantry) || (parentFrame.getEntity() instanceof BattleArmor)) {
             item = new JMenuItem();
-            item.setText("Infantry");
+            item.setText(resourceMap.getString("menu.file.unitType.infantry"));
             item.setMnemonic(KeyEvent.VK_I);
             item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I,
                     Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -312,17 +303,17 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         
         if (!parentFrame.getEntity().hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
             item = new JMenuItem();
-            item.setText("Protomech");
+            item.setText(resourceMap.getString("menu.file.unitType.protomech"));
             item.setMnemonic(KeyEvent.VK_P);
             item.addActionListener(ev -> jMenuLoadProtomech());
             unitMenu.add(item);
         }
 
-        JMenu pMenu = new JMenu("Primitive/Retro");
+        JMenu pMenu = new JMenu(resourceMap.getString("menu.file.unitType.primitive"));
         if (!(en instanceof Mech)
                 || !((Mech)en).isPrimitive()) {
             item = new JMenuItem();
-            item.setText("Mech");
+            item.setText(resourceMap.getString("menu.file.unitType.mech"));
             item.addActionListener(e ->jMenuLoadPrimitiveMech());
             pMenu.add(item);
         }
@@ -330,7 +321,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         if (!(en.isFighter())
                 || (en instanceof Aero && !((Aero)en).isPrimitive())) {
             item = new JMenuItem();
-            item.setText("Aero");
+            item.setText(resourceMap.getString("menu.file.unitType.aero"));
             item.addActionListener(e ->jMenuLoadPrimitiveAero());
             pMenu.add(item);
         }
@@ -338,7 +329,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         if (!(en instanceof SmallCraft)
                 || !((Aero)en).isPrimitive()) {
             item = new JMenuItem();
-            item.setText("Dropship/Small Craft");
+            item.setText(resourceMap.getString("menu.file.unitType.dropshipSmallCraft"));
             item.addActionListener(e ->jMenuLoadPrimitiveDropship());
             pMenu.add(item);
         }
@@ -346,7 +337,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         if (!(en instanceof Jumpship)
                 || !((Aero)en).isPrimitive()) {
             item = new JMenuItem();
-            item.setText("Jumpship");
+            item.setText(resourceMap.getString("menu.file.unitType.jumpship"));
             item.addActionListener(e ->jMenuLoadPrimitiveJumpship());
             pMenu.add(item);
         }
@@ -355,11 +346,11 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         fileMenu.add(unitMenu);
 
-        JMenu loadMenu = new JMenu("Load");
+        JMenu loadMenu = new JMenu(resourceMap.getString("menu.file.load"));
         loadMenu.setMnemonic(KeyEvent.VK_L);
         item = new JMenuItem();
 
-        item.setText("From Cache");
+        item.setText(resourceMap.getString("menu.file.load.fromCache"));
         item.setMnemonic(KeyEvent.VK_C);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_U,
                 Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -367,7 +358,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         loadMenu.add(item);
 
         item = new JMenuItem();
-        item.setText("From File");
+        item.setText(resourceMap.getString("menu.file.load.fromFile"));
         item.setMnemonic(KeyEvent.VK_F);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F,
                 Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -376,7 +367,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         fileMenu.add(loadMenu);
 
-        item = new JMenuItem("Current Unit");
+        item = new JMenuItem(resourceMap.getString("menu.file.print.currentUnit"));
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P,
                 Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
         item.setMnemonic(KeyEvent.VK_C);
@@ -385,7 +376,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         fileMenu.add(UnitPrintManager.printMenu(parentFrame, item));
 
         item = new JMenuItem();
-        item.setText("Save");
+        item.setText(resourceMap.getString("menu.file.save"));
         item.setMnemonic(KeyEvent.VK_S);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S,
                 Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
@@ -393,24 +384,24 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         fileMenu.add(item);
 
         item = new JMenuItem();
-        item.setText("Save As");
+        item.setText(resourceMap.getString("menu.file.saveAs"));
         item.setMnemonic(KeyEvent.VK_A);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A,
                 Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
         item.addActionListener(this::jMenuSaveAsEntity_actionPerformed);
         fileMenu.add(item);
 
-        JMenu exportMenu = new JMenu("Export");
+        JMenu exportMenu = new JMenu(resourceMap.getString("menu.file.export"));
         
-        item = new JMenuItem("to HTML");
+        item = new JMenuItem(resourceMap.getString("menu.file.export.toHTML"));
         item.addActionListener(e -> exportSummary(true));
         exportMenu.add(item);
 
-        item = new JMenuItem("to Text");
+        item = new JMenuItem(resourceMap.getString("menu.file.export.toText"));
         item.addActionListener(e -> exportSummary(false));
         exportMenu.add(item);
 
-        item = new JMenuItem("to Clipboard (text)");
+        item = new JMenuItem(resourceMap.getString("menu.file.export.toClipboard"));
         item.addActionListener(e -> exportSummaryClipboard());
         exportMenu.add(item);
 
@@ -418,7 +409,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         
         fileMenu.add(themeMenu);
 
-        item = new JMenuItem("Configuration");
+        item = new JMenuItem(resourceMap.getString("menu.file.configuration"));
         item.setMnemonic(KeyEvent.VK_C);
         item.addActionListener(this::jMenuConfiguration_actionPerformed);
         fileMenu.add(item);
@@ -487,7 +478,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         fileMenu.addSeparator();
 
         item = new JMenuItem();
-        item.setText("Exit");
+        item.setText(resourceMap.getString("menu.file.exit"));
         item.setMnemonic(KeyEvent.VK_X);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
         item.addActionListener(ev -> parentFrame.exit());
@@ -502,7 +493,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
      * @return The new menu
      */
     private JMenu createThemeMenu() {
-        JMenu menu = new JMenu("Themes");
+        JMenu menu = new JMenu(resourceMap.getString("menu.file.themes"));
         JCheckBoxMenuItem item;
         for (LookAndFeelInfo plaf : UIManager.getInstalledLookAndFeels()) {
             item = new JCheckBoxMenuItem(plaf.getName());
@@ -604,11 +595,12 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle("Choose Unit");
+        f.setDialogTitle(resourceMap.getString("dialog.chooseUnit.title"));
         f.setDialogType(JFileChooser.OPEN_DIALOG);
         f.setMultiSelectionEnabled(false);
 
-        FileNameExtensionFilter filter = new FileNameExtensionFilter("Unit Files", "blk", "mtf", "hmp");
+        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
+                "blk", "mtf", "hmp");
 
         // Add a filter for mul files
         f.setFileFilter(filter);
@@ -626,7 +618,8 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             UnitUtil.showBVCalculations(tempEntity.getBVText(), parentFrame);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(parentFrame,
-                    String.format("Warning:Invalid unit, it might load incorrectly!\n%1$s", ex.getMessage()));
+                    String.format(resourceMap.getString("message.invalidUnit.format"),
+                            ex.getMessage()));
         }
 
     }
@@ -637,11 +630,12 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle("Choose Unit");
+        f.setDialogTitle(resourceMap.getString("dialog.chooseUnit.title"));
         f.setDialogType(JFileChooser.OPEN_DIALOG);
         f.setMultiSelectionEnabled(false);
 
-        FileNameExtensionFilter filter = new FileNameExtensionFilter("Unit Files", "blk", "mtf", "hmp");
+        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
+                "blk", "mtf", "hmp");
 
         // Add a filter for mul files
         f.setFileFilter(filter);
@@ -656,7 +650,9 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         try {
             tempEntity = new MechFileParser(unitFile).getEntity();
         } catch (Exception ex) {
-            JOptionPane.showMessageDialog(parentFrame, String.format("Warning:Invalid unit, it might load incorrectly!\n%1$s", ex.getMessage()));
+            JOptionPane.showMessageDialog(parentFrame,
+                    String.format(resourceMap.getString("message.invalidUnit.format"),
+                    ex.getMessage()));
         } finally {
             UnitUtil.showValidation(tempEntity, parentFrame);
         }
@@ -666,11 +662,12 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle("Choose Unit");
+        f.setDialogTitle(resourceMap.getString("dialog.chooseUnit.title"));
         f.setDialogType(JFileChooser.OPEN_DIALOG);
         f.setMultiSelectionEnabled(false);
 
-        FileNameExtensionFilter filter = new FileNameExtensionFilter("Unit Files", "blk", "mtf", "hmp");
+        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
+                "blk", "mtf", "hmp");
 
         // Add a filter for mul files
         f.setFileFilter(filter);
@@ -686,7 +683,9 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             Entity tempEntity = new MechFileParser(unitFile).getEntity();
             UnitUtil.showUnitCostBreakDown(tempEntity, parentFrame);
         } catch (Exception ex) {
-            JOptionPane.showMessageDialog(parentFrame, String.format("Warning:Invalid unit, it might load incorrectly!\n%1$s", ex.getMessage()));
+            JOptionPane.showMessageDialog(parentFrame,
+                    String.format(resourceMap.getString("message.invalidUnit.format"),
+                            ex.getMessage()));
         }
     }
     
@@ -696,11 +695,12 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle("Choose Unit");
+        f.setDialogTitle(resourceMap.getString("dialog.chooseUnit.title"));
         f.setDialogType(JFileChooser.OPEN_DIALOG);
         f.setMultiSelectionEnabled(false);
 
-        FileNameExtensionFilter filter = new FileNameExtensionFilter("Unit Files", "blk", "mtf", "hmp");
+        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
+                "blk", "mtf", "hmp");
 
         // Add a filter for mul files
         f.setFileFilter(filter);
@@ -715,7 +715,9 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         try {
             tempEntity = new MechFileParser(unitFile).getEntity();
         } catch (Exception ex) {
-            JOptionPane.showMessageDialog(parentFrame, String.format("Warning:Invalid unit, it might load incorrectly!\n%1$s", ex.getMessage()));
+            JOptionPane.showMessageDialog(parentFrame,
+                    String.format(resourceMap.getString("message.invalidUnit.format"),
+                            ex.getMessage()));
         } finally {
             UnitUtil.showUnitWeightBreakDown(tempEntity, parentFrame);
         }
@@ -727,11 +729,12 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle("Choose Unit");
+        f.setDialogTitle(resourceMap.getString("dialog.chooseUnit.title"));
         f.setDialogType(JFileChooser.OPEN_DIALOG);
         f.setMultiSelectionEnabled(false);
 
-        FileNameExtensionFilter filter = new FileNameExtensionFilter("Unit Files", "blk", "mtf", "hmp");
+        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
+                "blk", "mtf", "hmp");
 
         // Add a filter for mul files
         f.setFileFilter(filter);
@@ -746,7 +749,9 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         try {
             tempEntity = new MechFileParser(unitFile).getEntity();
         } catch (Exception ex) {
-            JOptionPane.showMessageDialog(parentFrame, String.format("Warning:Invalid unit, it might load incorrectly!\n%1$s", ex.getMessage()));
+            JOptionPane.showMessageDialog(parentFrame,
+                    String.format(resourceMap.getString("message.invalidUnit.format"),
+                            ex.getMessage()));
         } finally {
             UnitUtil.showUnitSpecs(tempEntity, parentFrame);
         }
@@ -757,11 +762,12 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle("Load Mech");
+        f.setDialogTitle(resourceMap.getString("dialog.loadUnit.title"));
         f.setDialogType(JFileChooser.OPEN_DIALOG);
         f.setMultiSelectionEnabled(false);
 
-        FileNameExtensionFilter filter = new FileNameExtensionFilter("Unit Files", "blk", "mtf", "hmp");
+        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles")
+                , "blk", "mtf", "hmp");
 
         // Add a filter for mul files
         f.setFileFilter(filter);
@@ -777,10 +783,12 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             Entity tempEntity = new MechFileParser(unitFile).getEntity();
 
             if (UnitUtil.validateUnit(parentFrame.getEntity()).trim().length() > 0) {
-                JOptionPane.showMessageDialog(parentFrame, "Warning:Invalid unit, it might load incorrectly!");
+                JOptionPane.showMessageDialog(parentFrame,
+                        resourceMap.getString("message.invalidUnit.text"));
             }
 
-            FileDialog fDialog = new FileDialog(parentFrame, "Image Path", FileDialog.LOAD);
+            FileDialog fDialog = new FileDialog(parentFrame,
+                    resourceMap.getString("dialog.imagePath.title"), FileDialog.LOAD);
 
             if (parentFrame.getEntity().getFluff().getMMLImagePath().trim().length() > 0) {
                 String fullPath = new File(parentFrame.getEntity().getFluff().getMMLImagePath()).getAbsolutePath();
@@ -836,22 +844,21 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     private void jMenuHelpAbout_actionPerformed() {
 
         // make the dialog
-        JDialog dlg = new JDialog(parentFrame, "MegaMekLab Info");
+        JDialog dlg = new JDialog(parentFrame, resourceMap.getString("menu.help.about.title"));
 
         // set up the contents
         JPanel child = new JPanel();
         child.setLayout(new BoxLayout(child, BoxLayout.Y_AXIS));
 
         // set the text up.
-        JLabel mekwars = new JLabel("MegaMekLab Version: " + MegaMekLab.VERSION);
-        JLabel version = new JLabel("MegaMek Version: " + MegaMek.VERSION);
-        JLabel license1 = new JLabel("MegaMekLab software is under GPL. See");
-        JLabel license2 = new JLabel("license.txt in ./Docs/licenses for details.");
-        JLabel license3 = new JLabel("Project Info:");
-        JLabel license4 = new JLabel("       https://github.com/MegaMek/megameklab       ");
+        JLabel version = new JLabel(String.format(resourceMap.getString("menu.help.about.version.format"),
+                MegaMekLab.VERSION));
+        JLabel license1 = new JLabel(resourceMap.getString("menu.help.about.license.1"));
+        JLabel license2 = new JLabel(resourceMap.getString("menu.help.about.license.2"));
+        JLabel license3 = new JLabel(resourceMap.getString("menu.help.about.info.1"));
+        JLabel license4 = new JLabel(resourceMap.getString("menu.help.about.info.2"));
 
         // center everything
-        mekwars.setAlignmentX(Component.CENTER_ALIGNMENT);
         version.setAlignmentX(Component.CENTER_ALIGNMENT);
         license1.setAlignmentX(Component.CENTER_ALIGNMENT);
         license2.setAlignmentX(Component.CENTER_ALIGNMENT);
@@ -860,7 +867,6 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         // add to child panel
         child.add(new JLabel("\n"));
-        child.add(mekwars);
         child.add(version);
         child.add(new JLabel("\n"));
         child.add(license1);
@@ -883,7 +889,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     private void jMenuHelpFluff_actionPerformed() {
 
         // make the dialog
-        JDialog dlg = new JDialog(parentFrame, "Image Help");
+        JDialog dlg = new JDialog(parentFrame, resourceMap.getString("menu.help.imageHelp.title"));
 
         // set up the contents
         JPanel child = new JPanel();
@@ -894,7 +900,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         recordSheetImageHelp.setEditable(false);
 
-        recordSheetImageHelp.setText("To add a fluff image to a record sheet the following steps need to be taken\nPlease Note that currently only \'Mechs use fluff Images\nPlace the image you want to use in the data/images/fluff folder\nMegaMekLab will attempt to match the name of the \'Mech your are printing\nwith the images in the fluff folder.\nThe following is an example of how MegaMekLab look for the image\nExample\nYour \'Mech is called Archer ARC-7Q\nMegaMekLab would look for the following\n\nArcher ARC-7Q.jpg/png/gif\nARC-7Q.jpg/png/gif\nArcher.jpg/png/gif\nhud.png\n");
+        recordSheetImageHelp.setText(resourceMap.getString("menu.help.imageHelp.text"));
         // center everything
         recordSheetImageHelp.setAlignmentX(Component.CENTER_ALIGNMENT);
 
@@ -1020,8 +1026,9 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         } else if (parentFrame.getEntity() instanceof Protomech) {
             parentFrame.createNewUnit(Entity.ETYPE_PROTOMECH);
         } else {
-            System.out.println("util.MenuBarCreatoer: " +
-                        "Received unknown entityType!");
+            MegaMekLab.getLogger().warning(getClass(),
+            "jMenuResetEntity_actionPerformed(ActionEvent)",
+                "util.MenuBarCreator: Received unknown entityType!");
         }
         setVisible(true);
         reload();
@@ -1033,7 +1040,8 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     private void jMenuSaveEntity_actionPerformed(ActionEvent event) {
 
         if (UnitUtil.validateUnit(parentFrame.getEntity()).length() > 0) {
-            JOptionPane.showMessageDialog(parentFrame, "Warning: Saving an invalid unit, it might load incorrectly!");
+            JOptionPane.showMessageDialog(parentFrame,
+                    resourceMap.getString("messages.invalidUnit.text"));
         }
 
         String unitName = parentFrame.getEntity().getChassis() + " " + parentFrame.getEntity().getModel();
@@ -1042,7 +1050,9 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         String filePathName = CConfig.getParam(CConfig.CONFIG_SAVE_FILE_1);
 
         if ((filePathName.trim().length() < 1) || !filePathName.contains(unitName)) {
-            FileDialog fDialog = new FileDialog(parentFrame, "Save As", FileDialog.SAVE);
+            FileDialog fDialog = new FileDialog(parentFrame,
+                    resourceMap.getString("dialog.saveAs.title"),
+                    FileDialog.SAVE);
 
             filePathName = CConfig.getParam(CConfig.CONFIG_SAVE_LOC);
 
@@ -1075,19 +1085,24 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             ex.printStackTrace();
         }
 
-        JOptionPane.showMessageDialog(parentFrame, parentFrame.getEntity().getChassis() + " " + parentFrame.getEntity().getModel() + " saved to " + filePathName);
+        JOptionPane.showMessageDialog(parentFrame,
+                String.format(resourceMap.getString("dialog.saveAs.message.format"),
+                        parentFrame.getEntity().getChassis(),
+                        parentFrame.getEntity().getModel(), filePathName));
 
     }
 
     private void jMenuSaveAsEntity_actionPerformed(ActionEvent event) {
 
         if (UnitUtil.validateUnit(parentFrame.getEntity()).length() > 0) {
-            JOptionPane.showMessageDialog(parentFrame, "Warning: Saving an invalid unit, it might load incorrectly!");
+            JOptionPane.showMessageDialog(parentFrame,
+                    resourceMap.getString("message.savingInvalidUnit.text"));
         }
 
         UnitUtil.compactCriticals(parentFrame.getEntity());
 
-        FileDialog fDialog = new FileDialog(parentFrame, "Save As", FileDialog.SAVE);
+        FileDialog fDialog = new FileDialog(parentFrame,
+                resourceMap.getString("dialog.saveAs.title"), FileDialog.SAVE);
 
         String filePathName = CConfig.getParam(CConfig.CONFIG_SAVE_LOC);
 
@@ -1120,8 +1135,10 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             ex.printStackTrace();
         }
 
-        JOptionPane.showMessageDialog(parentFrame, parentFrame.getEntity().getChassis() + " " + parentFrame.getEntity().getModel() + " saved to " + filePathName);
-
+        JOptionPane.showMessageDialog(parentFrame,
+                String.format(resourceMap.getString("dialog.saveAs.message.format"),
+                        parentFrame.getEntity().getChassis(),
+                        parentFrame.getEntity().getModel(), filePathName));
     }
     
     private String entitySummaryText(boolean html) {
@@ -1136,12 +1153,14 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
     private void exportSummary(boolean html) {
         if (UnitUtil.validateUnit(parentFrame.getEntity()).length() > 0) {
-            JOptionPane.showMessageDialog(parentFrame, "Warning: exporting an invalid unit!");
+            JOptionPane.showMessageDialog(parentFrame,
+                    resourceMap.getString("message.exportingInvalidUnit.text"));
         }
 
         String unitName = parentFrame.getEntity().getChassis() + " " + parentFrame.getEntity().getModel();
 
-        FileDialog fDialog = new FileDialog(parentFrame, "Save As", FileDialog.SAVE);
+        FileDialog fDialog = new FileDialog(parentFrame,
+                resourceMap.getString("dialog.saveAs.title"), FileDialog.SAVE);
         String filePathName = new File(System.getProperty("user.dir")).getAbsolutePath();
         fDialog.setDirectory(filePathName);
         fDialog.setFile(unitName + (html?".html" : ".txt"));
@@ -1161,7 +1180,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             p.close();
             out.close();
         } catch (Exception ex) {
-            ex.printStackTrace();
+            MegaMekLab.getLogger().error(getClass(), "exportSummary(boolean)", ex);
         }
     }
 
@@ -1187,7 +1206,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         if (UnitUtil.validateUnit(newUnit).trim().length() > 0) {
             JOptionPane.showMessageDialog(parentFrame, String.format(
-                    "Warning:Invalid unit, it might load incorrectly!\n%1$s",
+                    resourceMap.getString("message.invalidUnit.format"),
                             UnitUtil.validateUnit(newUnit)));
         }
 
@@ -1214,9 +1233,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             }
             if (null == newUI) {
                 JOptionPane.showMessageDialog(parentFrame,
-                        "Warning: Could not create new UI, aborting unit load!"
-                        +System.lineSeparator()
-                        +"Probable cause: Unsupported unit type.");
+                        resourceMap.getString("message.abortUnitLoad.text"));
                 return;
             }
             parentFrame.dispose();
@@ -1274,11 +1291,12 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         if (!(unitFile.isFile())) {
             JFileChooser f = new JFileChooser(filePathName);
             f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-            f.setDialogTitle("Load Mech");
+            f.setDialogTitle(resourceMap.getString("dialog.loadUnit.title"));
             f.setDialogType(JFileChooser.OPEN_DIALOG);
             f.setMultiSelectionEnabled(false);
 
-            FileNameExtensionFilter filter = new FileNameExtensionFilter("Unit Files", "blk", "mtf", "hmp");
+            FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
+                    "blk", "mtf", "hmp");
 
             // Add a filter for mul files
             f.setFileFilter(filter);
@@ -1305,7 +1323,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
             if (UnitUtil.validateUnit(tempEntity).trim().length() > 0) {
                 JOptionPane.showMessageDialog(parentFrame, String.format(
-                        "Warning:Invalid unit, it might load incorrectly!\n%1$s",
+                        resourceMap.getString("message.invalidUnit.format"),
                                 UnitUtil.validateUnit(tempEntity)));
             }
 
@@ -1332,7 +1350,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
                 }
                 if (null == newUI) {
                     JOptionPane.showMessageDialog(parentFrame,
-                            "Warning: Could not create new UI, aborting unit load!");
+                            resourceMap.getString("message.abortUnitLoad.text"));
                     return;
                 }
                 parentFrame.dispose();
@@ -1349,7 +1367,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             CConfig.updateSaveFiles(unitFile.getAbsolutePath());
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(parentFrame, String.format(
-                    "Warning:Invalid unit, it might load incorrectly!\n%1$s",
+                    resourceMap.getString("message.invalidUnit.format"),
                     ex.getMessage()));
         }
         reload();

--- a/src/megameklab/com/util/MenuBarCreator.java
+++ b/src/megameklab/com/util/MenuBarCreator.java
@@ -27,13 +27,13 @@ import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FilenameFilter;
 import java.io.PrintStream;
 import java.util.ResourceBundle;
 
 import javax.swing.BoxLayout;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JDialog;
-import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
@@ -44,11 +44,11 @@ import javax.swing.JTextArea;
 import javax.swing.KeyStroke;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
-import javax.swing.filechooser.FileNameExtensionFilter;
 
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.UnitSelectorDialog;
 import megamek.common.*;
+import megamek.common.annotations.Nullable;
 import megamek.common.loaders.BLKFile;
 import megamek.common.templates.TROView;
 import megamek.common.util.EncodeControl;
@@ -591,26 +591,10 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private void jMenuGetUnitBVFromFile_actionPerformed() {
-
-        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
-        JFileChooser f = new JFileChooser(filePathName);
-        f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle(resourceMap.getString("dialog.chooseUnit.title"));
-        f.setDialogType(JFileChooser.OPEN_DIALOG);
-        f.setMultiSelectionEnabled(false);
-
-        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
-                "blk", "mtf", "hmp");
-
-        // Add a filter for mul files
-        f.setFileFilter(filter);
-
-        int returnVal = f.showOpenDialog(parentFrame);
-        if ((returnVal != JFileChooser.APPROVE_OPTION) || (f.getSelectedFile() == null)) {
-            // I want a file, y'know!
+        File unitFile = loadUnitFile();
+        if (unitFile == null) {
             return;
         }
-        File unitFile = f.getSelectedFile();
 
         try {
             Entity tempEntity = new MechFileParser(unitFile).getEntity();
@@ -625,59 +609,42 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private void jMenuGetUnitValidationFromFile_actionPerformed() {
-
-        Entity tempEntity = null;
-        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
-        JFileChooser f = new JFileChooser(filePathName);
-        f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle(resourceMap.getString("dialog.chooseUnit.title"));
-        f.setDialogType(JFileChooser.OPEN_DIALOG);
-        f.setMultiSelectionEnabled(false);
-
-        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
-                "blk", "mtf", "hmp");
-
-        // Add a filter for mul files
-        f.setFileFilter(filter);
-
-        int returnVal = f.showOpenDialog(parentFrame);
-        if ((returnVal != JFileChooser.APPROVE_OPTION) || (f.getSelectedFile() == null)) {
-            // I want a file, y'know!
-            return;
-        }
-        File unitFile = f.getSelectedFile();
+        File unitFile = loadUnitFile();
+        if (unitFile == null) return;
 
         try {
-            tempEntity = new MechFileParser(unitFile).getEntity();
+            Entity tempEntity = new MechFileParser(unitFile).getEntity();
+            UnitUtil.showValidation(tempEntity, parentFrame);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(parentFrame,
                     String.format(resourceMap.getString("message.invalidUnit.format"),
                     ex.getMessage()));
-        } finally {
-            UnitUtil.showValidation(tempEntity, parentFrame);
         }
     }
 
-    private void jMenuGetUnitBreakdownFromFile_actionPerformed() {
+    private @Nullable
+    File loadUnitFile() {
         String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
-        JFileChooser f = new JFileChooser(filePathName);
-        f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle(resourceMap.getString("dialog.chooseUnit.title"));
-        f.setDialogType(JFileChooser.OPEN_DIALOG);
-        f.setMultiSelectionEnabled(false);
+        FileDialog fDialog = new FileDialog(parentFrame,
+                resourceMap.getString("dialog.chooseUnit.title"),
+                FileDialog.LOAD);
+        fDialog.setLocationRelativeTo(parentFrame);
+        fDialog.setMultipleMode(false);
+        fDialog.setDirectory(filePathName);
+        fDialog.setFilenameFilter(unitFilesFilter);
 
-        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
-                "blk", "mtf", "hmp");
+        fDialog.setVisible(true);
+        if (fDialog.getFile() == null) {
+            return null;
+        }
+        return new File(fDialog.getDirectory(), fDialog.getFile());
+    }
 
-        // Add a filter for mul files
-        f.setFileFilter(filter);
-
-        int returnVal = f.showOpenDialog(parentFrame);
-        if ((returnVal != JFileChooser.APPROVE_OPTION) || (f.getSelectedFile() == null)) {
-            // I want a file, y'know!
+    private void jMenuGetUnitBreakdownFromFile_actionPerformed() {
+        File unitFile = loadUnitFile();
+        if (unitFile == null) {
             return;
         }
-        File unitFile = f.getSelectedFile();
 
         try {
             Entity tempEntity = new MechFileParser(unitFile).getEntity();
@@ -690,94 +657,42 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
     
     private void jMenuGetUnitWeightBreakdownFromFile_actionPerformed() {
-
-        Entity tempEntity = null;
-        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
-        JFileChooser f = new JFileChooser(filePathName);
-        f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle(resourceMap.getString("dialog.chooseUnit.title"));
-        f.setDialogType(JFileChooser.OPEN_DIALOG);
-        f.setMultiSelectionEnabled(false);
-
-        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
-                "blk", "mtf", "hmp");
-
-        // Add a filter for mul files
-        f.setFileFilter(filter);
-
-        int returnVal = f.showOpenDialog(parentFrame);
-        if ((returnVal != JFileChooser.APPROVE_OPTION) || (f.getSelectedFile() == null)) {
-            // I want a file, y'know!
+        File unitFile = loadUnitFile();
+        if (unitFile == null) {
             return;
         }
-        File unitFile = f.getSelectedFile();
 
         try {
-            tempEntity = new MechFileParser(unitFile).getEntity();
+            Entity tempEntity = new MechFileParser(unitFile).getEntity();
+            UnitUtil.showUnitWeightBreakDown(tempEntity, parentFrame);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(parentFrame,
                     String.format(resourceMap.getString("message.invalidUnit.format"),
                             ex.getMessage()));
-        } finally {
-            UnitUtil.showUnitWeightBreakDown(tempEntity, parentFrame);
         }
     }    
 
     private void jMenuGetUnitSpecsFromFile_actionPerformed() {
-
-        Entity tempEntity = null;
-        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
-        JFileChooser f = new JFileChooser(filePathName);
-        f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle(resourceMap.getString("dialog.chooseUnit.title"));
-        f.setDialogType(JFileChooser.OPEN_DIALOG);
-        f.setMultiSelectionEnabled(false);
-
-        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
-                "blk", "mtf", "hmp");
-
-        // Add a filter for mul files
-        f.setFileFilter(filter);
-
-        int returnVal = f.showOpenDialog(parentFrame);
-        if ((returnVal != JFileChooser.APPROVE_OPTION) || (f.getSelectedFile() == null)) {
-            // I want a file, y'know!
+        File unitFile = loadUnitFile();
+        if (unitFile == null) {
             return;
         }
-        File unitFile = f.getSelectedFile();
 
         try {
-            tempEntity = new MechFileParser(unitFile).getEntity();
+            Entity tempEntity = new MechFileParser(unitFile).getEntity();
+            UnitUtil.showUnitSpecs(tempEntity, parentFrame);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(parentFrame,
                     String.format(resourceMap.getString("message.invalidUnit.format"),
                             ex.getMessage()));
-        } finally {
-            UnitUtil.showUnitSpecs(tempEntity, parentFrame);
         }
     }
 
     private void jMenuInsertImageFile_actionPerformed() {
-        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
-
-        JFileChooser f = new JFileChooser(filePathName);
-        f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-        f.setDialogTitle(resourceMap.getString("dialog.loadUnit.title"));
-        f.setDialogType(JFileChooser.OPEN_DIALOG);
-        f.setMultiSelectionEnabled(false);
-
-        FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles")
-                , "blk", "mtf", "hmp");
-
-        // Add a filter for mul files
-        f.setFileFilter(filter);
-
-        int returnVal = f.showOpenDialog(parentFrame);
-        if ((returnVal != JFileChooser.APPROVE_OPTION) || (f.getSelectedFile() == null)) {
-            // I want a file, y'know!
+        File unitFile = loadUnitFile();
+        if (unitFile == null) {
             return;
         }
-        File unitFile = f.getSelectedFile();
 
         try {
             Entity tempEntity = new MechFileParser(unitFile).getEntity();
@@ -1267,7 +1182,6 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private void loadUnitFromFile(int fileNumber) {
-
         String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
 
         if (fileNumber > 0) {
@@ -1289,24 +1203,11 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         File unitFile = new File(filePathName);
         if (!(unitFile.isFile())) {
-            JFileChooser f = new JFileChooser(filePathName);
-            f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
-            f.setDialogTitle(resourceMap.getString("dialog.loadUnit.title"));
-            f.setDialogType(JFileChooser.OPEN_DIALOG);
-            f.setMultiSelectionEnabled(false);
-
-            FileNameExtensionFilter filter = new FileNameExtensionFilter(resourceMap.getString("dialog.filter.unitFiles"),
-                    "blk", "mtf", "hmp");
-
-            // Add a filter for mul files
-            f.setFileFilter(filter);
-
-            int returnVal = f.showOpenDialog(parentFrame);
-            if ((returnVal != JFileChooser.APPROVE_OPTION) || (f.getSelectedFile() == null)) {
+            unitFile = loadUnitFile();
+            if (unitFile == null) {
                 // I want a file, y'know!
                 return;
             }
-            unitFile = f.getSelectedFile();
         }
 
         loadUnitFromFile(unitFile);
@@ -1388,4 +1289,8 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
     }
 
+    private final FilenameFilter unitFilesFilter =
+            (dir, filename) -> filename.endsWith(".mtf")
+                    || filename.endsWith(".blk")
+                    || filename.endsWith(".hmp");
 }

--- a/src/megameklab/com/util/MenuBarCreator.java
+++ b/src/megameklab/com/util/MenuBarCreator.java
@@ -1,5 +1,5 @@
 /*
- * MegaMekLab - Copyright (C) 2011
+ * MegaMekLab - Copyright (C) 2011-2019 The MegaMek Team
  *
  * Original author - jtighe (torren@users.sourceforge.net)
  *
@@ -68,26 +68,22 @@ import megameklab.com.ui.MegaMekLabMainUI;
 
 public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -3998342610654551481L;
-    private JMenu file = new JMenu("File");
-    private JMenu help = new JMenu("Help");
-    private JMenu validate = new JMenu("Validate");
-    private JMenu themeMenu = new JMenu("Themes");
-    private MegaMekLabMainUI parentFrame = null;
+    private final JMenu themeMenu;
+    private final MegaMekLabMainUI parentFrame;
 
     public MenuBarCreator(MegaMekLabMainUI parent) {
 
         parentFrame = parent;
 
-        loadFileMenuOptions();
+        themeMenu = createThemeMenu();
+        JMenu fileMenu = createFileMenu();
 
         JMenuItem item = new JMenuItem();
         item.setText("About");
         item.setMnemonic(KeyEvent.VK_A);
         item.addActionListener(e -> jMenuHelpAbout_actionPerformed());
+        JMenu help = new JMenu("Help");
         help.add(item);
 
         item = new JMenuItem();
@@ -102,6 +98,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         item.addActionListener(e -> jMenuInsertImageFile_actionPerformed());
         help.add(item);
 
+        JMenu validate = new JMenu("Validate");
         validate.add(loadBVMenuOptions());
 
         validate.add(loadValidateMenuOptions());
@@ -112,7 +109,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         
         validate.add(loadUnitWeightBreakdownMenuOptions());
 
-        this.add(file);
+        this.add(fileMenu);
         this.add(validate);
         this.add(help);
 
@@ -225,18 +222,15 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         return unitSpecs;
     }
 
-    private void loadFileMenuOptions() {
+    private JMenu createFileMenu() {
+        JMenu fileMenu = new JMenu("File");
 
-        file.removeAll();
-
-        file.setMnemonic(KeyEvent.VK_F);
-        JMenuItem item = new JMenuItem();
-
-        item = new JMenuItem("Reset Current Unit");
+        fileMenu.setMnemonic(KeyEvent.VK_F);
+        JMenuItem item = new JMenuItem("Reset Current Unit");
         item.setMnemonic(KeyEvent.VK_R);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-        item.addActionListener(e -> jMenuResetEntity_actionPerformed(e));
-        file.add(item);
+        item.addActionListener(this::jMenuResetEntity_actionPerformed);
+        fileMenu.add(item);
 
         JMenu unitMenu = new JMenu("Switch Unit Type");
         unitMenu.setMnemonic(KeyEvent.VK_S);
@@ -253,8 +247,8 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             unitMenu.add(item);
         }
 
-        if (!(en.isFighter()
-                || (en.isFighter() && ((Aero)en).isPrimitive()))) {
+        if (!en.isFighter()
+                || ((en instanceof Aero) && ((Aero)en).isPrimitive())) {
             item = new JMenuItem();
             item.setText("Aero/Conv Fighter");
             item.setMnemonic(KeyEvent.VK_A);
@@ -334,14 +328,14 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         }
         
         if (!(en.isFighter())
-                || !((Aero)en).isPrimitive()) {
+                || (en instanceof Aero && !((Aero)en).isPrimitive())) {
             item = new JMenuItem();
             item.setText("Aero");
             item.addActionListener(e ->jMenuLoadPrimitiveAero());
             pMenu.add(item);
         }
         
-        if (!(en.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT))
+        if (!(en instanceof SmallCraft)
                 || !((Aero)en).isPrimitive()) {
             item = new JMenuItem();
             item.setText("Dropship/Small Craft");
@@ -349,7 +343,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             pMenu.add(item);
         }
         
-        if (!(en.hasETypeFlag(Entity.ETYPE_JUMPSHIP))
+        if (!(en instanceof Jumpship)
                 || !((Aero)en).isPrimitive()) {
             item = new JMenuItem();
             item.setText("Jumpship");
@@ -359,7 +353,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         
         unitMenu.add(pMenu);
 
-        file.add(unitMenu);
+        fileMenu.add(unitMenu);
 
         JMenu loadMenu = new JMenu("Load");
         loadMenu.setMnemonic(KeyEvent.VK_L);
@@ -369,7 +363,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         item.setMnemonic(KeyEvent.VK_C);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_U,
                 Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-        item.addActionListener(e -> jMenuLoadEntity_actionPerformed(e));
+        item.addActionListener(this::jMenuLoadEntity_actionPerformed);
         loadMenu.add(item);
 
         item = new JMenuItem();
@@ -377,34 +371,34 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         item.setMnemonic(KeyEvent.VK_F);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F,
                 Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-        item.addActionListener(e -> jMenuLoadEntityFromFile_actionPerformed(e));
+        item.addActionListener(this::jMenuLoadEntityFromFile_actionPerformed);
         loadMenu.add(item);
 
-        file.add(loadMenu);
+        fileMenu.add(loadMenu);
 
-        item = new JMenuItem(String.format("Current Unit"));
+        item = new JMenuItem("Current Unit");
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P,
                 Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
         item.setMnemonic(KeyEvent.VK_C);
         item.addActionListener(e -> jMenuPrintCurrentUnit());
 
-        file.add(UnitPrintManager.printMenu(parentFrame, item));
+        fileMenu.add(UnitPrintManager.printMenu(parentFrame, item));
 
         item = new JMenuItem();
         item.setText("Save");
         item.setMnemonic(KeyEvent.VK_S);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S,
                 Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-        item.addActionListener(e -> jMenuSaveEntity_actionPerformed(e));
-        file.add(item);
+        item.addActionListener(this::jMenuSaveEntity_actionPerformed);
+        fileMenu.add(item);
 
         item = new JMenuItem();
         item.setText("Save As");
         item.setMnemonic(KeyEvent.VK_A);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_A,
                 Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
-        item.addActionListener(e -> jMenuSaveAsEntity_actionPerformed(e));
-        file.add(item);
+        item.addActionListener(this::jMenuSaveAsEntity_actionPerformed);
+        fileMenu.add(item);
 
         JMenu exportMenu = new JMenu("Export");
         
@@ -420,19 +414,18 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         item.addActionListener(e -> exportSummaryClipboard());
         exportMenu.add(item);
 
-        file.add(exportMenu);
+        fileMenu.add(exportMenu);
         
-        JMenu themeMenu = createThemeMenu();
-        file.add(themeMenu);
+        fileMenu.add(themeMenu);
 
         item = new JMenuItem("Configuration");
         item.setMnemonic(KeyEvent.VK_C);
-        item.addActionListener(e -> jMenuConfiguration_actionPerformed(e));
-        file.add(item);
+        item.addActionListener(this::jMenuConfiguration_actionPerformed);
+        fileMenu.add(item);
 
         int fileNumber = 1;
         if (CConfig.getParam(CConfig.CONFIG_SAVE_FILE_1).length() > 1) {
-            file.addSeparator();
+            fileMenu.addSeparator();
             item = new JMenuItem();
             String newFile = CConfig.getParam(CConfig.CONFIG_SAVE_FILE_1);
             if (newFile.length() > 35) {
@@ -443,7 +436,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             item.setMnemonic(fileNumber);
             item.addActionListener(e -> jMenuLoadEntityFromFile_actionPerformed(1));
 
-            file.add(item);
+            fileMenu.add(item);
             fileNumber++;
         }
 
@@ -458,7 +451,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             item.setMnemonic(fileNumber);
             item.addActionListener(e -> jMenuLoadEntityFromFile_actionPerformed(2));
 
-            file.add(item);
+            fileMenu.add(item);
             fileNumber++;
         }
 
@@ -473,7 +466,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             item.setMnemonic(fileNumber);
             item.addActionListener(e -> jMenuLoadEntityFromFile_actionPerformed(3));
 
-            file.add(item);
+            fileMenu.add(item);
             fileNumber++;
         }
 
@@ -488,19 +481,19 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             item.setMnemonic(fileNumber);
             item.addActionListener(e -> jMenuLoadEntityFromFile_actionPerformed(4));
 
-            file.add(item);
-            fileNumber++;
+            fileMenu.add(item);
         }
 
-        file.addSeparator();
+        fileMenu.addSeparator();
 
         item = new JMenuItem();
         item.setText("Exit");
         item.setMnemonic(KeyEvent.VK_X);
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_X, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
         item.addActionListener(ev -> parentFrame.exit());
-        file.add(item);
+        fileMenu.add(item);
 
+        return fileMenu;
     }
     
     /**
@@ -509,7 +502,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
      * @return The new menu
      */
     private JMenu createThemeMenu() {
-        themeMenu = new JMenu("Themes");
+        JMenu menu = new JMenu("Themes");
         JCheckBoxMenuItem item;
         for (LookAndFeelInfo plaf : UIManager.getInstalledLookAndFeels()) {
             item = new JCheckBoxMenuItem(plaf.getName());
@@ -517,13 +510,13 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
                     UIManager.getLookAndFeel().getName())) {
                 item.setSelected(true);
             }
-            themeMenu.add(item);
+            menu.add(item);
             item.addActionListener(ev -> {
                 parentFrame.changeTheme(plaf);
                 refreshThemeMenu(plaf.getName());
             });
         }
-        return themeMenu;
+        return menu;
     }
     
     /**
@@ -535,7 +528,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         for (int i = 0; i < themeMenu.getItemCount(); i++) {
             final JMenuItem item = themeMenu.getItem(i);
             if (item instanceof JCheckBoxMenuItem) {
-                ((JCheckBoxMenuItem) item).setSelected(item.getText().equals(currentThemeName));
+                item.setSelected(item.getText().equals(currentThemeName));
             }
         }
     }
@@ -608,9 +601,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
     private void jMenuGetUnitBVFromFile_actionPerformed() {
 
-        Entity tempEntity = null;
-        String filePathName = System.getProperty("user.dir").toString() + "/data/mechfiles/";
-        File unitFile = new File(filePathName);
+        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
         f.setDialogTitle("Choose Unit");
@@ -627,15 +618,15 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             // I want a file, y'know!
             return;
         }
-        unitFile = f.getSelectedFile();
+        File unitFile = f.getSelectedFile();
 
         try {
-            tempEntity = new MechFileParser(unitFile).getEntity();
-        } catch (Exception ex) {
-            JOptionPane.showMessageDialog(parentFrame, String.format("Warning:Invalid unit, it might load incorrectly!\n%1$s", ex.getMessage()));
-        } finally {
+            Entity tempEntity = new MechFileParser(unitFile).getEntity();
             tempEntity.calculateBattleValue(true, true);
             UnitUtil.showBVCalculations(tempEntity.getBVText(), parentFrame);
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(parentFrame,
+                    String.format("Warning:Invalid unit, it might load incorrectly!\n%1$s", ex.getMessage()));
         }
 
     }
@@ -643,8 +634,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     private void jMenuGetUnitValidationFromFile_actionPerformed() {
 
         Entity tempEntity = null;
-        String filePathName = System.getProperty("user.dir").toString() + "/data/mechfiles/";
-        File unitFile = new File(filePathName);
+        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
         f.setDialogTitle("Choose Unit");
@@ -661,7 +651,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             // I want a file, y'know!
             return;
         }
-        unitFile = f.getSelectedFile();
+        File unitFile = f.getSelectedFile();
 
         try {
             tempEntity = new MechFileParser(unitFile).getEntity();
@@ -673,10 +663,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private void jMenuGetUnitBreakdownFromFile_actionPerformed() {
-
-        Entity tempEntity = null;
-        String filePathName = System.getProperty("user.dir").toString() + "/data/mechfiles/";
-        File unitFile = new File(filePathName);
+        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
         f.setDialogTitle("Choose Unit");
@@ -693,22 +680,20 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             // I want a file, y'know!
             return;
         }
-        unitFile = f.getSelectedFile();
+        File unitFile = f.getSelectedFile();
 
         try {
-            tempEntity = new MechFileParser(unitFile).getEntity();
+            Entity tempEntity = new MechFileParser(unitFile).getEntity();
+            UnitUtil.showUnitCostBreakDown(tempEntity, parentFrame);
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(parentFrame, String.format("Warning:Invalid unit, it might load incorrectly!\n%1$s", ex.getMessage()));
-        } finally {
-            UnitUtil.showUnitCostBreakDown(tempEntity, parentFrame);
         }
     }
     
     private void jMenuGetUnitWeightBreakdownFromFile_actionPerformed() {
 
         Entity tempEntity = null;
-        String filePathName = System.getProperty("user.dir").toString() + "/data/mechfiles/";
-        File unitFile = new File(filePathName);
+        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
         f.setDialogTitle("Choose Unit");
@@ -725,7 +710,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             // I want a file, y'know!
             return;
         }
-        unitFile = f.getSelectedFile();
+        File unitFile = f.getSelectedFile();
 
         try {
             tempEntity = new MechFileParser(unitFile).getEntity();
@@ -739,8 +724,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     private void jMenuGetUnitSpecsFromFile_actionPerformed() {
 
         Entity tempEntity = null;
-        String filePathName = System.getProperty("user.dir").toString() + "/data/mechfiles/";
-        File unitFile = new File(filePathName);
+        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
         f.setDialogTitle("Choose Unit");
@@ -757,7 +741,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             // I want a file, y'know!
             return;
         }
-        unitFile = f.getSelectedFile();
+        File unitFile = f.getSelectedFile();
 
         try {
             tempEntity = new MechFileParser(unitFile).getEntity();
@@ -769,10 +753,8 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private void jMenuInsertImageFile_actionPerformed() {
+        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
 
-        String filePathName = System.getProperty("user.dir").toString() + "/data/mechfiles/";
-
-        File unitFile = new File(filePathName);
         JFileChooser f = new JFileChooser(filePathName);
         f.setLocation(parentFrame.getLocation().x + 150, parentFrame.getLocation().y + 100);
         f.setDialogTitle("Load Mech");
@@ -789,7 +771,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             // I want a file, y'know!
             return;
         }
-        unitFile = f.getSelectedFile();
+        File unitFile = f.getSelectedFile();
 
         try {
             Entity tempEntity = new MechFileParser(unitFile).getEntity();
@@ -817,42 +799,41 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
             if (fDialog.getFile() != null) {
                 String relativeFilePath = new File(fDialog.getDirectory() + fDialog.getFile()).getAbsolutePath();
-                relativeFilePath = "." + File.separatorChar + relativeFilePath.substring(new File(System.getProperty("user.dir").toString()).getAbsolutePath().length() + 1);
+                relativeFilePath = "." + File.separatorChar + relativeFilePath.substring(new File(System.getProperty("user.dir")).getAbsolutePath().length() + 1);
                 parentFrame.getEntity().getFluff().setMMLImagePath(relativeFilePath);
                 BLKFile.encode(unitFile.getAbsolutePath(), tempEntity);
             }
         } catch (Exception ex) {
-
+            MegaMekLab.getLogger().error(getClass(), "jMenuInsertImageFile_actionPerformed()", ex);
         }
-        return;
     }
 
     // Show BV Calculations
 
-    public void jMenuBVCalculations_actionPerformed() {
+    private void jMenuBVCalculations_actionPerformed() {
         parentFrame.getEntity().calculateBattleValue(true, true);
         UnitUtil.showBVCalculations(parentFrame.getEntity().getBVText(), parentFrame);
     }
 
-    public void jMenuUnitCostBreakdown_actionPerformed() {
+    private void jMenuUnitCostBreakdown_actionPerformed() {
         UnitUtil.showUnitCostBreakDown(parentFrame.getEntity(), parentFrame);
     }
     
-    public void jMenuUnitWeightBreakdown_actionPerformed() {
+    private void jMenuUnitWeightBreakdown_actionPerformed() {
         UnitUtil.showUnitWeightBreakDown(parentFrame.getEntity(), parentFrame);
     }
 
-    public void jMenuUnitSpecs_actionPerformed() {
+    private void jMenuUnitSpecs_actionPerformed() {
         UnitUtil.showUnitSpecs(parentFrame.getEntity(), parentFrame);
     }
 
     // Show Validation data.
-    public void jMenuValidateUnit_actionPerformed() {
+    private void jMenuValidateUnit_actionPerformed() {
         UnitUtil.showValidation(parentFrame.getEntity(), parentFrame);
     }
 
     // Show data about MegaMekLab
-    public void jMenuHelpAbout_actionPerformed() {
+    private void jMenuHelpAbout_actionPerformed() {
 
         // make the dialog
         JDialog dlg = new JDialog(parentFrame, "MegaMekLab Info");
@@ -899,7 +880,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     // Show how to create fluff images for Record Sheets
-    public void jMenuHelpFluff_actionPerformed() {
+    private void jMenuHelpFluff_actionPerformed() {
 
         // make the dialog
         JDialog dlg = new JDialog(parentFrame, "Image Help");
@@ -931,7 +912,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         dlg.setVisible(true);
     }
 
-    public void jMenuConfiguration_actionPerformed(ActionEvent event) {
+    private void jMenuConfiguration_actionPerformed(ActionEvent event) {
         new ConfigurationDialog(parentFrame).setVisible(true);
         parentFrame.refreshAll();
     }
@@ -1000,19 +981,19 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         UnitPrintManager.printEntity(parentFrame.getEntity());
     }
 
-    public void jMenuLoadEntity_actionPerformed(ActionEvent event) {
+    private void jMenuLoadEntity_actionPerformed(ActionEvent event) {
         loadUnit();
     }
 
-    public void jMenuLoadEntityFromFile_actionPerformed(ActionEvent event) {
+    private void jMenuLoadEntityFromFile_actionPerformed(ActionEvent event) {
         loadUnitFromFile();
     }
 
-    public void jMenuLoadEntityFromFile_actionPerformed(int fileNumber) {
+    private void jMenuLoadEntityFromFile_actionPerformed(int fileNumber) {
         loadUnitFromFile(fileNumber);
     }
 
-    public void jMenuResetEntity_actionPerformed(ActionEvent event) {
+    private void jMenuResetEntity_actionPerformed(ActionEvent event) {
         CConfig.updateSaveFiles("Reset Unit");
         CConfig.setParam(CConfig.CONFIG_SAVE_FILE_1, "");
         Entity en = parentFrame.getEntity();
@@ -1049,7 +1030,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         parentFrame.repaint();
     }
 
-    public void jMenuSaveEntity_actionPerformed(ActionEvent event) {
+    private void jMenuSaveEntity_actionPerformed(ActionEvent event) {
 
         if (UnitUtil.validateUnit(parentFrame.getEntity()).length() > 0) {
             JOptionPane.showMessageDialog(parentFrame, "Warning: Saving an invalid unit, it might load incorrectly!");
@@ -1098,7 +1079,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
     }
 
-    public void jMenuSaveAsEntity_actionPerformed(ActionEvent event) {
+    private void jMenuSaveAsEntity_actionPerformed(ActionEvent event) {
 
         if (UnitUtil.validateUnit(parentFrame.getEntity()).length() > 0) {
             JOptionPane.showMessageDialog(parentFrame, "Warning: Saving an invalid unit, it might load incorrectly!");
@@ -1153,8 +1134,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         }
     }
 
-    public void exportSummary(boolean html) {
-
+    private void exportSummary(boolean html) {
         if (UnitUtil.validateUnit(parentFrame.getEntity()).length() > 0) {
             JOptionPane.showMessageDialog(parentFrame, "Warning: exporting an invalid unit!");
         }
@@ -1162,7 +1142,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         String unitName = parentFrame.getEntity().getChassis() + " " + parentFrame.getEntity().getModel();
 
         FileDialog fDialog = new FileDialog(parentFrame, "Save As", FileDialog.SAVE);
-        String filePathName = new File(System.getProperty("user.dir").toString()).getAbsolutePath();
+        String filePathName = new File(System.getProperty("user.dir")).getAbsolutePath();
         fDialog.setDirectory(filePathName);
         fDialog.setFile(unitName + (html?".html" : ".txt"));
         fDialog.setLocationRelativeTo(parentFrame);
@@ -1271,7 +1251,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
     private void loadUnitFromFile(int fileNumber) {
 
-        String filePathName = System.getProperty("user.dir").toString() + "/data/mechfiles/";
+        String filePathName = System.getProperty("user.dir") + "/data/mechfiles/";
 
         if (fileNumber > 0) {
             switch (fileNumber) {


### PR DESCRIPTION
Replaces use of Swing's cross-platform JFileChooser with the AWT FileDialog, which uses the OS-native dialog. This was already being used for saving and for opening fluff images.

This might best be reviewed one commit at a time. The first was a code cleanup. The next (after the upstream merge) involved tokenizing all the string literals. The third replaced the dialog.

I looked at replacing the cross-platform print dialog with a native one but that is a bit more involved and best left as a separate change.

Fixes #174