### PR TITLE
Add Small Command Console to the general cockpits

### DIFF
--- a/src/megameklab/com/ui/view/MekChassisView.java
+++ b/src/megameklab/com/ui/view/MekChassisView.java
@@ -128,8 +128,8 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
     
     private static final int[] GENERAL_COCKPITS = {
             Mech.COCKPIT_STANDARD, Mech.COCKPIT_SMALL, Mech.COCKPIT_COMMAND_CONSOLE,
-            Mech.COCKPIT_TORSO_MOUNTED, Mech.COCKPIT_DUAL, Mech.COCKPIT_INTERFACE,
-            Mech.COCKPIT_VRRP
+            Mech.COCKPIT_SMALL_COMMAND_CONSOLE, Mech.COCKPIT_TORSO_MOUNTED, 
+            Mech.COCKPIT_DUAL, Mech.COCKPIT_INTERFACE, Mech.COCKPIT_VRRP
     };
     
     private static final String[] ENHANCEMENT_NAMES = {


### PR DESCRIPTION
What I have missed on #346.

Although Small Command Console was implemented, without it mechs are not able to choose Small Command Console. The others are fine - #346 already did for Superheavy and industrial mech, but most mechs are have the consoles defined in GENERAL_COCKPITS and Small Command Console was not included.