### PR TITLE
Fix for sorting equipment table by tonnage/BV

### DIFF
--- a/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
@@ -73,6 +73,7 @@ import megamek.common.Mounted;
 import megamek.common.WeaponType;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
 import megamek.common.weapons.bayweapons.BayWeapon;
+import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.CriticalTableModel;
 import megameklab.com.util.EquipmentTableModel;
@@ -845,19 +846,21 @@ public class EquipmentTab extends ITab implements ActionListener {
         public int compare(String s0, String s1) {
             //lets find the weight class integer for each name
             DecimalFormat format = new DecimalFormat();
-            int l0 = 0;
+            double l0 = 0.0;
             try {
-                l0 = format.parse(s0).intValue();
+                l0 = format.parse(s0).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
+                        "Parse error comparing " + s0 + " and " + s1, e);
             }
-            int l1 = 0;
+            double l1 = 0.0;
             try {
-                l1 = format.parse(s1).intValue();
+                l1 = format.parse(s1).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
+                        "Parse error comparing " + s0 + " and " + s1, e);
             }
-            return ((Comparable<Integer>)l0).compareTo(l1);
+            return Double.compare(l0, l1);
         }
     }
     

--- a/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
@@ -67,6 +67,7 @@ import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.WeaponType;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
+import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.CriticalTableModel;
 import megameklab.com.util.EquipmentTableModel;
@@ -823,24 +824,26 @@ public class EquipmentTab extends ITab implements ActionListener {
      *
      */
     public class FormattedNumberSorter implements Comparator<String> {
-        DecimalFormat format = new DecimalFormat();
 
         @Override
         public int compare(String s0, String s1) {
             //lets find the weight class integer for each name
-            int l0 = 0;
+            DecimalFormat format = new DecimalFormat();
+            double l0 = 0.0;
             try {
-                l0 = format.parse(s0).intValue();
+                l0 = format.parse(s0).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
+                        "Parse error comparing " + s0 + " and " + s1, e);
             }
-            int l1 = 0;
+            double l1 = 0.0;
             try {
-                l1 = format.parse(s1).intValue();
+                l1 = format.parse(s1).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
+                        "Parse error comparing " + s0 + " and " + s1, e);
             }
-            return ((Comparable<Integer>)l0).compareTo(l1);
+            return Double.compare(l0, l1);
         }
     }
     

--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -69,6 +69,7 @@ import megamek.common.Mounted;
 import megamek.common.QuadVee;
 import megamek.common.WeaponType;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
+import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.CriticalTableModel;
 import megameklab.com.util.EquipmentTableModel;
@@ -803,19 +804,21 @@ public class EquipmentTab extends ITab implements ActionListener {
         public int compare(String s0, String s1) {
             //lets find the weight class integer for each name
             DecimalFormat format = new DecimalFormat();
-            int l0 = 0;
+            double l0 = 0.0;
             try {
-                l0 = format.parse(s0).intValue();
+                l0 = format.parse(s0).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
+                        "Parse error comparing " + s0 + " and " + s1, e);
             }
-            int l1 = 0;
+            double l1 = 0.0;
             try {
-                l1 = format.parse(s1).intValue();
+                l1 = format.parse(s1).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
+                        "Parse error comparing " + s0 + " and " + s1, e);
             }
-            return ((Comparable<Integer>)l0).compareTo(l1);
+            return Double.compare(l0, l1);
         }
     }
     

--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -71,6 +71,7 @@ import megamek.common.Tank;
 import megamek.common.VTOL;
 import megamek.common.WeaponType;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
+import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.CriticalTableModel;
 import megameklab.com.util.EquipmentTableModel;
@@ -808,19 +809,21 @@ public class EquipmentTab extends ITab implements ActionListener {
         public int compare(String s0, String s1) {
             //lets find the weight class integer for each name
             DecimalFormat format = new DecimalFormat();
-            int l0 = 0;
+            double l0 = 0.0;
             try {
-                l0 = format.parse(s0).intValue();
+                l0 = format.parse(s0).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
+                        "Parse error comparing " + s0 + " and " + s1, e);
             }
-            int l1 = 0;
+            double l1 = 0.0;
             try {
-                l1 = format.parse(s1).intValue();
+                l1 = format.parse(s1).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
+                        "Parse error comparing " + s0 + " and " + s1, e);
             }
-            return ((Comparable<Integer>)l0).compareTo(l1);
+            return Double.compare(l0, l1);
         }
     }
     

--- a/src/megameklab/com/ui/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/tabs/EquipmentTab.java
@@ -911,19 +911,21 @@ public class EquipmentTab extends ITab implements ActionListener {
         public int compare(String s0, String s1) {
             //lets find the weight class integer for each name
             DecimalFormat format = new DecimalFormat();
-            int l0 = 0;
+            double l0 = 0.0;
             try {
-                l0 = format.parse(s0).intValue();
+                l0 = format.parse(s0).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
+                        "Parse error comparing " + s0 + " and " + s1, e);
             }
-            int l1 = 0;
+            double l1 = 0.0;
             try {
-                l1 = format.parse(s1).intValue();
+                l1 = format.parse(s1).doubleValue();
             } catch (java.text.ParseException e) {
-                e.printStackTrace();
+                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
+                        "Parse error comparing " + s0 + " and " + s1, e);
             }
-            return ((Comparable<Integer>)l0).compareTo(l1);
+            return Double.compare(l0, l1);
         }
     }
     


### PR DESCRIPTION
Fix for #341

The comparator used for sorting equipment by weight and BV is converting the formatted Strings to int rather than floating point.

I considered factoring out the comparators that are duplicated in equipment tab views for several unit types, but that should be taken care of by eventually replacing the individual EquipmentTab classes with the EquipmentTab that's used for the past 3-4 unit types that have been implemented. It just needs to be updated to include special considerations for the remaining unit types. That's a separate issue.