### PR TITLE
Large engine crits

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -498,6 +498,7 @@ public class StructureTab extends ITab implements MekBuildListener {
                         .getBaseChassisHeatSinks(getMech().hasCompactHeatSinks()));
                 getMech().setEngine(engine);
                 UnitUtil.updateAutoSinks(getMech(), getMech().hasCompactHeatSinks());
+                resetSystemCrits();
             }
         }
         return true;

--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -221,6 +221,10 @@ public class StructureTab extends ITab implements MekBuildListener {
             case Mech.GYRO_NONE:
                 UnitUtil.compactCriticals(getMech(), Mech.LOC_CT);
                 break;
+            case Mech.GYRO_SUPERHEAVY:
+                clearCritsForGyro(2);
+                getMech().addGyro();
+                break;
             default:
                 clearCritsForGyro(4);
                 getMech().addGyro();

--- a/src/megameklab/com/ui/view/MekChassisView.java
+++ b/src/megameklab/com/ui/view/MekChassisView.java
@@ -688,9 +688,12 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
         if (null == e) {
             return null;
         }
-        // Clan and large flags are specific to the engine. the superheavy flag depends on the mech
-        // and may have changed since the last refresh.
-        int flags = e.getFlags() & (Engine.CLAN_ENGINE | Engine.LARGE_ENGINE);
+        // Clan and flag is specific to the engine. the superheavy and large flags depend on the mech
+        // and rating and may have changed since the last refresh.
+        int flags = e.getFlags() & Engine.CLAN_ENGINE;
+        if (getEngineRating() > 400) {
+            flags |= Engine.LARGE_ENGINE;
+        }
         if (isSuperheavy()) {
             flags |= Engine.SUPERHEAVY_ENGINE;
         }


### PR DESCRIPTION
Fixes #352 
Large engines (rating > 400) occupy more critical slots and may need to punt equipment that has previously been installed there. The call to resetSystemCrits was missing in the method that recalculates engine rating. There was also a bug that assumed the large engine flag was set correctly in the engine combo box, but this was not always true. Also, superheavy mechs were reserving four slots for the gryo, when then should only be requiring two double slots.