### PR TITLE
Sv misc

### DIFF
--- a/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 /**
  * Structure tab for support vehicle construction
  */
-class SVStructureTab extends ITab implements SVBuildListener {
+public class SVStructureTab extends ITab implements SVBuildListener {
 
     private RefreshListener refresh = null;
     private JPanel masterPanel;

--- a/src/megameklab/com/ui/tabs/TransportTab.java
+++ b/src/megameklab/com/ui/tabs/TransportTab.java
@@ -655,12 +655,11 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                     return bayTypeList.get(rowIndex).getPersonnel()
                             * (int)bayList.get(rowIndex).getCapacity();
                 case COL_TONNAGE:
-                    if (!bayTypeList.get(rowIndex).isCargoBay()) {
-                        return bayList.get(rowIndex).getWeight();
-                    } else if (useKilogramStandard()) {
-                        return TestEntity.round(bayList.get(rowIndex).getWeight(), TestEntity.Ceil.KILO) * 1000.0;
+                    final double weight = TestEntity.round(bayList.get(rowIndex).getWeight(), TestEntity.Ceil.KILO);
+                    if (useKilogramStandard()) {
+                        return weight * 1000.0;
                     } else {
-                        return TestEntity.ceil(bayList.get(rowIndex).getWeight(), TestEntity.Ceil.HALFTON);
+                        return weight;
                     }
                 case COL_FACING:
                     if (bayTypeList.get(rowIndex).requiresFacing()) {

--- a/src/megameklab/com/ui/view/SVChassisView.java
+++ b/src/megameklab/com/ui/view/SVChassisView.java
@@ -73,7 +73,7 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
     private final CustomComboBox<Integer> cbStructureTechRating = new CustomComboBox<>(ITechnology::getRatingName);
     private final CustomComboBox<TestSupportVehicle.SVType> cbType = new CustomComboBox<>(t -> typeNames.getOrDefault(t, "?"));
     private final TechComboBox<TestSupportVehicle.SVEngine> cbEngine = new TechComboBox<>(e -> e.engine.getEngineName()
-            .replaceAll("^\\d+ ", ""));
+            .replaceAll("^\\d+ ", "").replace("[SV]", ""));
     private final CustomComboBox<Integer> cbEngineTechRating = new CustomComboBox<>(ITechnology::getRatingName);
     private final CustomComboBox<Integer> cbTurrets = new CustomComboBox<>(i -> turretNames[i]);
     private final JCheckBox chkSponson = new JCheckBox();


### PR DESCRIPTION
A few more tweaks for support vehicle construction:
1. Strip the "[SV]" from the name in the engine combo box. We already know they're support vehicle engines (or at least we hope they are).
2. Allow units to apportion weight to cargo bays by the kilogram, even if they aren't on the kg standard. There are a number of combat and support vehicles that do this.
3. Make the SVStructureTab class public so it can be used in MekHQ's MekLabTab.