### PR TITLE
Move some initialization code earlier in the sequence.

### DIFF
--- a/src/megameklab/com/MegaMekLab.java
+++ b/src/megameklab/com/MegaMekLab.java
@@ -34,6 +34,8 @@ import javax.swing.UIManager;
 
 import megamek.MegaMek;
 import megamek.common.Configuration;
+import megamek.common.EquipmentType;
+import megamek.common.MechSummaryCache;
 import megamek.common.logging.DefaultMmLogger;
 import megamek.common.logging.LogLevel;
 import megamek.common.logging.MMLogger;
@@ -41,6 +43,7 @@ import megamek.common.preference.PreferenceManager;
 import megamek.common.util.MegaMekFile;
 import megameklab.com.ui.StartupGUI;
 import megameklab.com.util.CConfig;
+import megameklab.com.util.UnitUtil;
 
 public class MegaMekLab {
     public static final String VERSION = "0.47.1-SNAPSHOT";
@@ -126,8 +129,11 @@ public class MegaMekLab {
     }
     
     private static void startup() {
-        System.out.println("Starting MegaMekLab version: " + MegaMekLab.VERSION);
         Locale.setDefault(Locale.US);
+        EquipmentType.initializeTypes();
+        MechSummaryCache.getInstance();
+        new CConfig();
+        UnitUtil.loadFonts();
         showInfo();
         setLookAndFeel();
         //create a start up frame and display it

--- a/src/megameklab/com/MegaMekLab.java
+++ b/src/megameklab/com/MegaMekLab.java
@@ -129,12 +129,12 @@ public class MegaMekLab {
     }
     
     private static void startup() {
+        showInfo();
         Locale.setDefault(Locale.US);
         EquipmentType.initializeTypes();
         MechSummaryCache.getInstance();
         new CConfig();
         UnitUtil.loadFonts();
-        showInfo();
         setLookAndFeel();
         //create a start up frame and display it
         StartupGUI sud = new StartupGUI();

--- a/src/megameklab/com/ui/MegaMekLabMainUI.java
+++ b/src/megameklab/com/ui/MegaMekLabMainUI.java
@@ -55,11 +55,6 @@ public abstract class MegaMekLabMainUI extends JFrame implements
     protected MenuBarCreator menubarcreator;
     
     public MegaMekLabMainUI() {
-
-        EquipmentType.initializeTypes();
-        MechSummaryCache.getInstance();
-        new CConfig();
-        UnitUtil.loadFonts();
         setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
         addWindowListener(new WindowAdapter() {
             @Override


### PR DESCRIPTION
The code moved only needs to run once, when the application is first launched. Having it in MegaMekLabMainUI caused it to run every time the unit type is changed. This doesn't hurt anything, but CConfig does need to initialize before calling setLookAndFeel().