### PR TITLE
SV MekHQ compatibility

### DIFF
--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -258,7 +258,15 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
         }
         return true;
     }
-    
+
+    /**
+     * Disables controls that cannot be changed when customizing a refit.
+     */
+    public void setAsCustomization() {
+        panBasicInfo.setAsCustomization();
+        panChassis.setAsCustomization();
+    }
+
     public void refreshSummary() {
         panSummary.refresh();
     }

--- a/src/megameklab/com/ui/supportvehicle/SVArmorTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVArmorTab.java
@@ -43,7 +43,7 @@ public class SVArmorTab extends ITab implements ArmorAllocationListener {
     private final PatchworkArmorView panPatchwork;
     private final ITechManager techManager;
 
-    SVArmorTab(EntitySource eSource, ITechManager techManager) {
+    public SVArmorTab(EntitySource eSource, ITechManager techManager) {
         super(eSource);
         this.techManager = techManager;
         panArmor = new MVFArmorView(techManager, true);

--- a/src/megameklab/com/ui/supportvehicle/SVBuildTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVBuildTab.java
@@ -48,7 +48,7 @@ public class SVBuildTab extends ITab implements ActionListener {
     private String AUTOFILLCOMMAND = "autofillbuttoncommand";
     private String RESETCOMMAND = "resetbuttoncommand";
 
-    SVBuildTab(EntitySource eSource, EquipmentTab equipmentTab) {
+    public SVBuildTab(EntitySource eSource, EquipmentTab equipmentTab) {
         super(eSource);
         this.critList = equipmentTab.getEquipmentList();
         setLayout(new BoxLayout(this, BoxLayout.X_AXIS));

--- a/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
@@ -173,6 +173,14 @@ public class SVStructureTab extends ITab implements SVBuildListener {
         refresh = l;
     }
 
+    /**
+     * Disables controls that cannot be changed when customizing a refit.
+     */
+    public void setAsCustomization() {
+        panBasicInfo.setAsCustomization();
+        panChassis.setAsCustomization();
+    }
+
     @Override
     public void refreshSummary() {
         panSummary.refresh();

--- a/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
@@ -49,7 +49,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
     private ChassisModView panChassisMod;
     private SVCrewView panCrew;
 
-    SVStructureTab(EntitySource eSource) {
+    public SVStructureTab(EntitySource eSource) {
         super(eSource);
         setLayout(new BorderLayout());
         setupPanels();
@@ -142,6 +142,13 @@ public class SVStructureTab extends ITab implements SVBuildListener {
 
     public ITechManager getTechManager() {
         return panBasicInfo;
+    }
+
+    /*
+     * Used by MekHQ to set the tech faction for custom refits.
+     */
+    public void setTechFaction(int techFaction) {
+        panBasicInfo.setTechFaction(techFaction);
     }
 
     private void removeAllListeners() {

--- a/src/megameklab/com/ui/view/CVChassisView.java
+++ b/src/megameklab/com/ui/view/CVChassisView.java
@@ -254,7 +254,15 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
         spnChassisTurretWt.setEnabled(chkOmni.isSelected() && (cbTurrets.getSelectedIndex() > 0));
         spnChassisTurret2Wt.setEnabled(chkOmni.isSelected() && (cbTurrets.getSelectedIndex() > 1));
     }
-    
+
+    /**
+     * Disables controls that cannot be changed when customizing a refit.
+     */
+    public void setAsCustomization() {
+        spnTonnage.setEnabled(false);
+        cbMotiveType.setEnabled(false);
+    }
+
     public void refresh() {
         refreshTonnage();
         chkOmni.removeActionListener(this);

--- a/src/megameklab/com/ui/view/SVChassisView.java
+++ b/src/megameklab/com/ui/view/SVChassisView.java
@@ -495,6 +495,15 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         spnFireConWt.setEnabled(entity.isOmni() && (cbFireControl.getSelectedIndex() > SVBuildListener.FIRECON_NONE));
     }
 
+    /**
+     * Disables controls that cannot be changed when customizing a refit.
+     */
+    public void setAsCustomization() {
+        spnTonnage.setEnabled(false);
+        cbType.setEnabled(false);
+        cbStructureTechRating.setEnabled(false);
+    }
+
     public void refresh() {
         refreshTonnage();
         refreshTurrets();


### PR DESCRIPTION
I made some changes that allows SV customizations in the MekLab tab of MekHQ. This mostly involves changing visibility modifiers to public, but also adds a setAsCustomization() method that MekHQ uses to signal that certain options such as tonnage and motive type cannot be changed. I did this for combat vehicles as well, but other unit types have it implemented.