### PR TITLE
'Mech record sheet layout tweaks

### DIFF
--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -548,13 +548,14 @@ public class PrintMech extends PrintEntity {
         
         double rollX = viewX;
         double critX = viewX + viewWidth * 0.11;
+        double critWidth = viewX + viewWidth - critX;
         double gap = 0;
         if (mech.getNumberOfCriticals(loc) > 6) {
             gap = viewHeight * 0.05;
         }
         double lineHeight = (viewHeight - gap) / mech.getNumberOfCriticals(loc);
         double currY = viewY;
-        float fontSize = (float) lineHeight * 0.85f;
+        float fontSize = (float) Math.floor(lineHeight * 0.85f);
         
         Mounted startingMount = null;
         double startingMountY = 0;
@@ -582,7 +583,7 @@ public class PrintMech extends PrintEntity {
                             && (!crit.getMount().getType().isHittable()))) {
                 style = "standard";
                 fill = "#3f3f3f";
-                addTextElement(canvas, critX, currY, formatCritName(crit), fontSize, "start", style, fill);
+                addTextElementToFit(canvas, critX, currY, critWidth, formatCritName(crit), fontSize, "start", style, fill);
             } else if (crit.isArmored()) {
                 Element pip = createPip(critX, currY - fontSize * 0.8, fontSize * 0.4, 0.7);
                 canvas.appendChild(pip);

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -504,7 +504,7 @@ public class PrintMech extends PrintEntity {
                     }
                     addTextElement(canvas, locX,  currY, line.getLocationField(row), fontSize, "middle", "normal");
                     addTextElement(canvas, heatX, currY, line.getHeatField(row), fontSize, "middle", "normal");
-                    lines = Math.max(lines, addMultilineTextElement(canvas, dmgX, currY, minX - dmgX, lineHeight,
+                    lines = Math.max(lines, addMultilineTextElement(canvas, dmgX, currY, minX - dmgX - fontSize, lineHeight,
                             line.getDamageField(row), fontSize, "start", "normal"));
                     addTextElement(canvas, minX, currY, line.getMinField(row), fontSize, "middle", "normal");
                     addTextElement(canvas, shortX, currY, line.getShortField(row), fontSize, "middle", "normal");

--- a/src/megameklab/com/printing/PrintRecordSheet.java
+++ b/src/megameklab/com/printing/PrintRecordSheet.java
@@ -106,8 +106,8 @@ public abstract class PrintRecordSheet implements Printable {
     /**
      * Creates an SVG object for the record sheet
      * 
-     * @param startPage The print job page number for this sheet
-     * @param options Overrides the global options for which elements are printed 
+     * @param firstPage The print job page number for this sheet
+     * @param options   Overrides the global options for which elements are printed
      */
     protected PrintRecordSheet(int firstPage, RecordSheetOptions options) {
         this.firstPage = firstPage;
@@ -274,7 +274,7 @@ public abstract class PrintRecordSheet implements Printable {
     /**
      * Renders the sheet to the Graphics object.
      * 
-     * @param graphics   The graphics object passed by {@link Printable#print(Graphics, PageFormat, int) print}
+     * @param g2d        The graphics object passed by {@link Printable#print(Graphics, PageFormat, int) print}
      * @param pageFormat The page format passed by {@link Printable#print(Graphics, PageFormat, int) print}
      * @param pageNum    Indicates which page of multi-page sheets to print. The first page is 0.
      * 
@@ -326,7 +326,7 @@ public abstract class PrintRecordSheet implements Printable {
     }
     
     /**
-     * Convenience method for creating a new SVG Text element and adding it to the parent.  The height of the text is
+     * Convenience method for creating a new SVG Text element and adding it to the parent.  The width of the text is
      * returned, to aid in layout.
      * 
      * @param parent    The SVG element to add the text element to.
@@ -336,6 +336,8 @@ public abstract class PrintRecordSheet implements Printable {
      * @param fontSize  Font size of the text.
      * @param anchor    Set the Text elements text-anchor.  Should be either start, middle, or end.
      * @param weight    The font weight, either normal or bold.
+     *
+     * @return          The width of the text in the current font size
      */
     protected double addTextElement(Element parent, double x, double y, String text,
             float fontSize, String anchor, String weight) {
@@ -370,7 +372,8 @@ public abstract class PrintRecordSheet implements Printable {
         newText.setAttributeNS(null, SVGConstants.SVG_FILL_ATTRIBUTE, fill);
         parent.appendChild(newText);
         
-        return getTextLength(text, fontSize);
+        return weight.equals(SVGConstants.SVG_BOLD_VALUE) ?
+                getBoldTextLength(text, fontSize) : getTextLength(text, fontSize);
     }
     
     /**
@@ -898,7 +901,7 @@ public abstract class PrintRecordSheet implements Printable {
     /**
      * Creates a new set pip row regions sized according to the scaling factor.
      * 
-     * @param list  The rectangular regions describing pip rows in the SVG diagram.
+     * @param rows  The rectangular regions describing pip rows in the SVG diagram.
      * @param scale The scaling factor
      * @return      A list of rectangular regions scaled according to the provided factor.
      */

--- a/src/megameklab/com/util/StringUtils.java
+++ b/src/megameklab/com/util/StringUtils.java
@@ -359,7 +359,7 @@ public class StringUtils {
         } else {
             info = "  [E]";
         }
-        return info;
+        return info.trim();
     }
 
     public static String getEquipmentInfo(Aero unit, Mounted mount) {


### PR DESCRIPTION
There are some variations in the way text appears on record sheets which may be due to PDF print driver or differences in OS sizing the text differently. What works fine on my system is too large to fit in the available space when @HammerGS prints.

I've made the following changes to address this:
1. When positioning the "(CASE)" indicator, take into account that the location name is bold and takes up more space.
2. After calculating the size of font to use for the critical slots (as a proportion of the space available for the section), round it down. This seems to fix the differences in font sizes, which I suspect comes from a system call.
3. Fix a similar issue in the equipment table by making sure there is space between the Dmg and Min columns.
4. Trim leading and trailing spaces in the Dmg column entry. While working on the rest of this I noticed that a targeting computer shows as " [E]", with a leading space that causes it not to align with the rest of the column.

Example of something I printed:
![Screenshot from 2019-11-05 12-37-33](https://user-images.githubusercontent.com/16927464/68235729-5e78df80-ffc9-11e9-87cf-ac6c0d468838.png)

Example of something printed using Windows and a different PDF driver:
![Screenshot from 2019-11-05 12-39-07](https://user-images.githubusercontent.com/16927464/68235828-8b2cf700-ffc9-11e9-9305-8e2ce1810ac6.png)



