### PR TITLE
Protomek fluff

### DIFF
--- a/src/megameklab/com/ui/protomek/ProtomekMainUI.java
+++ b/src/megameklab/com/ui/protomek/ProtomekMainUI.java
@@ -15,7 +15,6 @@ package megameklab.com.ui.protomek;
 
 import java.awt.BorderLayout;
 
-import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingConstants;
 
@@ -30,8 +29,8 @@ import megamek.common.TechConstants;
 import megamek.common.verifier.TestProtomech;
 import megameklab.com.ui.MegaMekLabMainUI;
 import megameklab.com.ui.tabs.EquipmentTab;
+import megameklab.com.ui.tabs.FluffTab;
 import megameklab.com.ui.tabs.PreviewTab;
-import megameklab.com.util.MenuBarCreator;
 
 /**
  * Main UI for building protomechs
@@ -43,8 +42,8 @@ public class ProtomekMainUI extends MegaMekLabMainUI {
 
     private static final long serialVersionUID = 8103672350822665207L;
 
-    JTabbedPane configPane = new JTabbedPane(SwingConstants.TOP);
-    JPanel contentPane;
+    private JTabbedPane configPane = new JTabbedPane(SwingConstants.TOP);
+
     private ProtomekStructureTab structureTab;
     private EquipmentTab equipmentTab;
     private PreviewTab previewTab;
@@ -72,13 +71,16 @@ public class ProtomekMainUI extends MegaMekLabMainUI {
         statusbar = new ProtomekStatusBar(this);
         equipmentTab = new EquipmentTab(this);
         buildTab = new ProtomekBuildTab(this, equipmentTab, this);
+        FluffTab fluffTab = new FluffTab(this);
         structureTab.addRefreshedListener(this);
         equipmentTab.addRefreshedListener(this);
         statusbar.addRefreshedListener(this);
+        fluffTab.setRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", structureTab);
         configPane.addTab("Equipment", equipmentTab);
         configPane.addTab("Assign Criticals", buildTab);
+        configPane.addTab("Fluff", fluffTab);
         configPane.addTab("Preview", previewTab);
 
         //masterPanel.add(header);

--- a/src/megameklab/com/ui/tabs/FluffTab.java
+++ b/src/megameklab/com/ui/tabs/FluffTab.java
@@ -19,8 +19,6 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
-import java.util.EnumMap;
-import java.util.Map;
 import java.util.ResourceBundle;
 
 import javax.swing.BorderFactory;
@@ -33,7 +31,6 @@ import javax.swing.border.Border;
 
 import megamek.common.Entity;
 import megamek.common.EntityFluff;
-import megamek.common.EntityFluff.System;
 import megamek.common.util.EncodeControl;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.ITab;
@@ -60,9 +57,7 @@ public class FluffTab extends ITab implements FocusListener {
     private final JTextField txtLength = new JTextField(8);
     private final JTextField txtWidth = new JTextField(8);
     private final JTextField txtHeight = new JTextField(8);
-    private final Map<System, JTextField> txtCompManufacturers = new EnumMap<>(System.class);
-    private final Map<System, JTextField> txtCompModels = new EnumMap<>(System.class);
-    
+
     private final JTextArea txtNotes = new JTextArea(4, 40);
     
     private static final String TAG_MANUFACTURER = "manufacturer"; //$NON-NLS-1
@@ -226,14 +221,12 @@ public class FluffTab extends ITab implements FocusListener {
             JTextField txt = new JTextField(12);
             txt.setText(getFluff().getSystemManufacturer(system));
             panRight.add(txt, gbc);
-            txtCompManufacturers.put(system, txt);
             txt.setName(system.name() + ":" + TAG_MANUFACTURER);
             txt.addFocusListener(this);
             gbc.gridx = 2;
             txt = new JTextField(12);
             txt.setText(getFluff().getSystemModel(system));
             panRight.add(txt, gbc);
-            txtCompModels.put(system, txt);
             txt.setName(system.name() + ":" + TAG_MODEL);
             txt.addFocusListener(this);
             gbc.gridy++;


### PR DESCRIPTION
Adds a fluff tab for protomechs, which somehow got left out. Also removes some unused code in FluffTab - since the system text fields are identified by the component name there's no reason to track them in a map.

Fixes #365 