### PR TITLE
Install automatic SV chassis mods

### DIFF
--- a/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
@@ -374,6 +374,11 @@ public class SVStructureTab extends ITab implements SVBuildListener {
     @Override
     public void engineChanged(Engine engine) {
         getSV().setEngine(engine);
+        // Switching between maglev and non-maglev engines changes movement mode
+        if (TestSupportVehicle.SVType.RAIL.equals(TestSupportVehicle.SVType.getVehicleType(getSV()))) {
+            getSV().setMovementMode((engine.getEngineType() == Engine.MAGLEV) ?
+                    EntityMovementMode.MAGLEV : EntityMovementMode.RAIL);
+        }
         // Make sure the engine tech rating is at least the minimum for the engine type
         if (getSV().getEngineTechRating() < engine.getTechRating()) {
             getSV().setEngineTechRating(engine.getTechRating());
@@ -439,6 +444,15 @@ public class SVStructureTab extends ITab implements SVBuildListener {
             panChassis.setFromEntity(getEntity());
         } else if (mod.equals(TestSupportVehicle.ChassisModification.ARMORED.equipment)) {
             refresh.refreshArmor();
+        }
+        if (TestSupportVehicle.SVType.NAVAL.equals(TestSupportVehicle.SVType.getVehicleType(getEntity()))) {
+            if (getEntity().hasMisc(MiscType.F_HYDROFOIL)) {
+                getEntity().setMovementMode(EntityMovementMode.HYDROFOIL);
+            } else if (getEntity().hasMisc(MiscType.F_SUBMERSIBLE)) {
+                getEntity().setMovementMode(EntityMovementMode.SUBMARINE);
+            } else {
+                getEntity().setMovementMode(EntityMovementMode.NAVAL);
+            }
         }
         refreshFuel();
         panChassisMod.refresh();

--- a/src/megameklab/com/ui/view/ChassisModView.java
+++ b/src/megameklab/com/ui/view/ChassisModView.java
@@ -22,8 +22,8 @@ import megamek.common.verifier.TestSupportVehicle;
 import megameklab.com.ui.view.listeners.SVBuildListener;
 
 import javax.swing.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +34,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * Panel for selecting support vehicle chassis modifcations
  */
 
-public class ChassisModView extends BuildView implements ActionListener {
+public class ChassisModView extends BuildView implements ItemListener {
 
     private final List<SVBuildListener> listeners = new CopyOnWriteArrayList<>();
     public void addListener(SVBuildListener l) {
@@ -57,7 +57,7 @@ public class ChassisModView extends BuildView implements ActionListener {
         for (TestSupportVehicle.ChassisModification mod : TestSupportVehicle.ChassisModification.values()) {
             JCheckBox cb = new JCheckBox(mod.equipment.getShortName());
             cb.setActionCommand(mod.equipment.getInternalName());
-            cb.addActionListener(this);
+            cb.addItemListener(this);
             checkboxMap.put(mod, cb);
             add(cb);
         }
@@ -112,9 +112,9 @@ public class ChassisModView extends BuildView implements ActionListener {
     }
 
     @Override
-    public void actionPerformed(ActionEvent e) {
+    public void itemStateChanged(ItemEvent e) {
         if (e.getSource() instanceof JCheckBox) {
-            final EquipmentType eq = EquipmentType.get(e.getActionCommand());
+            final EquipmentType eq = EquipmentType.get(((JCheckBox) e.getSource()).getActionCommand());
             if (null != eq) {
                 listeners.forEach(l -> l.setChassisMod(eq, ((JCheckBox) e.getSource()).isSelected()));
             }


### PR DESCRIPTION
Fixes #367

When checkboxes for SV chassis mods are selected programatically to fulfill construction rules the mod is not actually being added to the vehicle. This is because JCheckbox::setSelected does not fire an ActionEvent. It does fire an ItemEvent whether toggled by the user or programatically, so I changed the listener type.

I also noticed that changing between MagLev and other engine types, the movement mode does not get changed. The same goes for hydrofoil or submersible chassis mods for naval support vehicles.