### PR TITLE
Fix for NPE in aero mirroring

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -3768,7 +3768,9 @@ public class UnitUtil {
         } else {
             for (int slot = 0; slot < entity.getNumberOfCriticals(fromLoc); slot++) {
                 final CriticalSlot crit = entity.getCritical(fromLoc, slot);
-                copyEquipment(entity, toLoc, crit.getMount(), removed);
+                if ((null != crit) && (crit.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
+                    copyEquipment(entity, toLoc, crit.getMount(), removed);
+                }
             }
         }
         // Link up Artemis, etc.


### PR DESCRIPTION
When copying equipment from one side of an aerospace unit to the other, check that the critical slot exists and contains equipment before trying to copy it.
Fixes #369
