### PR TITLE
Restore ability to switch to primitive

### DIFF
--- a/src/megameklab/com/ui/dialog/LoadingDialog.java
+++ b/src/megameklab/com/ui/dialog/LoadingDialog.java
@@ -68,6 +68,8 @@ public class LoadingDialog extends JDialog {
         super(frame, "MML Loading"); //$NON-NLS-1$
         this.frame = frame;
         this.type = type;
+        this.primitive = primitive;
+        this.industrial = industrial;
         newUnit = en;
         
         setUndecorated(true);


### PR DESCRIPTION
The LoadingDialog constructor ignores the primitive and industrial parameters, preventing the user from switching the unit type to primitive.
Fixes #376