### PR TITLE
Remove unused block that was incorrectly filtering out mpod.

### DIFF
--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -563,15 +563,6 @@ public class EquipmentTab extends ITab implements ActionListener {
                                         && !etype.hasSubType(MiscType.S_JETBOOSTER)))) {
                     return false;
                 }
-                boolean isSupportTankEquipment = false;
-                if (etype.hasFlag(MiscType.F_ARMORED_CHASSIS)) {
-                    isSupportTankEquipment = true;
-                }
-                if (isSupportTankEquipment
-                        && !((tank instanceof SupportTank)
-                                || (tank instanceof SupportVTOL))) {
-                    return false;
-                }
                 if (((nType == T_OTHER) && UnitUtil.isTankEquipment(etype, tank instanceof VTOL))
                         || (((nType == T_WEAPON) && (UnitUtil.isTankWeapon(etype, tank))))
                         || ((nType == T_ENERGY) && UnitUtil.isTankWeapon(etype, tank)


### PR DESCRIPTION
The check for armored chassis that I removed is not needed, since it gets filtered out by UnitUtil#isTankEquipment anyway. It has the side effect of filtering out MPods also, since MiscType.F_ARMORED_CHASSIS and WeaponType.F_M_POD have the same value and it doesn't check whether the equipment is MiscType.

Fixes #388 