### PR TITLE
Show BA Standard (Prototype) slots for allocation.

### DIFF
--- a/src/megameklab/com/ui/BattleArmor/views/BuildView.java
+++ b/src/megameklab/com/ui/BattleArmor/views/BuildView.java
@@ -126,9 +126,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
         for (Mounted mount : getBattleArmor().getMisc()) {
             if ((mount.getBaMountLoc() == BattleArmor.MOUNT_LOC_NONE
                     && !mount.getType().hasFlag(MiscType.F_BA_MANIPULATOR)
-                    && mount.getType().getCriticals(getBattleArmor()) > 0
-   //                 && !mount.getName().contains("BA Standard")
-            )) {
+                    && mount.getType().getCriticals(getBattleArmor()) > 0)) {
                 masterEquipmentList.add(mount);
             }
         }

--- a/src/megameklab/com/ui/BattleArmor/views/BuildView.java
+++ b/src/megameklab/com/ui/BattleArmor/views/BuildView.java
@@ -126,7 +126,9 @@ public class BuildView extends IView implements ActionListener, MouseListener {
         for (Mounted mount : getBattleArmor().getMisc()) {
             if ((mount.getBaMountLoc() == BattleArmor.MOUNT_LOC_NONE
                     && !mount.getType().hasFlag(MiscType.F_BA_MANIPULATOR)
-                    && !mount.getName().contains("BA Standard"))) {
+                    && mount.getType().getCriticals(getBattleArmor()) > 0
+   //                 && !mount.getName().contains("BA Standard")
+            )) {
                 masterEquipmentList.add(mount);
             }
         }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -222,8 +222,9 @@ public class UnitUtil {
             toReturn = 4;
         } else  if (isMisc
                 && (eq.hasFlag(MiscType.F_JUMP_BOOSTER)
-                        || eq.hasFlag(MiscType.F_TALON) || eq
-                            .hasFlag(MiscType.F_STEALTH))) {
+                        || eq.hasFlag(MiscType.F_TALON)
+                        // Stealth armor is allocated 2 slots/location in mechs, but by individual slot for BA
+                        || (eq.hasFlag(MiscType.F_STEALTH) && !(unit instanceof BattleArmor)))) {
             toReturn = 2;
         } else  if (UnitUtil.isFixedLocationSpreadEquipment(eq) || UnitUtil.isTSM(eq)
                 || UnitUtil.isArmorOrStructure(eq)) {


### PR DESCRIPTION
The table for unallocated BA equipment prevents showing the zero-slot BA Standard armor by filtering out any equipment with a name that contains the String "BA Standard" instead of just checking for criticals == 0. This also filters out the 4-slot BA Standard (Prototype). During testing I noticed that the table was showing that each slot of BA stealth armor requires two slots. I tracked this to handling of 'Mech stealth armor, which requires two slots per location. This has no effect on how the slots were actually allocated, but is confusing.

Best viewed with whitespace changes hidden.

Fixes #391 