### PR TITLE
Fix primitive jumpship armor rounding per errata.

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1500,6 +1500,12 @@ public class UnitUtil {
                     EquipmentType.getProtomechArmorWeightPerPoint(unit.getArmorType(Protomech.LOC_TORSO)));
         } else if (unit.isSupportVehicle()) {
             return Math.floor(armorTons / TestSupportVehicle.armorWeightPerPoint(unit));
+        } else if ((unit instanceof Jumpship)
+                && unit.getArmorType(unit.firstArmorIndex()) == EquipmentType.T_ARMOR_PRIMITIVE_AERO) {
+            // Because primitive jumpship armor has an extra step of rounding we have to give it special treatment.
+            // Standard armor value is computed first, rounded down, then the primitive armor mod is applied.
+            return Math.floor(Math.floor(armorTons * TestAdvancedAerospace.armorPointsPerTon((Jumpship) unit,
+                    EquipmentType.T_ARMOR_AEROSPACE, false)) * 0.66);
         }
         return armorTons * UnitUtil.getArmorPointsPerTon(unit,
                 unit.getArmorType(1), unit.getArmorTechLevel(1));
@@ -1520,7 +1526,7 @@ public class UnitUtil {
         } else if (entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
             double points = Math.round(((Jumpship) entity).getSI() / 10.0) * 6;
             if (((Jumpship) entity).isPrimitive()) {
-                return points * EquipmentType.getArmorPointMultiplier(EquipmentType.T_ARMOR_PRIMITIVE_AERO);
+                return Math.floor(points * EquipmentType.getArmorPointMultiplier(EquipmentType.T_ARMOR_PRIMITIVE_AERO));
             } else {
                 return points;
             }


### PR DESCRIPTION
As clarified in the errata to IO, the armor points for a primitive jumpship are calculated as for standard armor, then rounded down, then the primitive multiplier of 0.66 is applied, then rounded down again. The free armor points gained from SI are rounded normally as for standard advanced aero, but the 0.66 mulitplier is applied to that value as well and rounded down. The way MML currently does it is by applying the primitive factor to the standard points per ton then rounding once, but this can carry over enough accumulation of fractional amounts to result in an extra point or two. The double rounding required special handling.

Neither IO nor the errata address the method used for dropships, but since IS standard armor is always an even whole number per ton, each half ton lot is a whole number of armor points and the first rounding step is not required.

Fixes #386