### PR TITLE
Cv trailers

### DIFF
--- a/resources/megameklab/resources/Views.properties
+++ b/resources/megameklab/resources/Views.properties
@@ -102,6 +102,9 @@ CVChassisView.chkSuperheavy.tooltip=<html>Change vehicle type to superheavy.<br/
 CVChassisView.chkTrailer.text=Trailer
 CVChassisView.chkTrailer.tooltip=<html>Vehicles constructed as trailers can be towed by other combat vehicles, or support vehicles with the tractor chassis modification.<br/>\
   They are not required to have an engine unless they are intended to operate independently, in which case they can use a rating 10 engine.</html>
+CVChassisView.chkControlSystems.text=Control Systems
+CVChassisView.chkControlSystems.tooltip=<html>Combat vehicles built as trailers can leave out the control systems to reduce weight<br/>\
+  Trailers without control systems cannot operate independently of a suitable tractor.</html>
 CVChassisView.cbEngine.text=Engine:
 CVChassisView.cbEngine.tooltip=Non-fusion or fission engines require power amplifiers for energy weapons. Fusion and fission engines require weight allocated to shielding.
 CVChassisView.cbMotiveType.text=Motive Type:

--- a/resources/megameklab/resources/Views.properties
+++ b/resources/megameklab/resources/Views.properties
@@ -99,6 +99,9 @@ CVChassisView.chkOmni.text=Omni
 CVChassisView.chkOmni.tooltip=Omni units mount equipment in pods that can be swapped quickly.
 CVChassisView.chkSuperheavy.text=Superheavy
 CVChassisView.chkSuperheavy.tooltip=<html>Change vehicle type to superheavy.<br/>Resets non-VTOL units.</html>
+CVChassisView.chkTrailer.text=Trailer
+CVChassisView.chkTrailer.tooltip=<html>Vehicles constructed as trailers can be towed by other combat vehicles, or support vehicles with the tractor chassis modification.<br/>\
+  They are not required to have an engine unless they are intended to operate independently, in which case they can use a rating 10 engine.</html>
 CVChassisView.cbEngine.text=Engine:
 CVChassisView.cbEngine.tooltip=Non-fusion or fission engines require power amplifiers for energy weapons. Fusion and fission engines require weight allocated to shielding.
 CVChassisView.cbMotiveType.text=Motive Type:

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -537,6 +537,18 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
     }
 
     @Override
+    public void controlSystemsChanged(boolean controlSystems) {
+        getTank().setHasNoControlSystems(!controlSystems);
+        if (!controlSystems) {
+            walkChanged(0);
+        }
+        panChassis.setFromEntity(getTank());
+        panSummary.refresh();
+        refresh.refreshPreview();
+        refresh.refreshStatus();
+    }
+
+    @Override
     public void motiveChanged(EntityMovementMode motive) {
         // If we are changing to or from VTOL we need a new Entity
         if ((motive == EntityMovementMode.VTOL)
@@ -560,6 +572,7 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
         if (getTank().isTrailer() && !motive.equals(EntityMovementMode.TRACKED)
             && !motive.equals(EntityMovementMode.WHEELED)) {
             getTank().setTrailer(false);
+            getTank().setHasNoControlSystems(false);
         }
         panChassis.removeListener(this);
         panChassis.setFromEntity(getTank());

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -367,8 +367,14 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
             panChassis.addListener(this);
             return;
         }
-        getTank().setOriginalWalkMP((getTank().getEngine().getRating() + getTank().getSuspensionFactor())
-                / (int)getTank().getWeight());
+        // Some units (e.g. hover) have a minimum engine rating, which may result in a higher MP.
+        // Trailers have a minimum of zero even if they have an engine.
+        if (getTank().isTrailer() && walkMP == 0) {
+            getTank().setOriginalWalkMP(0);
+        } else {
+            getTank().setOriginalWalkMP((getTank().getEngine().getRating() + getTank().getSuspensionFactor())
+                    / (int) getTank().getWeight());
+        }
         panSummary.refresh();
         refresh.refreshStatus();
         refresh.refreshPreview();

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -524,6 +524,13 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
     }
 
     @Override
+    public void trailerChanged(boolean trailer) {
+        getTank().setTrailer(trailer);
+        panChassis.setFromEntity(getTank());
+        panMovement.setFromEntity(getTank());
+    }
+
+    @Override
     public void motiveChanged(EntityMovementMode motive) {
         // If we are changing to or from VTOL we need a new Entity
         if ((motive == EntityMovementMode.VTOL)
@@ -544,6 +551,10 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
             return;
         }
         getTank().setMovementMode(motive);
+        if (getTank().isTrailer() && !motive.equals(EntityMovementMode.TRACKED)
+            && !motive.equals(EntityMovementMode.WHEELED)) {
+            getTank().setTrailer(false);
+        }
         panChassis.removeListener(this);
         panChassis.setFromEntity(getTank());
         panChassis.addListener(this);
@@ -566,6 +577,11 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
         panMovement.removeListener(this);
         panMovement.setFromEntity(getTank());
         panMovement.addListener(this);
+        // MP may change due to switching from large engine to type without a large equivalent
+        // or trailer removing engine
+        if (panMovement.getWalk() != getTank().getOriginalWalkMP()) {
+            walkChanged(panMovement.getWalk());
+        }
         refreshSummary();
         refresh.refreshPreview();
         refresh.refreshStatus();

--- a/src/megameklab/com/ui/view/CVChassisView.java
+++ b/src/megameklab/com/ui/view/CVChassisView.java
@@ -20,13 +20,7 @@ import java.awt.event.ActionListener;
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JSpinner;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -96,6 +90,7 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
     private final JCheckBox chkOmni = new JCheckBox();
     private final JCheckBox chkSuperheavy = new JCheckBox();
     private final JCheckBox chkTrailer = new JCheckBox();
+    private final JCheckBox chkControlSystems = new JCheckBox();
     private final CustomComboBox<EntityMovementMode> cbMotiveType = new CustomComboBox<>(motiveNames::get);
     private final TechComboBox<Engine> cbEngine = new TechComboBox<>(e -> e.getEngineName()
             .replaceAll("^\\d+ ", "").replace(" [Vehicle]", ""));
@@ -151,10 +146,18 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridy++;
 
         chkTrailer.setText(resourceMap.getString("CVChassisView.chkTrailer.text")); //$NON-NLS-1$
-        gbc.gridx = 2;
+        gbc.gridx = 0;
+        gbc.gridwidth = 2;
         chkTrailer.setToolTipText(resourceMap.getString("CVChassisView.chkTrailer.tooltip")); // $NON-NLS-1$
+        chkTrailer.setHorizontalAlignment(SwingConstants.RIGHT);
         add(chkTrailer, gbc);
         chkTrailer.addActionListener(this);
+        chkControlSystems.setText(resourceMap.getString("CVChassisView.chkControlSystems.text")); //$NON-NLS-1$
+        gbc.gridx = 2;
+        chkControlSystems.setToolTipText(resourceMap.getString("CVChassisView.chkControlSystems.tooltip")); // $NON-NLS-1$
+        add(chkControlSystems, gbc);
+        chkControlSystems.addActionListener(this);
+        gbc.gridwidth = 1;
         gbc.gridy++;
 
         cbMotiveType.setModel(new DefaultComboBoxModel<>(MOTIVE_TYPES));
@@ -236,11 +239,13 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
         chkOmni.setSelected(tank.isOmni());
         chkSuperheavy.setSelected(tank.isSuperHeavy());
         chkTrailer.setSelected(tank.isTrailer());
+        chkControlSystems.setSelected(!tank.hasNoControlSystems());
         cbMotiveType.setSelectedItem(tank.getMovementMode());
         setEngine(tank.getEngine());
 
         chkTrailer.setEnabled(tank.getMovementMode().equals(EntityMovementMode.WHEELED)
                 || tank.getMovementMode().equals(EntityMovementMode.TRACKED));
+        chkControlSystems.setEnabled(isTrailer);
         if (!tank.hasNoDualTurret()) {
             cbTurrets.setSelectedItem(TURRET_DUAL);
         } else if (!tank.hasNoTurret()) {
@@ -492,6 +497,8 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
             listeners.forEach(l -> l.superheavyChanged(chkSuperheavy.isSelected()));
         } else if (e.getSource() == chkTrailer) {
             listeners.forEach(l -> l.trailerChanged(chkTrailer.isSelected()));
+        } else if (e.getSource() == chkControlSystems) {
+            listeners.forEach(l -> l.controlSystemsChanged(chkControlSystems.isSelected()));
         } else if (e.getSource() == cbMotiveType) {
             listeners.forEach(l -> l.motiveChanged((EntityMovementMode)cbMotiveType.getSelectedItem()));
         } else if (e.getSource() == cbEngine) {

--- a/src/megameklab/com/ui/view/CVChassisView.java
+++ b/src/megameklab/com/ui/view/CVChassisView.java
@@ -17,11 +17,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ResourceBundle;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.swing.DefaultComboBoxModel;
@@ -74,12 +70,13 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
             EntityMovementMode.VTOL, EntityMovementMode.WIGE,
             EntityMovementMode.NAVAL, EntityMovementMode.HYDROFOIL, EntityMovementMode.SUBMARINE
     };
-    
+
     // Engines that can be used by mechs and the order they appear in the combobox
     private final static int[] ENGINE_TYPES = {
             Engine.COMBUSTION_ENGINE, Engine.NORMAL_ENGINE, Engine.XL_ENGINE, Engine.XXL_ENGINE,
             Engine.FUEL_CELL, Engine.LIGHT_ENGINE, Engine.COMPACT_ENGINE, Engine.FISSION
     };
+    private final Engine NO_ENGINE = new Engine(0, Engine.NONE, Engine.TANK_ENGINE);
 
     public final static int TURRET_NONE   = 0;
     public final static int TURRET_SINGLE = 1;
@@ -98,7 +95,8 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
     private final JSpinner spnTonnage = new JSpinner(spnTonnageModel);
     private final JCheckBox chkOmni = new JCheckBox();
     private final JCheckBox chkSuperheavy = new JCheckBox();
-    private final CustomComboBox<EntityMovementMode> cbMotiveType = new CustomComboBox<>(m -> motiveNames.get(m));
+    private final JCheckBox chkTrailer = new JCheckBox();
+    private final CustomComboBox<EntityMovementMode> cbMotiveType = new CustomComboBox<>(motiveNames::get);
     private final TechComboBox<Engine> cbEngine = new TechComboBox<>(e -> e.getEngineName()
             .replaceAll("^\\d+ ", "").replace(" [Vehicle]", ""));
     private final CustomComboBox<Integer> cbTurrets = new CustomComboBox<>(i -> turretNames[i]);
@@ -109,8 +107,8 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
 
     private ITechManager techManager;
     private int engineRating;
-    private boolean isSuperheavy;
-    
+    private boolean isTrailer;
+
     public CVChassisView(ITechManager techManager) {
         super();
         this.techManager = techManager;
@@ -150,64 +148,66 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
         chkSuperheavy.setToolTipText(resourceMap.getString("CVChassisView.chkSuperheavy.tooltip")); //$NON-NLS-1$
         add(chkSuperheavy, gbc);
         chkSuperheavy.addActionListener(this);
+        gbc.gridy++;
+
+        chkTrailer.setText(resourceMap.getString("CVChassisView.chkTrailer.text")); //$NON-NLS-1$
+        gbc.gridx = 2;
+        chkTrailer.setToolTipText(resourceMap.getString("CVChassisView.chkTrailer.tooltip")); // $NON-NLS-1$
+        add(chkTrailer, gbc);
+        chkTrailer.addActionListener(this);
+        gbc.gridy++;
 
         cbMotiveType.setModel(new DefaultComboBoxModel<>(MOTIVE_TYPES));
         gbc.gridx = 0;
-        gbc.gridy = 1;
         add(createLabel(resourceMap.getString("CVChassisView.cbMotiveType.text"), labelSize), gbc); //$NON-NLS-1$
         gbc.gridx = 1;
-        gbc.gridy = 1;
         gbc.gridwidth = 3;
         setFieldSize(cbMotiveType, controlSize);
         cbMotiveType.setToolTipText(resourceMap.getString("CVChassisView.cbMotiveType.tooltip")); //$NON-NLS-1$
         add(cbMotiveType, gbc);
         cbMotiveType.addActionListener(this);
+        gbc.gridy++;
 
         gbc.gridx = 0;
-        gbc.gridy = 2;
         gbc.gridwidth = 1;
         add(createLabel(resourceMap.getString("CVChassisView.cbEngine.text"), labelSize), gbc); //$NON-NLS-1$
         gbc.gridx = 1;
-        gbc.gridy = 2;
         gbc.gridwidth = 3;
         setFieldSize(cbEngine, controlSize);
         cbEngine.setToolTipText(resourceMap.getString("CVChassisView.cbEngine.tooltip")); //$NON-NLS-1$
         add(cbEngine, gbc);
         cbEngine.addActionListener(this);
+        gbc.gridy++;
 
         gbc.gridx = 0;
-        gbc.gridy = 3;
         gbc.gridwidth = 1;
         add(createLabel(resourceMap.getString("CVChassisView.cbTurrets.text"), labelSize), gbc); //$NON-NLS-1$
         gbc.gridx = 1;
-        gbc.gridy = 3;
         gbc.gridwidth = 3;
         setFieldSize(cbTurrets, controlSize);
         cbTurrets.setToolTipText(resourceMap.getString("CVChassisView.cbTurrets.tooltip")); //$NON-NLS-1$
         add(cbTurrets, gbc);
         cbTurrets.addActionListener(this);
-        
+        gbc.gridy++;
+
         gbc.gridx = 0;
-        gbc.gridy = 4;
         gbc.gridwidth = 3;
         JLabel lbl = createLabel(resourceMap.getString("CVChassisView.spnTurretWt.text"), labelSize); //$NON-NLS-1$
         add(lbl, gbc);
         gbc.gridx = 3;
-        gbc.gridy = 4;
         setFieldSize(spnChassisTurretWt, spinnerSize);
         spnChassisTurretWt.setToolTipText(resourceMap.getString("CVChassisView.spnTurretWt.tooltip")); //$NON-NLS-1$
         add(spnChassisTurretWt, gbc);
         spnChassisTurretWt.addChangeListener(this);
         omniComponents.add(lbl);
         omniComponents.add(spnChassisTurretWt);
-        
+        gbc.gridy++;
+
         gbc.gridx = 0;
-        gbc.gridy = 5;
         gbc.gridwidth = 3;
         lbl = createLabel(resourceMap.getString("CVChassisView.spnTurret2Wt.text"), labelSize); //$NON-NLS-1$
         add(lbl, gbc);
         gbc.gridx = 3;
-        gbc.gridy = 5;
         gbc.gridwidth = 1;
         setFieldSize(spnChassisTurret2Wt, spinnerSize);
         spnChassisTurret2Wt.setToolTipText(resourceMap.getString("CVChassisView.spnTurret2Wt.tooltip")); //$NON-NLS-1$
@@ -215,11 +215,11 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
         spnChassisTurret2Wt.addChangeListener(this);
         omniComponents.add(lbl);
         omniComponents.add(spnChassisTurret2Wt);
-        
+        gbc.gridy++;
+
         JButton btnResetChassis = new JButton(resourceMap.getString("CVChassisView.btnResetChassis.text")); //$NON-NLS-1$
         btnResetChassis.setActionCommand(CMD_RESET_CHASSIS);
         gbc.gridx = 1;
-        gbc.gridy = 6;
         gbc.gridwidth = 3;
         setFieldSize(btnResetChassis, controlSize);
         btnResetChassis.setToolTipText(resourceMap.getString("CVChassisView.btnResetChassis.tooltip")); //$NON-NLS-1$
@@ -230,15 +230,17 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
     
     public void setFromEntity(Tank tank) {
         engineRating = tank.hasEngine()? tank.getEngine().getRating() : 0;
-        isSuperheavy = tank.isSuperHeavy();
-        
+        isTrailer = tank.isTrailer();
         refresh();
         setTonnage(tank.getWeight());
         chkOmni.setSelected(tank.isOmni());
-        chkSuperheavy.setSelected(isSuperheavy);
+        chkSuperheavy.setSelected(tank.isSuperHeavy());
+        chkTrailer.setSelected(tank.isTrailer());
         cbMotiveType.setSelectedItem(tank.getMovementMode());
         setEngine(tank.getEngine());
-        
+
+        chkTrailer.setEnabled(tank.getMovementMode().equals(EntityMovementMode.WHEELED)
+                || tank.getMovementMode().equals(EntityMovementMode.TRACKED));
         if (!tank.hasNoDualTurret()) {
             cbTurrets.setSelectedItem(TURRET_DUAL);
         } else if (!tank.hasNoTurret()) {
@@ -321,6 +323,9 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
         cbEngine.removeAllItems();
         for (Engine e : getAvailableEngines()) {
             cbEngine.addItem(e);
+        }
+        if (isTrailer) {
+            cbEngine.addItem(NO_ENGINE);
         }
         setEngine(prevEngine);
         cbEngine.addActionListener(this);
@@ -407,8 +412,7 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
             flags |= Engine.LARGE_ENGINE;
         }
         int altFlags = flags ^ Engine.CLAN_ENGINE;
-        int[] engineTypes = ENGINE_TYPES;
-        for (int i : engineTypes) {
+        for (int i : ENGINE_TYPES) {
             Engine e = new Engine(getEngineRating(), i, flags);
             if (e.engineValid && techManager.isLegal(e)) {
                 retVal.add(e);
@@ -423,14 +427,6 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
             }
         }
         return retVal;
-    }
-    
-    public boolean hasTurret() {
-        return cbTurrets.getSelectedIndex() > 0;
-    }
-    
-    public boolean hasDualTurret() {
-        return ((Integer)cbTurrets.getSelectedIndex()) == TURRET_DUAL;
     }
     
     /**
@@ -461,9 +457,20 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
             }
         }
     }
-    
+
+    /**
+     * The turret configuration should be one of {@link CVChassisView#TURRET_NONE TURRET_NONE},
+     * {@link CVChassisView#TURRET_SINGLE TURRET_SINGLE}, {@link CVChassisView#TURRET_DUAL TURRET_DUAL}, or
+     * {@link CVChassisView#TURRET_CHIN TURRET_CHIN}.
+     * @return The currently selected turret configuration.
+     */
     public int getTurretConfiguration() {
-        return (Integer)cbTurrets.getSelectedItem();
+        Integer config = (Integer) cbTurrets.getSelectedItem();
+        if (config == null) {
+            return TURRET_NONE; // Failsafe in case this gets called while in an indeterminate state
+        } else {
+            return config;
+        }
     }
 
     @Override
@@ -483,14 +490,16 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
             listeners.forEach(l -> l.omniChanged(chkOmni.isSelected()));
         } else if (e.getSource() == chkSuperheavy) {
             listeners.forEach(l -> l.superheavyChanged(chkSuperheavy.isSelected()));
+        } else if (e.getSource() == chkTrailer) {
+            listeners.forEach(l -> l.trailerChanged(chkTrailer.isSelected()));
         } else if (e.getSource() == cbMotiveType) {
             listeners.forEach(l -> l.motiveChanged((EntityMovementMode)cbMotiveType.getSelectedItem()));
         } else if (e.getSource() == cbEngine) {
             listeners.forEach(l -> l.engineChanged((Engine)cbEngine.getSelectedItem()));
         } else if (e.getSource() == cbTurrets) {
-            listeners.forEach(l -> l.turretChanged((Integer)cbTurrets.getSelectedItem()));
+            listeners.forEach(l -> l.turretChanged(getTurretConfiguration()));
         } else if (e.getActionCommand().equals(CMD_RESET_CHASSIS)) {
-            listeners.forEach(l -> l.resetChassis());
+            listeners.forEach(CVBuildListener::resetChassis);
         }
     }
 }

--- a/src/megameklab/com/ui/view/MovementView.java
+++ b/src/megameklab/com/ui/view/MovementView.java
@@ -255,6 +255,9 @@ public class MovementView extends BuildView implements ActionListener, ChangeLis
         spnWalkModel.setMinimum(minWalk);
         spnWalkModel.setMaximum(maxWalk);
         spnWalk.setValue(Math.max(minWalk, en.getOriginalWalkMP()));
+        if (null != maxWalk && getWalk() > maxWalk) {
+            spnWalk.setValue(maxWalk);
+        }
         txtWalkFinal.setText(String.valueOf(en.getWalkMP()));
 
         txtRunBase.setText(String.valueOf((int)Math.ceil(((Number) spnWalk.getValue()).intValue() * 1.5)));

--- a/src/megameklab/com/ui/view/MovementView.java
+++ b/src/megameklab/com/ui/view/MovementView.java
@@ -210,7 +210,7 @@ public class MovementView extends BuildView implements ActionListener, ChangeLis
         } else if (en instanceof Protomech) {
             maxJump = TestProtomech.maxJumpMP((Protomech) en);
         }
-        if (en.hasETypeFlag(Entity.ETYPE_TANK) && !en.isSupportVehicle()) {
+        if (en.hasETypeFlag(Entity.ETYPE_TANK) && !en.isSupportVehicle() && !en.isTrailer()) {
             int minRating = 10 + Tank.getSuspensionFactor(en.getMovementMode(), en.getWeight());
             minWalk = Math.max(1, (int)(minRating / en.getWeight()));
         } else if (en.hasETypeFlag(Entity.ETYPE_LAND_AIR_MECH)) {

--- a/src/megameklab/com/ui/view/listeners/CVBuildListener.java
+++ b/src/megameklab/com/ui/view/listeners/CVBuildListener.java
@@ -16,6 +16,7 @@ package megameklab.com.ui.view.listeners;
 import megamek.common.Engine;
 import megamek.common.EntityMovementMode;
 import megamek.common.verifier.BayData;
+import megameklab.com.ui.view.CVChassisView;
 
 /**
  * Listener for views used by combat vehicles.
@@ -24,16 +25,76 @@ import megamek.common.verifier.BayData;
  *
  */
 public interface CVBuildListener extends BuildListener {
-
+    /**
+     * Notify of a change in the vehicle tonnage
+     * @param tonnage The construction weight of the vehicle in tons
+     */
     void tonnageChanged(double tonnage);
-    void omniChanged(boolean omni);
-    void superheavyChanged(boolean superheavy);
-    void motiveChanged(EntityMovementMode motive);
-    void engineChanged(Engine engine);
-    void turretChanged(int turretConfig);
-    void turretBaseWtChanged(double turret1, double turret2);
-    void troopSpaceChanged(double fixed, double pod);
-    void cargoSpaceChanged(BayData bayType, double fixed, double pod);
-    void resetChassis();
 
+    /**
+     * Notify of a change in omni status
+     * @param omni Whether the vehicle is an OmniVehicle
+     */
+    void omniChanged(boolean omni);
+
+    /**
+     * Notify of a change in superheavy status
+     * @param superheavy Whether the vehicle is in the superheavy weight range.
+     */
+    void superheavyChanged(boolean superheavy);
+
+    /**
+     * Notify of a change in trailer status
+     * @param trailer Whether the vehicle is construted as a trailer
+     */
+    void trailerChanged(boolean trailer);
+
+    /**
+     * Notify of a change in motive type. May require instantiation of a new {@link megamek.common.Entity Entity}.
+     * @param motive The new motive type
+     */
+    void motiveChanged(EntityMovementMode motive);
+
+    /**
+     * Notify of a change in the type of engine
+     * @param engine The new engine type
+     */
+    void engineChanged(Engine engine);
+
+    /**
+     * Notify of a change in turret configuration.
+     * @param turretConfig One of {@link CVChassisView#TURRET_NONE TURRET_NONE},
+     *      * {@link CVChassisView#TURRET_SINGLE TURRET_SINGLE}, {@link CVChassisView#TURRET_DUAL TURRET_DUAL}, or
+     *      * {@link CVChassisView#TURRET_CHIN TURRET_CHIN}
+     */
+    void turretChanged(int turretConfig);
+
+    /**
+     * Notify of a change in the base weight of one or more turrets. This is used for omnivehicles,
+     * which have to set the limit of pod space in the turret(s) as part of the base chassis design.
+     * @param turret1 The weight of the turret, or the rear turret in dual-turret vehicles
+     * @param turret2 The weight of the front turret in dual-turret vehicles
+     */
+    void turretBaseWtChanged(double turret1, double turret2);
+
+    /**
+     * Notify of a change in the size of any infantry compartment
+     * @param fixed The weight in tons of the infantry compartment
+     * @param pod   The weight in tons of any pod-mounted infantry compartment
+     */
+    void troopSpaceChanged(double fixed, double pod);
+
+    /**
+     * Notify of a change in the size of a cargo bay
+     * @param bayType The type of bay
+     * @param fixed   The size of a fixed bay
+     * @param pod     The size of a pod-mounted bay
+     */
+    void cargoSpaceChanged(BayData bayType, double fixed, double pod);
+
+    /**
+     * Notify of a command to remove all pod-mounted equipment from an omnivehicle and reset
+     * it to the base chassis.
+     */
+    void resetChassis();
 }

--- a/src/megameklab/com/ui/view/listeners/CVBuildListener.java
+++ b/src/megameklab/com/ui/view/listeners/CVBuildListener.java
@@ -45,9 +45,15 @@ public interface CVBuildListener extends BuildListener {
 
     /**
      * Notify of a change in trailer status
-     * @param trailer Whether the vehicle is construted as a trailer
+     * @param trailer Whether the vehicle is constructed as a trailer
      */
     void trailerChanged(boolean trailer);
+
+    /**
+     * Notify of a change in whether a trailer has control systems.
+     * @param controlSystems Whether the trailer has control systems.
+     */
+    void controlSystemsChanged(boolean controlSystems);
 
     /**
      * Notify of a change in motive type. May require instantiation of a new {@link megamek.common.Entity Entity}.


### PR DESCRIPTION
Adds two checkboxes to the chassis section of the combat vehicle structure tab. One designates the vehicle as a trailer (only enabled when motive type is wheeled or tracked) and the other allows the trailer to be built without control systems to save weight (only enabled if trailer is checked). Trailers have a minimum of 0 MP and can be built with no engine.

![Screenshot from 2020-01-14 10-33-55](https://user-images.githubusercontent.com/16927464/72362808-6a63da80-36b9-11ea-84c8-1a2a52578929.png)

Closes #316