### PR TITLE
External fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ timestamp
 /.classpath
 /.project
 /properties_local.gradle
+/data/fonts/

--- a/resources/megameklab/resources/Dialogs.properties
+++ b/resources/megameklab/resources/Dialogs.properties
@@ -18,7 +18,8 @@ ConfigurationDialog.chkShowExtinct.tooltip=Whether to show options that have gon
 ConfigurationDialog.chkUnofficialIgnoreYear.text=Unofficial Ignores Year
 ConfigurationDialog.chkUnofficialIgnoreYear.tooltip=If the tech level is set to unofficial, the intro/extinct year will be ignored.
 ConfigurationDialog.cbFont.text=Font Family:
-ConfigurationDialog.cbFont.tooltip=Select the typeface to use when printing record sheets
+ConfigurationDialog.cbFont.tooltip=<html>Select the typeface to use when printing record sheets.<br/>\
+  Additional truetype fonts can be made available to MML by placing the font file in the data/fonts directory.</html>
 ConfigurationDialog.txtFontDisplay.text=The quick brown fox jumps over the lazy dog.
 ConfigurationDialog.chkShowQuirks.text=Show quirks
 ConfigurationDialog.chkShowQuirks.tooltip=Displays featured design quirks

--- a/src/megameklab/com/util/ConfigurationDialog.java
+++ b/src/megameklab/com/util/ConfigurationDialog.java
@@ -209,6 +209,7 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
         gbc.gridy = 0;
         panPrinting.add(new JLabel(resourceMap.getString("ConfigurationDialog.cbFont.text")), gbc);
         gbc.gridx = 1;
+        cbFont.setToolTipText(resourceMap.getString("ConfigurationDialog.cbFont.tooltip")); //$NON-NLS-1$
         panPrinting.add(cbFont, gbc);
         cbFont.addActionListener(ev -> updateFont());
         


### PR DESCRIPTION
@HammerGS discovered that on Windows the font selection combo box does not necessarily show all fonts installed on the system. I was not able to determine the reason (hampered by not having a Windows system to experiment with) but I found a solution involving recursively searching the data/fonts directory for any *.ttf files and registering them with the graphics environment. This also allows use of a font for printing record sheets without installing it on the system (for whatever reason someone might want to do that). I also took the precaution of adding data/fonts to .gitignore to prevent accidentally committing proprietary font files.