### PR TITLE
Add -Dfile.encoding=utf-8 to Gradle JVM arguments.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmArgs=-Dfile.encoding=utf-8


### PR DESCRIPTION
This is probably not needed on MML, but it doesn't hurt to play it safe. See Megamek/megamek#1653