### PR TITLE
Simplified check for armored component eligibility.

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2413,23 +2413,12 @@ public class UnitUtil {
     }
     
     public static boolean isArmorable(EquipmentType eq) {
-        if (UnitUtil.isArmorOrStructure(eq)) {
-            return false;
+        if (eq instanceof AmmoType) {
+            // The prohibition against armoring ammo bins presumably only applies to actual
+            // ammo bins and not equipment that we've implemented as ammo because it's explody and gets used up.
+            return ((AmmoType) eq).getAmmoType() == AmmoType.T_COOLANT_POD;
         }
-
-        if (UnitUtil.isTSM(eq)) {
-            return false;
-        }
-
-        if (eq instanceof MiscType) {
-            if (eq.hasFlag(MiscType.F_SPIKES)
-                    || eq.hasFlag(MiscType.F_REACTIVE)
-                    || eq.hasFlag(MiscType.F_MODULAR_ARMOR)
-                    || ((MiscType) eq).isShield()) {
-                return false;
-            }
-        }
-        return true;
+        return eq.isHittable();
     }
 
     /**


### PR DESCRIPTION
Per TacOps, p. 282: "Any component on a unit’s Critical Hit Table can be armored except for ammunition bins, CASE and other items that have a “roll again” effect (such as Ferro-Fibrous Armor slots)."

I simplified the check to follow this rule. The current implementation leaves some things out and also includes some equipment, such as shields and spikes, which are not excluded by either the armored component rules or by their own.

Fixes #418.