### PR TITLE
Expand theme support and include dark themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ timestamp
 /.project
 /properties_local.gradle
 /data/fonts/
-.idea
+.idea/
+.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -75,9 +75,6 @@ dependencies {
     // the conversion to batik is complete.
     implementation files('lib/svgSalamander.jar')
 
-    // Light and Dark themes
-    implementation 'com.formdev:flatlaf:0.26'
-
     jarbundler 'com.ultramixer.jarbundler:jarbundler-core:3.3.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
     // the conversion to batik is complete.
     implementation files('lib/svgSalamander.jar')
 
+    // Light and Dark themes
+    implementation 'com.formdev:flatlaf:0.26'
+
     jarbundler 'com.ultramixer.jarbundler:jarbundler-core:3.3.0'
 }
 

--- a/src/megameklab/com/MegaMekLab.java
+++ b/src/megameklab/com/MegaMekLab.java
@@ -164,6 +164,13 @@ public class MegaMekLab {
         }
         new CConfig();
         UnitUtil.loadFonts();
+
+        // Add additional themes
+        UIManager.installLookAndFeel("Flat Light", "com.formdev.flatlaf.FlatLightLaf");
+        UIManager.installLookAndFeel("Flat IntelliJ", "com.formdev.flatlaf.FlatIntelliJLaf");
+        UIManager.installLookAndFeel("Flat Dark", "com.formdev.flatlaf.FlatDarkLaf");
+        UIManager.installLookAndFeel("Flat Darcula", "com.formdev.flatlaf.FlatDarculaLaf");
+
         setLookAndFeel();
         //create a start up frame and display it
         StartupGUI sud = new StartupGUI();

--- a/src/megameklab/com/ui/Aero/StatusBar.java
+++ b/src/megameklab/com/ui/Aero/StatusBar.java
@@ -27,6 +27,7 @@ import java.text.DecimalFormat;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.UIManager;
 
 import megamek.common.AmmoType;
 import megamek.common.Entity;
@@ -122,7 +123,7 @@ public class StatusBar extends ITab {
         if (totalHeat > heat) {
             heatSink.setForeground(Color.red);
         } else {
-            heatSink.setForeground(Color.black);
+            heatSink.setForeground(UIManager.getColor("Label.foreground"));
         }
         heatSink.setVisible(getAero().getEntityType() == Entity.ETYPE_AERO);
 
@@ -131,7 +132,7 @@ public class StatusBar extends ITab {
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);
         } else {
-            tons.setForeground(Color.black);
+            tons.setForeground(UIManager.getColor("Label.foreground"));
         }
 
         bvLabel.setText("BV: " + bv);

--- a/src/megameklab/com/ui/BattleArmor/MainUI.java
+++ b/src/megameklab/com/ui/BattleArmor/MainUI.java
@@ -22,6 +22,7 @@ import java.awt.Color;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 
 import megamek.common.BattleArmor;
 import megamek.common.Entity;
@@ -149,7 +150,7 @@ public class MainUI extends MegaMekLabMainUI {
             title += "  (Invalid)";
             setForeground(Color.red);
         } else {
-            setForeground(Color.BLACK);
+            setForeground(UIManager.getColor("Label.foreground"));
         }
         setTitle(title);
 

--- a/src/megameklab/com/ui/BattleArmor/StatusBar.java
+++ b/src/megameklab/com/ui/BattleArmor/StatusBar.java
@@ -28,6 +28,7 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.UIManager;
 
 import megamek.common.BattleArmor;
 import megamek.common.verifier.EntityVerifier;
@@ -45,37 +46,37 @@ public class StatusBar extends ITab {
      */
     private static final long serialVersionUID = -6754327753693500675L;
 
-    private JButton btnValidate = new JButton("Validate Unit");
-    private JButton btnFluffImage = new JButton("Set Fluff Image");
+    private final JButton btnValidate = new JButton("Validate Unit");
+    private final JButton btnFluffImage = new JButton("Set Fluff Image");
     
-    private JPanel tonnagePanel = new JPanel();
-    private JPanel movementPanel = new JPanel();
-    private JPanel bvPanel = new JPanel();
+    private final JPanel tonnagePanel = new JPanel();
+    private final JPanel movementPanel = new JPanel();
+    private final JPanel bvPanel = new JPanel();
     
-    private JLabel move = new JLabel();
-    private JLabel bvLabel = new JLabel();
-    private JLabel tons = new JLabel();
-    private JLabel cost = new JLabel();
+    private final JLabel move = new JLabel();
+    private final JLabel bvLabel = new JLabel();
+    private final JLabel tons = new JLabel();
+    private final JLabel cost = new JLabel();
     
-    private EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
+    private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
             "data/mechfiles/UnitVerifierOptions.xml"));
     
     private TestBattleArmor testBA = null;
-    private DecimalFormat formatter;
+    private final DecimalFormat formatter;
     private JFrame parentFrame;
 
     private RefreshListener refresh;
-    public StatusBar(MegaMekLabMainUI parent) {
+    public StatusBar(final MegaMekLabMainUI parent) {
         super(parent);
         
         formatter = new DecimalFormat();
         btnValidate.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+            public void actionPerformed(final java.awt.event.ActionEvent evt) {
                 UnitUtil.showValidation(getBattleArmor(), getParentFrame());
             }
         });
         btnFluffImage.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
+            public void actionPerformed(final java.awt.event.ActionEvent evt) {
                 getFluffImage();
             }
         });
@@ -86,7 +87,7 @@ public class StatusBar extends ITab {
         this.add(bvPanel());
         this.add(tonnagePanel());
 
-        GridBagConstraints gbc = new GridBagConstraints();
+        final GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0;
         gbc.gridy = 0;
         gbc.insets = new Insets(5,2,2,30);
@@ -109,8 +110,8 @@ public class StatusBar extends ITab {
     }
 
     public JPanel movementPanel() {
-        int walk = getBattleArmor().getOriginalWalkMP();
-        int jump = getBattleArmor().getOriginalJumpMP();
+        final int walk = getBattleArmor().getOriginalWalkMP();
+        final int jump = getBattleArmor().getOriginalJumpMP();
 
         move.setText("Movement: " + walk + "/" + jump);
         movementPanel.add(move);
@@ -118,7 +119,7 @@ public class StatusBar extends ITab {
     }
 
     public JPanel bvPanel() {
-        int bv = getBattleArmor().calculateBattleValue();
+        final int bv = getBattleArmor().calculateBattleValue();
         bvLabel.setText("BV: " + bv);
         bvPanel.add(bvLabel);
 
@@ -133,12 +134,12 @@ public class StatusBar extends ITab {
 
     public void refresh() {
 
-        int walk = getBattleArmor().getOriginalWalkMP();
-        int jump = getBattleArmor().getOriginalJumpMP();
-        double maxKilos = getBattleArmor().getTrooperWeight();
+        final int walk = getBattleArmor().getOriginalWalkMP();
+        final int jump = getBattleArmor().getOriginalJumpMP();
+        final double maxKilos = getBattleArmor().getTrooperWeight();
         double currentKilos;
-        int bv = getBattleArmor().calculateBattleValue();
-        long currentCost = (long) Math.round(getBattleArmor().getCost(false));
+        final int bv = getBattleArmor().calculateBattleValue();
+        final long currentCost = (long) Math.round(getBattleArmor().getCost(false));
 
         testBA = new TestBattleArmor(getBattleArmor(), entityVerifier.baOption,
                 null);
@@ -152,7 +153,7 @@ public class StatusBar extends ITab {
         if (currentKilos > maxKilos) {
             tons.setForeground(Color.red);
         } else {
-            tons.setForeground(Color.black);
+            tons.setForeground(UIManager.getColor("Label.foreground"));
         }
 
         bvLabel.setText("BV: " + bv);
@@ -166,7 +167,7 @@ public class StatusBar extends ITab {
     
     private void getFluffImage() {
         // copied from structureTab
-        FileDialog fDialog = new FileDialog(getParentFrame(), "Image Path",
+        final FileDialog fDialog = new FileDialog(getParentFrame(), "Image Path",
                 FileDialog.LOAD);
         fDialog.setDirectory(new File(ImageHelper.fluffPath).getAbsolutePath()
                 + File.separatorChar + ImageHelper.imageMech
@@ -193,7 +194,7 @@ public class StatusBar extends ITab {
         return parentFrame;
     }
     
-    public void addRefreshedListener(RefreshListener l) {
+    public void addRefreshedListener(final RefreshListener l) {
         refresh = l;
     }
 

--- a/src/megameklab/com/ui/Infantry/views/ArmorView.java
+++ b/src/megameklab/com/ui/Infantry/views/ArmorView.java
@@ -18,7 +18,6 @@ package megameklab.com.ui.Infantry.views;
 
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -47,6 +46,7 @@ import javax.swing.RowSorter;
 import javax.swing.SortOrder;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
@@ -255,7 +255,7 @@ public class ArmorView extends IView implements ActionListener, ChangeListener {
         customView.add(armorValue, gbc);
         JFormattedTextField tf = ((JSpinner.DefaultEditor)armorValue.getEditor()).getTextField();
         tf.setEditable(false);
-        tf.setBackground(Color.white);
+        tf.setBackground(UIManager.getColor("TextField.background"));
         
         chEncumber.setText("Encumbering");
         gbc.gridx = 0;

--- a/src/megameklab/com/ui/Infantry/views/SpecializationView.java
+++ b/src/megameklab/com/ui/Infantry/views/SpecializationView.java
@@ -286,8 +286,6 @@ public class SpecializationView extends IView implements TableModelListener {
                     int column) {
                 super.getTableCellRendererComponent(table, value, isSelected,
                         hasFocus, row, column);
-                setOpaque(true);
-                // setFont(new Font("Arial", Font.PLAIN, 12));
                 int actualCol = table.convertColumnIndexToModel(column);
                 int actualRow = table.convertRowIndexToModel(row);
                 setHorizontalAlignment(getAlignment(actualCol));

--- a/src/megameklab/com/ui/Mek/MainUI.java
+++ b/src/megameklab/com/ui/Mek/MainUI.java
@@ -223,14 +223,6 @@ public class MainUI extends MegaMekLabMainUI {
 
         String title = getEntity().getChassis() + " " + getEntity().getModel()
                 + ".mtf";
-        /*  
-        if (UnitUtil.validateUnit(entity).length() > 0) {
-            title += "  (Invalid)";
-            setForeground(Color.red);
-        } else {
-            setForeground(Color.BLACK);
-        }
-        */
         setTitle(title);
 
     }

--- a/src/megameklab/com/ui/Mek/StatusBar.java
+++ b/src/megameklab/com/ui/Mek/StatusBar.java
@@ -27,6 +27,7 @@ import java.text.DecimalFormat;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.UIManager;
 
 import megamek.common.AmmoType;
 import megamek.common.Engine;
@@ -136,7 +137,7 @@ public class StatusBar extends ITab {
         if (totalHeat > heat) {
             heatSink.setForeground(Color.red);
         } else {
-            heatSink.setForeground(Color.black);
+            heatSink.setForeground(UIManager.getColor("Label.foreground"));
         }
 
         tons.setText("Tonnage: " + currentTonnage + "/" + tonnage);
@@ -144,7 +145,7 @@ public class StatusBar extends ITab {
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);
         } else {
-            tons.setForeground(Color.black);
+            tons.setForeground(UIManager.getColor("Label.foreground"));
         }
 
         bvLabel.setText("BV: " + bv);
@@ -156,7 +157,7 @@ public class StatusBar extends ITab {
         if(currentCrits > maxCrits) {
             crits.setForeground(Color.red);
         } else {
-            crits.setForeground(Color.BLACK);
+            crits.setForeground(UIManager.getColor("Label.foreground"));
         }
 
     }

--- a/src/megameklab/com/ui/StartupGUI.java
+++ b/src/megameklab/com/ui/StartupGUI.java
@@ -14,7 +14,6 @@
 package megameklab.com.ui;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.DisplayMode;
 import java.awt.FontMetrics;
@@ -35,6 +34,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.UIManager;
 
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.UnitSelectorDialog;
@@ -90,7 +90,7 @@ public class StartupGUI extends javax.swing.JPanel {
                 true);
         
         frame = new JFrame("MegaMekLab");
-        setBackground(Color.DARK_GRAY);
+        setBackground(UIManager.getColor("controlHighlight"));
         
         imgSplash = getToolkit().getImage(startupScreenImages.floorEntry((int)MegaMekLab.calculateMaxScreenWidth()).getValue());
         // wait for splash image to load completely

--- a/src/megameklab/com/ui/Vehicle/MainUI.java
+++ b/src/megameklab/com/ui/Vehicle/MainUI.java
@@ -22,13 +22,13 @@ import java.awt.Color;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 
 import megamek.common.Engine;
 import megamek.common.Entity;
 import megamek.common.EntityMovementMode;
 import megamek.common.EquipmentType;
 import megamek.common.ITechManager;
-import megamek.common.MechSummaryCache;
 import megamek.common.SimpleTechLevel;
 import megamek.common.SuperHeavyTank;
 import megamek.common.Tank;
@@ -139,7 +139,7 @@ public class MainUI extends MegaMekLabMainUI {
             title += "  (Invalid)";
             setForeground(Color.red);
         } else {
-            setForeground(Color.BLACK);
+            setForeground(UIManager.getColor("Label.foreground"));
         }
         setTitle(title);
     }

--- a/src/megameklab/com/ui/Vehicle/StatusBar.java
+++ b/src/megameklab/com/ui/Vehicle/StatusBar.java
@@ -28,6 +28,7 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.UIManager;
 
 import megamek.common.Tank;
 import megamek.common.verifier.EntityVerifier;
@@ -164,7 +165,7 @@ public class StatusBar extends ITab {
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);
         } else {
-            tons.setForeground(Color.black);
+            tons.setForeground(UIManager.getColor("Label.foreground"));
         }
         Tank tank = getTank();
         int currentSlots = tank.getTotalSlots() - tank.getFreeSlots();
@@ -172,7 +173,7 @@ public class StatusBar extends ITab {
         if (currentSlots > tank.getTotalSlots()) {
             slots.setForeground(Color.red);
         } else {
-            slots.setForeground(Color.black);
+            slots.setForeground(UIManager.getColor("Label.foreground"));
         }
 
         bvLabel.setText("BV: " + bv);

--- a/src/megameklab/com/ui/Vehicle/views/WeaponView.java
+++ b/src/megameklab/com/ui/Vehicle/views/WeaponView.java
@@ -43,6 +43,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SpringLayout;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 
 import megamek.common.AmmoType;
 import megamek.common.Entity;
@@ -194,8 +195,8 @@ public class WeaponView extends IView implements ActionListener, MouseListener, 
             tScrollPane.getVerticalScrollBar().setUnitIncrement(20);
             tScrollPane.setPreferredSize(size);
             tScrollPane.setMaximumSize(size);
-            tScrollPane.setBackground(Color.WHITE);
-            tPanels.get(tScrollPanes.indexOf(tScrollPane)).setBackground(Color.WHITE);
+            tScrollPane.setBackground(UIManager.getColor("ScrollPane.background"));
+            tPanels.get(tScrollPanes.indexOf(tScrollPane)).setBackground(UIManager.getColor("Panel.background"));
             tScrollPane.setViewportView(tPanels.get(tScrollPanes.indexOf(tScrollPane)));
         }
 

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
@@ -24,6 +24,7 @@ import java.text.DecimalFormat;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.UIManager;
 
 import megamek.common.AmmoType;
 import megamek.common.Entity;
@@ -118,7 +119,7 @@ public class AdvancedAeroStatusBar extends ITab {
         if (totalHeat > heat) {
             heatSink.setForeground(Color.red);
         } else {
-            heatSink.setForeground(Color.black);
+            heatSink.setForeground(UIManager.getColor("Label.foreground"));
         }
         heatSink.setVisible(getJumpship().getEntityType() == Entity.ETYPE_AERO);
 
@@ -129,8 +130,8 @@ public class AdvancedAeroStatusBar extends ITab {
             tons.setForeground(Color.red);
             remainingTons.setForeground(Color.red);
         } else {
-            tons.setForeground(Color.black);
-            remainingTons.setForeground(Color.black);
+            tons.setForeground(UIManager.getColor("Label.foreground"));
+            remainingTons.setForeground(UIManager.getColor("Label.foreground"));
         }
 
 

--- a/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
@@ -24,6 +24,7 @@ import java.text.DecimalFormat;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.UIManager;
 
 import megamek.common.AmmoType;
 import megamek.common.Entity;
@@ -116,7 +117,7 @@ public class DropshipStatusBar extends ITab {
         if (totalHeat > heat) {
             heatSink.setForeground(Color.red);
         } else {
-            heatSink.setForeground(Color.black);
+            heatSink.setForeground(UIManager.getColor("Label.foreground"));
         }
         heatSink.setVisible(getSmallCraft().getEntityType() == Entity.ETYPE_AERO);
 
@@ -125,7 +126,7 @@ public class DropshipStatusBar extends ITab {
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);
         } else {
-            tons.setForeground(Color.black);
+            tons.setForeground(UIManager.getColor("Label.foreground"));
         }
 
         bvLabel.setText("BV: " + bv);

--- a/src/megameklab/com/ui/protomek/ProtomekStatusBar.java
+++ b/src/megameklab/com/ui/protomek/ProtomekStatusBar.java
@@ -24,6 +24,7 @@ import java.text.DecimalFormat;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.UIManager;
 
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestProtomech;
@@ -113,7 +114,7 @@ public class ProtomekStatusBar extends ITab {
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);
         } else {
-            tons.setForeground(Color.black);
+            tons.setForeground(UIManager.getColor("Label.foreground"));
         }
 
         bvLabel.setText("BV: " + bv);
@@ -125,7 +126,7 @@ public class ProtomekStatusBar extends ITab {
         if(currentCrits > maxCrits) {
             crits.setForeground(Color.red);
         } else {
-            crits.setForeground(Color.BLACK);
+            crits.setForeground(UIManager.getColor("Label.foreground"));
         }
 
     }

--- a/src/megameklab/com/ui/supportvehicle/SVMainUI.java
+++ b/src/megameklab/com/ui/supportvehicle/SVMainUI.java
@@ -131,7 +131,7 @@ public class SVMainUI extends MegaMekLabMainUI {
             title += "  (Invalid)";
             setForeground(Color.red);
         } else {
-            setForeground(Color.BLACK);
+            setForeground(UIManager.getColor("Label.foreground"));
         }
         setTitle(title);
     }

--- a/src/megameklab/com/ui/supportvehicle/SVStatusBar.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStatusBar.java
@@ -142,7 +142,7 @@ class SVStatusBar extends ITab {
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);
         } else {
-            tons.setForeground(Color.black);
+            tons.setForeground(UIManager.getColor("Label.foreground"));
         }
 
         final int totalSlots = testEntity.totalSlotCount();
@@ -151,7 +151,7 @@ class SVStatusBar extends ITab {
         if (currentSlots > totalSlots) {
             slots.setForeground(Color.red);
         } else {
-            slots.setForeground(Color.black);
+            slots.setForeground(UIManager.getColor("Label.foreground"));
         }
 
         bvLabel.setText("BV: " + bv);

--- a/src/megameklab/com/ui/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/tabs/EquipmentTab.java
@@ -920,10 +920,6 @@ public class EquipmentTab extends ITab implements ActionListener {
     private static class CategoryListCellRenderer extends JLabel implements ListCellRenderer<EquipmentCategory> {
         private static final long serialVersionUID = -6019108605730297067L;
         
-        CategoryListCellRenderer() {
-            setOpaque(true);
-        }
-
         @Override
         public Component getListCellRendererComponent(JList<? extends EquipmentCategory> list,
                 EquipmentCategory value, int index, boolean isSelected, boolean cellHasFocus) {

--- a/src/megameklab/com/ui/tabs/PreviewTab.java
+++ b/src/megameklab/com/ui/tabs/PreviewTab.java
@@ -17,9 +17,9 @@
 package megameklab.com.ui.tabs;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 
 import javax.swing.JTabbedPane;
+import javax.swing.UIManager;
 
 import megamek.client.ui.swing.MechViewPanel;
 import megamek.common.Entity;
@@ -52,7 +52,7 @@ public class PreviewTab extends ITab {
         panPreview.addTab("TRO", panelTROView);
 
         add(panPreview, BorderLayout.CENTER);
-        setBackground(Color.WHITE);
+        setBackground(UIManager.getColor("TabbedPane.background"));
         refresh();
 	}
 	

--- a/src/megameklab/com/ui/view/ArmorAllocationView.java
+++ b/src/megameklab/com/ui/view/ArmorAllocationView.java
@@ -28,6 +28,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 
 import megamek.common.*;
 import megamek.common.util.EncodeControl;
@@ -252,7 +253,7 @@ public class ArmorAllocationView extends BuildView implements
         if (armorPoints != currentPoints) {
             txtUnallocated.setForeground(Color.RED);
         } else {
-            txtUnallocated.setForeground(Color.BLACK);
+            txtUnallocated.setForeground(UIManager.getColor("Label.foreground"));
         }
         txtTotal.setText(String.valueOf(armorPoints));
         txtMaxPossible.setText(String.valueOf(maxArmorPoints));

--- a/src/megameklab/com/util/CriticalTableModel.java
+++ b/src/megameklab/com/util/CriticalTableModel.java
@@ -227,7 +227,6 @@ public class CriticalTableModel extends AbstractTableModel {
             JLabel c = (JLabel) super.getTableCellRendererComponent(table,
                     value, isSelected, hasFocus, row, column);
             
-            c.setOpaque(true);
             if ((crits.size() < row) || (row < 0)) {
                 return c;
             }

--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 
@@ -500,16 +501,14 @@ public class EquipmentTableModel extends AbstractTableModel {
                 int column) {
             super.getTableCellRendererComponent(table, value, isSelected,
                     hasFocus, row, column);
-            setOpaque(true);
-            // setFont(new Font("Arial", Font.PLAIN, 12));
             int actualCol = table.convertColumnIndexToModel(column);
             int actualRow = table.convertRowIndexToModel(row);
             setHorizontalAlignment(getAlignment(actualCol));
             EquipmentType etype = ((EquipmentTableModel) table.getModel()).getType(actualRow);
             if (null != techManager && !techManager.isLegal(etype)) {
-                setForeground(Color.gray);
+                setForeground(UIManager.getColor("Label.disabledForeground"));
             } else {
-                setForeground(Color.black);
+                setForeground(UIManager.getColor("Label.foreground"));
             }
             return this;
         }


### PR DESCRIPTION
This expands the theme support in MML to support dark themes and reworks most of the underlying controls to be look-less to ensure they display correctly under each theme. This isn't 100% perfect, but pretty close for an hour of work.
![image](https://user-images.githubusercontent.com/8238690/74108456-af5c1f00-4b48-11ea-9b11-a801a31c96e1.png)
![image](https://user-images.githubusercontent.com/8238690/74108488-e2061780-4b48-11ea-82cd-3aec6390e90c.png)
![image](https://user-images.githubusercontent.com/8238690/74108475-c864d000-4b48-11ea-8df0-cd2b7b5451c1.png)
![image](https://user-images.githubusercontent.com/8238690/74108478-cdc21a80-4b48-11ea-8efe-0375e1f58046.png)
