### PR TITLE
Prototype double heat sinks

### DIFF
--- a/resources/megameklab/resources/Views.properties
+++ b/resources/megameklab/resources/Views.properties
@@ -211,6 +211,9 @@ HeatSinkView.spnCount.text=Number:
 HeatSinkView.spnCount.tooltip=The total number of heat sinks on the unit. Some heat sinks are integral to fusion (10), fission (5), and fuel cell engines (1) at no additional weight.
 HeatSinkView.spnBaseCount.text=Base (Omni):
 HeatSinkView.spnBaseCount.tooltip=The number of heat sinks that are part of the base chassis configuration.
+HeatSinkView.spnPrototypeCount.text=Double:
+HeatSinkView.spnPrototypeCount.tooltip=<html>Prototype double heat sinks can be mixed with single heat sinks on the same unit.<br/>\
+  The engine's slot-free capacity may only be applied to the single heat sinks.
 HeatSinkView.lblCritFree.text=Engine Free:
 HeatSinkView.lblCritFree.tooltip=<html>These heat sinks are an integral part of the engine and do not have to be assigned critical space.<br/>Omni units must assign critical space to any pod-mounted heat sinks even if they would be part of the engine in standard Mechs.</html>
 HeatSinkView.lblWeightFree.text=Weight Free:

--- a/resources/megameklab/resources/Views.properties
+++ b/resources/megameklab/resources/Views.properties
@@ -204,7 +204,7 @@ BAChassisView.chkHarjel.text=Harjel
 BAChassisView.chkHarjel.tooltip=Clan exoskeletons may be constructed with a lighter chassis that does not include Harjel.
 
 HeatSinkView.mechNames.values=Single,IS Double,Clan Double,Compact,Laser,Double (Prototype),Double(Freezer)
-HeatSinkView.aeroNames.values=Single,Double
+HeatSinkView.aeroNames.values=Single,Double,Double (Prototype)
 HeatSinkView.cbHSType.text=Type:
 HeatSinkView.cbHSType.tooltip=Type determines weight, space, and heat dissipation abilities. All heat sinks on the unit must be of the same type.
 HeatSinkView.spnCount.text=Number:

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -680,8 +680,9 @@ public class PrintMech extends PrintEntity {
     
     private String formatHeatSinkCount() {
         int hsCount = mech.heatSinks();
-        if (mech.hasDoubleHeatSinks()) {
-            return String.format("%d (%d)", hsCount, hsCount * 2);
+        int capacity = mech.getHeatCapacity(false, false);
+        if (hsCount != capacity) {
+            return String.format("%d (%d)", hsCount, capacity);
         } else {
             return Integer.toString(hsCount);
         }

--- a/src/megameklab/com/ui/Aero/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/StructureTab.java
@@ -361,11 +361,15 @@ public class StructureTab extends ITab implements AeroBuildListener, ArmorAlloca
         }
         panChassis.refresh();
         panHeat.refresh();
+        heatSinksChanged(panHeat.getHeatSinkIndex(), panHeat.getCount());
         panArmor.refresh();
         panMovement.refresh();
         panArmorAllocation.setFromEntity(getAero());
         panPatchwork.setFromEntity(getAero());
         addAllListeners();
+        panSummary.refresh();
+        refresh.refreshStatus();
+        refresh.refreshPreview();
     }
 
     @Override

--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -211,8 +211,13 @@ public class BuildView extends IView implements ActionListener, MouseListener {
 
     private boolean isEngineHeatSink(Mounted mount) {
         if ((mount.getLocation() == Entity.LOC_NONE) && UnitUtil.isHeatSink(mount) && (engineHeatSinkCount > 0)) {
-            if(mount.getType().hasFlag(MiscType.F_COMPACT_HEAT_SINK) && mount.getType().hasFlag(MiscType.F_DOUBLE_HEAT_SINK)) {
+            if (mount.getType().hasFlag(MiscType.F_COMPACT_HEAT_SINK)
+                    && mount.getType().hasFlag(MiscType.F_DOUBLE_HEAT_SINK)) {
                 //only single compact HS should be used for engine sinks
+                return false;
+            }
+            // Prototype double heat sinks cannot be used for engine sinks
+            if (mount.getType().hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)) {
                 return false;
             }
             engineHeatSinkCount--;

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
@@ -288,9 +288,12 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
         panChassis.setFromEntity(getJumpship());
         panArmor.refresh();
         panHeat.setFromAero(getJumpship());
+        heatSinksChanged(panHeat.getHeatSinkIndex(), panHeat.getCount());
         panArmorAllocation.setFromEntity(getJumpship());
         panSummary.refresh();
         refresh.refreshTransport();
+        refresh.refreshStatus();
+        refresh.refreshPreview();
     }
 
     @Override

--- a/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
@@ -278,9 +278,12 @@ public class DropshipStructureTab extends ITab implements DropshipBuildListener,
         }
         panArmor.refresh();
         panHeat.setFromAero(getSmallCraft());
+        heatSinksChanged(panHeat.getHeatSinkIndex(), panHeat.getCount());
         panArmorAllocation.setFromEntity(getSmallCraft());
         panSummary.refresh();
         refresh.refreshTransport();
+        refresh.refreshStatus();
+        refresh.refreshPreview();
     }
 
     @Override

--- a/src/megameklab/com/ui/view/HeatSinkView.java
+++ b/src/megameklab/com/ui/view/HeatSinkView.java
@@ -29,12 +29,7 @@ import javax.swing.SpinnerNumberModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import megamek.common.Aero;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.Mech;
-import megamek.common.Mounted;
+import megamek.common.*;
 import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestAero;
 import megameklab.com.ui.util.CustomComboBox;
@@ -72,14 +67,15 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     public final static int TYPE_FREEZER     = 6;
     
     private final static String[] LOOKUP_NAMES = {
-            "Heat Sink", "ISDoubleHeatSink", "CLDoubleHeatSink", "IS1 Compact Heat Sink",
-            "CLLaser Heat Sink", "ISDoubleHeatSinkPrototype", "ISDoubleHeatSinkFreezer"
+            EquipmentTypeLookup.SINGLE_HS, EquipmentTypeLookup.IS_DOUBLE_HS,
+            EquipmentTypeLookup.CLAN_DOUBLE_HS, EquipmentTypeLookup.COMPACT_HS_1,
+            EquipmentTypeLookup.IS_DOUBLE_HS_PROTOTYPE, EquipmentTypeLookup.IS_DOUBLE_HS_FREEZER
     };
     private final List<EquipmentType> heatSinks;
     private String[] mechDisplayNames;
     private String[] aeroDisplayNames;
 
-    private final CustomComboBox<Integer> cbHSType = new CustomComboBox<>(i -> getDisplayName(i));
+    private final CustomComboBox<Integer> cbHSType = new CustomComboBox<>(this::getDisplayName);
     private final JSpinner spnCount = new JSpinner();
     private final JLabel lblBaseCount = new JLabel();
     private final JSpinner spnBaseCount = new JSpinner();
@@ -90,7 +86,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     
     private SpinnerNumberModel countModel = new SpinnerNumberModel(0, 0, null, 1);
     private SpinnerNumberModel baseCountModel = new SpinnerNumberModel(0, 0, null, 1);
-    
+
     private final ITechManager techManager;
     private boolean isAero;
     private boolean isPrimitive;
@@ -176,7 +172,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         isPrimitive = mech.isPrimitive();
         refresh();
         Optional<EquipmentType> hs = mech.getMisc().stream().map(Mounted::getType)
-                .filter(et -> UnitUtil.isHeatSink(et)).findAny();
+                .filter(UnitUtil::isHeatSink).findAny();
         if (hs.isPresent()) {
             cbHSType.removeActionListener(this);
             setHeatSinkType(hs.get());
@@ -250,7 +246,10 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     }
     
     public int getHeatSinkIndex() {
-        return (Integer)cbHSType.getSelectedItem();
+        if (cbHSType.getSelectedItem() != null) {
+            return (Integer) cbHSType.getSelectedItem();
+        }
+        return 0;
     }
     
     public void setHeatSinkIndex(int index) {

--- a/src/megameklab/com/ui/view/HeatSinkView.java
+++ b/src/megameklab/com/ui/view/HeatSinkView.java
@@ -313,7 +313,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     }
 
     /**
-     * @return The number of heat sinks out of the total that are single heat sinks instead of the main type.
+     * @return The number of heat sinks out of the total that are prototype double heat sinks.
      */
     public int getPrototypeCount() {
         if (hasPrototypeDoubles) {

--- a/src/megameklab/com/ui/view/listeners/BuildListener.java
+++ b/src/megameklab/com/ui/view/listeners/BuildListener.java
@@ -16,6 +16,7 @@ package megameklab.com.ui.view.listeners;
 import megamek.common.EquipmentType;
 import megamek.common.FuelType;
 import megamek.common.SimpleTechLevel;
+import megameklab.com.ui.view.HeatSinkView;
 
 /**
  * Combined listener interface for the various subviews of the structure tab. Includes callbacks
@@ -45,8 +46,31 @@ public interface BuildListener {
      * ignore them.
      */
 
+    /**
+     * Notifies of a change in heat sink type or count for aerospace units
+     * @param index Either {@link HeatSinkView#TYPE_SINGLE} or {@link HeatSinkView#TYPE_DOUBLE_AERO}
+     * @param count The number of heat sinks
+     */
     default void heatSinksChanged(int index, int count) {};
+
+    /**
+     * Notifies of a change in heat sink type or count for mechs
+     * @param hsType        The type of heat sink
+     * @param count         The total number of heat sinks
+     */
     default void heatSinksChanged(EquipmentType hsType, int count) {};
+
+    /**
+     * Notifies of a change in the distribution between single and double heat sinks on a unit with
+     * prototype double heat sinks.
+     * @param prototype  The number of prototype double heat sinks
+     */
+    default void redistributePrototypeHS(int prototype) {};
+
+    /**
+     * Notifies of a change in the number of heat sinks that are part of the base chassis of an omni unit
+     * @param count The number of fixed heat sinks
+     */
     default void heatSinkBaseCountChanged(int count) {};
 
     // For aerospace units and support vehicles

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -917,13 +917,14 @@ public class UnitUtil {
      */
     public static void updateAutoSinks(Mech unit, boolean compact) {
         int base = UnitUtil.getCriticalFreeHeatSinks(unit, compact);
-        Vector<Mounted> unassigned = new Vector<Mounted>();
-        Vector<Mounted> assigned = new Vector<Mounted>();
+        List<Mounted> unassigned = new ArrayList<>();
+        List<Mounted> assigned = new ArrayList<>();
         for (Mounted m : unit.getMisc()) {
             if (UnitUtil.isHeatSink(m)) {
                 if (m.getLocation() == Entity.LOC_NONE) {
                     unassigned.add(m);
-                } else {
+                } else if (!m.getType().hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)) {
+                    // Prototype double heat sinks can never be integrated into the engine
                     assigned.add(m);
                 }
             }


### PR DESCRIPTION
For Mechs: adds a spinner to the heat sink view, visible when either prototype double heat sink option is selected, to indicate how many of the installed heat sinks are prototype doubles. The function of the main spinner remains the same, to select the total number of heat sinks. Prototype doubles must always be assigned to critical slots, regardless of the capacity of the engine for slot-free heat sinks.

For aerospace units that use heat sinks: MM does not have a way as this time to split heat sinks between singles and prototype doubles. Unless or until such support is added, the heat sink view does performs a parlor trick to make prototype doubles available when the year and tech level allows them but not true doubles, but the Aero itself treats them like any other double heat sink.

While working on aerospace heat sinks I noticed that a change in year or tech level that makes the current heat sink type unavailable does not update the unit, and I fixed that as well.

Fixes #438