### PR TITLE
Include tripod center leg when expanding spreadable equipment mounts.

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1772,7 +1772,7 @@ public class UnitUtil {
      * @param unit
      */
     public static void expandUnitMounts(Mech unit) {
-        for (int location = 0; location <= Mech.LOC_LLEG; location++) {
+        for (int location = 0; location <= unit.locations(); location++) {
             for (int slot = 0; slot < unit.getNumberOfCriticals(location); slot++) {
                 CriticalSlot cs = unit.getCritical(location, slot);
                 if ((cs == null) || (cs.getType() == CriticalSlot.TYPE_SYSTEM)) {


### PR DESCRIPTION
It took me over an hour to hunt this down. When a mech is loaded into MML the spreadable mounts (endo-steel, TSM, etc) get reworked from a single mount linked from multiple slots to multiple single-slot mounts so they can be reallocated. The loop that does this assumes that the left leg is the last location, so any spreadable equipment in the center leg gets removed from the equipment list, leaving the critical slot in the leg pointing to an orphaned mount.

Fixes #430