### PR TITLE
Filter vehicle equipment tables by motive type

### DIFF
--- a/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
@@ -584,7 +584,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                     return false;
                 }
                 BattleArmor ba = getBattleArmor();
-                if (((nType == T_OTHER) && UnitUtil.isUnitEquipment(etype, ba))
+                if (((nType == T_OTHER) && UnitUtil.isBAEquipment(etype, ba))
                         || (((nType == T_WEAPON) && (UnitUtil.isUnitWeapon(etype, ba))))
                         || ((nType == T_ENERGY) && UnitUtil.isUnitWeapon(etype, ba)
                             && (wtype != null) && (wtype.hasFlag(WeaponType.F_ENERGY)

--- a/src/megameklab/com/ui/BattleArmor/views/EquipmentView.java
+++ b/src/megameklab/com/ui/BattleArmor/views/EquipmentView.java
@@ -117,7 +117,7 @@ public class EquipmentView extends IView implements ActionListener {
         while (miscTypes.hasMoreElements()) {
             EquipmentType eq = miscTypes.nextElement();
 
-            if (UnitUtil.isUnitEquipment(eq, eSource.getEntity())) {
+            if (UnitUtil.isBAEquipment(eq, getBattleArmor())) {
                 masterEquipmentList.add(eq);
             }
         }
@@ -156,7 +156,7 @@ public class EquipmentView extends IView implements ActionListener {
             if (UnitUtil.isArmorOrStructure(mount.getType())) {
                 continue;
             }
-            if (UnitUtil.isUnitEquipment(mount.getType(), getBattleArmor())) {
+            if (UnitUtil.isBAEquipment(mount.getType(), getBattleArmor())) {
                 equipmentList.addCrit(mount);
             }
         }

--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -563,7 +563,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                                         && !etype.hasSubType(MiscType.S_JETBOOSTER)))) {
                     return false;
                 }
-                if (((nType == T_OTHER) && UnitUtil.isTankEquipment(etype, tank instanceof VTOL))
+                if (((nType == T_OTHER) && UnitUtil.isTankEquipment(etype, tank.getMovementMode()))
                         || (((nType == T_WEAPON) && (UnitUtil.isTankWeapon(etype, tank))))
                         || ((nType == T_ENERGY) && UnitUtil.isTankWeapon(etype, tank)
                             && (wtype != null) && (wtype.hasFlag(WeaponType.F_ENERGY)

--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -563,8 +563,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                                         && !etype.hasSubType(MiscType.S_JETBOOSTER)))) {
                     return false;
                 }
-                if (((nType == T_OTHER) && UnitUtil.isTankEquipment(etype, tank)
-                            && !UnitUtil.isTankWeapon(etype, tank))
+                if (((nType == T_OTHER) && UnitUtil.isTankMiscEquipment(etype, tank))
                         || (((nType == T_WEAPON) && (UnitUtil.isTankWeapon(etype, tank))))
                         || ((nType == T_ENERGY) && UnitUtil.isTankWeapon(etype, tank)
                             && (wtype != null) && (wtype.hasFlag(WeaponType.F_ENERGY)

--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -563,7 +563,8 @@ public class EquipmentTab extends ITab implements ActionListener {
                                         && !etype.hasSubType(MiscType.S_JETBOOSTER)))) {
                     return false;
                 }
-                if (((nType == T_OTHER) && UnitUtil.isTankEquipment(etype, tank.getMovementMode()))
+                if (((nType == T_OTHER) && UnitUtil.isTankEquipment(etype, tank)
+                            && !UnitUtil.isTankWeapon(etype, tank))
                         || (((nType == T_WEAPON) && (UnitUtil.isTankWeapon(etype, tank))))
                         || ((nType == T_ENERGY) && UnitUtil.isTankWeapon(etype, tank)
                             && (wtype != null) && (wtype.hasFlag(WeaponType.F_ENERGY)

--- a/src/megameklab/com/ui/Vehicle/views/EquipmentView.java
+++ b/src/megameklab/com/ui/Vehicle/views/EquipmentView.java
@@ -109,7 +109,7 @@ public class EquipmentView extends IView implements ActionListener {
         while (miscTypes.hasMoreElements()) {
             EquipmentType eq = miscTypes.nextElement();
 
-            if (UnitUtil.isUnitEquipment(eq, eSource.getEntity())) {
+            if (UnitUtil.isTankEquipment(eq, getTank())) {
                 masterEquipmentList.add(eq);
             }
         }
@@ -146,7 +146,7 @@ public class EquipmentView extends IView implements ActionListener {
             if (UnitUtil.isHeatSink(mount) || UnitUtil.isArmorOrStructure(mount.getType())) {
                 continue;
             }
-            if (UnitUtil.isUnitEquipment(mount.getType(), getTank())) {
+            if (UnitUtil.isTankEquipment(mount.getType(), getTank())) {
                 equipmentList.addCrit(mount);
             }
         }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2847,6 +2847,10 @@ public class UnitUtil {
         if (eq instanceof InfantryWeapon) {
             return false;
         }
+        // Some weapons such as TAG and C3M should show as non-weapon equipment
+        if (isTankMiscEquipment(eq, unit)) {
+            return false;
+        }
 
         if (eq instanceof WeaponType) {
 
@@ -2992,8 +2996,25 @@ public class UnitUtil {
         return eq instanceof InfantryWeapon;
     }
 
+    /**
+     * Tests whether equipment should be shown on the equipment tab for the unit. This is
+     * used for both combat vehicles and non-aerospace support vehicles.
+     * @param eq   The equipment to show
+     * @param tank The tank
+     * @return     Whether the equipment should show on the table
+     */
     public static boolean isTankEquipment(EquipmentType eq, Tank tank) {
+        return isTankMiscEquipment(eq, tank) || isTankWeapon(eq, tank);
+    }
 
+    /**
+     * Tests whether equipment should be shown on the equipment tab for the unit as non-weapon
+     * equipment. This is used for both combat vehicles and non-aerospace support vehicles.
+     * @param eq   The equipment to show
+     * @param tank The tank
+     * @return     Whether the equipment should show on the table
+     */
+    public static boolean isTankMiscEquipment(EquipmentType eq, Entity tank) {
         if (UnitUtil.isArmorOrStructure(eq)) {
             return false;
         }
@@ -3011,29 +3032,18 @@ public class UnitUtil {
         }
 
         if (eq instanceof MiscType) {
-            return (eq.hasFlag(MiscType.F_TANK_EQUIPMENT)
-                        || (eq.hasFlag(MiscType.F_VTOL_EQUIPMENT) && (tank instanceof VTOL)))
-                    && TestTank.legalForMotiveType(eq, tank.getMovementMode());
+            if (!TestTank.legalForMotiveType(eq, tank.getMovementMode())) {
+                return false;
+            }
+            if (eq.hasFlag(MiscType.F_VTOL_EQUIPMENT) && (tank instanceof VTOL)) {
+                return true;
+            }
+            if (tank.isSupportVehicle()) {
+                return eq.hasFlag(MiscType.F_SUPPORT_TANK_EQUIPMENT);
+            } else {
+                return eq.hasFlag(MiscType.F_TANK_EQUIPMENT);
+            }
         }
-
-        return isTankWeapon(eq, tank);
-    }
-
-    public static boolean isBattleArmorEquipment(EquipmentType eq) {
-
-        if (UnitUtil.isArmorOrStructure(eq)) {
-            return false;
-        }
-
-        if ((eq instanceof CLBALightTAG) || (eq instanceof ISBALightTAG)) {
-            return true;
-        }
-
-        if ((eq instanceof MiscType) && eq.hasFlag(MiscType.F_BA_EQUIPMENT)) {
-            return true;
-
-        }
-
         return false;
     }
 

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2542,7 +2542,7 @@ public class UnitUtil {
     @Deprecated
     public static boolean isUnitEquipment(EquipmentType eq, Entity unit) {
         if (unit instanceof Tank) {
-            return UnitUtil.isTankEquipment(eq, unit.getMovementMode());
+            return UnitUtil.isTankEquipment(eq, (Tank) unit);
         }
 
         if (unit instanceof BattleArmor) {
@@ -2860,20 +2860,6 @@ public class UnitUtil {
         return true;
     }
     
-    public static boolean isTankEquipment(EquipmentType eq, Tank tank) {
-        if (eq instanceof MiscType) {
-            if (tank.hasETypeFlag(Entity.ETYPE_VTOL)){
-                return eq.hasFlag(MiscType.F_TANK_EQUIPMENT)
-                        || eq.hasFlag(MiscType.F_VTOL_EQUIPMENT);
-            } else {
-                return eq.hasFlag(MiscType.F_TANK_EQUIPMENT);
-            } 
-        } else if (eq instanceof WeaponType) {
-            return isTankWeapon(eq, tank);
-        }
-        return true;
-    }
-
     public static boolean isTankWeapon(EquipmentType eq, Entity unit) {
         if (eq instanceof InfantryWeapon) {
             return false;
@@ -3022,7 +3008,7 @@ public class UnitUtil {
         return eq instanceof InfantryWeapon;
     }
 
-    public static boolean isTankEquipment(EquipmentType eq, EntityMovementMode mode) {
+    public static boolean isTankEquipment(EquipmentType eq, Tank tank) {
 
         if (UnitUtil.isArmorOrStructure(eq)) {
             return false;
@@ -3047,6 +3033,7 @@ public class UnitUtil {
         }
 
         if (eq instanceof MiscType) {
+            final EntityMovementMode mode = tank.getMovementMode();
             if (eq.hasFlag(MiscType.F_FLOTATION_HULL)) {
                 // Per errata, WiGE vehicles automatically include flotation hull
                 return mode.equals(EntityMovementMode.HOVER) || mode.equals(EntityMovementMode.VTOL);
@@ -3058,15 +3045,17 @@ public class UnitUtil {
                 return mode.equals(EntityMovementMode.WHEELED);
             }
             if (eq.hasFlag(MiscType.F_LIFEBOAT)) {
-                return mode.equals(EntityMovementMode.NAVAL)
+                // Need to filter out atmospheric lifeboat
+                return eq.hasFlag(MiscType.F_TANK_EQUIPMENT)
+                    && (mode.equals(EntityMovementMode.NAVAL)
                         || mode.equals(EntityMovementMode.HYDROFOIL)
-                        || mode.equals(EntityMovementMode.SUBMARINE);
+                        || mode.equals(EntityMovementMode.SUBMARINE));
             }
             return eq.hasFlag(MiscType.F_TANK_EQUIPMENT)
                     || (eq.hasFlag(MiscType.F_VTOL_EQUIPMENT) && mode.equals(EntityMovementMode.VTOL));
         }
 
-        return false;
+        return isTankWeapon(eq, tank);
     }
 
     public static boolean isBattleArmorEquipment(EquipmentType eq) {

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2896,10 +2896,7 @@ public class UnitUtil {
                 }
             }
 
-            if (weapon.getAmmoType() == AmmoType.T_NAIL_RIVET_GUN) {
-                return !unit.getMovementMode().equals(EntityMovementMode.VTOL);
-            }
-            return true;
+            return TestTank.legalForMotiveType(weapon, unit.getMovementMode());
         }
         return false;
     }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -3051,6 +3051,17 @@ public class UnitUtil {
                 // Per errata, WiGE vehicles automatically include flotation hull
                 return mode.equals(EntityMovementMode.HOVER) || mode.equals(EntityMovementMode.VTOL);
             }
+            if (eq.hasFlag(MiscType.F_FULLY_AMPHIBIOUS) || eq.hasFlag(MiscType.F_LIMITED_AMPHIBIOUS)) {
+                return mode.equals(EntityMovementMode.WHEELED) || mode.equals(EntityMovementMode.TRACKED);
+            }
+            if (eq.hasFlag(MiscType.F_DUNE_BUGGY)) {
+                return mode.equals(EntityMovementMode.WHEELED);
+            }
+            if (eq.hasFlag(MiscType.F_LIFEBOAT)) {
+                return mode.equals(EntityMovementMode.NAVAL)
+                        || mode.equals(EntityMovementMode.HYDROFOIL)
+                        || mode.equals(EntityMovementMode.SUBMARINE);
+            }
             return eq.hasFlag(MiscType.F_TANK_EQUIPMENT)
                     || (eq.hasFlag(MiscType.F_VTOL_EQUIPMENT) && mode.equals(EntityMovementMode.VTOL));
         }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2535,23 +2535,6 @@ public class UnitUtil {
         return UnitUtil.isMechWeapon(eq, unit);
     }
 
-    /**
-     * @deprecated Use {@link #isEntityEquipment(EquipmentType, Entity)}
-     * There are two methods that do the same thing, but this one hasn't been updated.
-     */
-    @Deprecated
-    public static boolean isUnitEquipment(EquipmentType eq, Entity unit) {
-        if (unit instanceof Tank) {
-            return UnitUtil.isTankEquipment(eq, (Tank) unit);
-        }
-
-        if (unit instanceof BattleArmor) {
-            return UnitUtil.isBattleArmorEquipment(eq);
-        }
-
-        return UnitUtil.isMechEquipment(eq, (Mech) unit);
-    }
-
     public static boolean isMechWeapon(EquipmentType eq, Entity unit) {
         if (eq instanceof InfantryWeapon) {
             return false;
@@ -2912,6 +2895,10 @@ public class UnitUtil {
                     return false;
                 }
             }
+
+            if (weapon.getAmmoType() == AmmoType.T_NAIL_RIVET_GUN) {
+                return !unit.getMovementMode().equals(EntityMovementMode.VTOL);
+            }
             return true;
         }
         return false;
@@ -3014,12 +3001,6 @@ public class UnitUtil {
             return false;
         }
 
-        // Chassis modifications should be ignored, as they will be added
-        // via checkboxes, and not shown as equipment
-        //if (eq.hasFlag(MiscType.F_CHASSIS_MODIFICATION)) {
-        //    return false;
-        //}
-
         // Display AMS as equipment (even though it's a weapon)
         if (eq.hasFlag(WeaponType.F_AMS)
                 && eq.hasFlag(WeaponType.F_TANK_WEAPON)) {
@@ -3033,26 +3014,9 @@ public class UnitUtil {
         }
 
         if (eq instanceof MiscType) {
-            final EntityMovementMode mode = tank.getMovementMode();
-            if (eq.hasFlag(MiscType.F_FLOTATION_HULL)) {
-                // Per errata, WiGE vehicles automatically include flotation hull
-                return mode.equals(EntityMovementMode.HOVER) || mode.equals(EntityMovementMode.VTOL);
-            }
-            if (eq.hasFlag(MiscType.F_FULLY_AMPHIBIOUS) || eq.hasFlag(MiscType.F_LIMITED_AMPHIBIOUS)) {
-                return mode.equals(EntityMovementMode.WHEELED) || mode.equals(EntityMovementMode.TRACKED);
-            }
-            if (eq.hasFlag(MiscType.F_DUNE_BUGGY)) {
-                return mode.equals(EntityMovementMode.WHEELED);
-            }
-            if (eq.hasFlag(MiscType.F_LIFEBOAT)) {
-                // Need to filter out atmospheric lifeboat
-                return eq.hasFlag(MiscType.F_TANK_EQUIPMENT)
-                    && (mode.equals(EntityMovementMode.NAVAL)
-                        || mode.equals(EntityMovementMode.HYDROFOIL)
-                        || mode.equals(EntityMovementMode.SUBMARINE));
-            }
-            return eq.hasFlag(MiscType.F_TANK_EQUIPMENT)
-                    || (eq.hasFlag(MiscType.F_VTOL_EQUIPMENT) && mode.equals(EntityMovementMode.VTOL));
+            return (eq.hasFlag(MiscType.F_TANK_EQUIPMENT)
+                        || (eq.hasFlag(MiscType.F_VTOL_EQUIPMENT) && (tank instanceof VTOL)))
+                    && TestTank.legalForMotiveType(eq, tank.getMovementMode());
         }
 
         return isTankWeapon(eq, tank);

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2542,7 +2542,7 @@ public class UnitUtil {
     @Deprecated
     public static boolean isUnitEquipment(EquipmentType eq, Entity unit) {
         if (unit instanceof Tank) {
-            return UnitUtil.isTankEquipment(eq, unit instanceof VTOL);
+            return UnitUtil.isTankEquipment(eq, unit.getMovementMode());
         }
 
         if (unit instanceof BattleArmor) {
@@ -3022,7 +3022,7 @@ public class UnitUtil {
         return eq instanceof InfantryWeapon;
     }
 
-    public static boolean isTankEquipment(EquipmentType eq, boolean isVTOL) {
+    public static boolean isTankEquipment(EquipmentType eq, EntityMovementMode mode) {
 
         if (UnitUtil.isArmorOrStructure(eq)) {
             return false;
@@ -3046,13 +3046,13 @@ public class UnitUtil {
             return true;
         }
 
-        if ((eq instanceof MiscType) && eq.hasFlag(MiscType.F_TANK_EQUIPMENT)) {
-            return true;
-        }
-
-        if ((eq instanceof MiscType) && eq.hasFlag(MiscType.F_VTOL_EQUIPMENT)
-                && isVTOL) { // Mast Mount!
-            return true;
+        if (eq instanceof MiscType) {
+            if (eq.hasFlag(MiscType.F_FLOTATION_HULL)) {
+                // Per errata, WiGE vehicles automatically include flotation hull
+                return mode.equals(EntityMovementMode.HOVER) || mode.equals(EntityMovementMode.VTOL);
+            }
+            return eq.hasFlag(MiscType.F_TANK_EQUIPMENT)
+                    || (eq.hasFlag(MiscType.F_VTOL_EQUIPMENT) && mode.equals(EntityMovementMode.VTOL));
         }
 
         return false;


### PR DESCRIPTION
Improves filtering in the combat and support vehicle equipment tables to remove equipment that is ineligible based on motive type. Also removes deprecated, redundant, and/or conflicting methods from UnitUtil. Two of the files updated have line ending changes are best viewed with whitespace changes hidden.

Fixes #440 