### PR TITLE
Non-weapon equipment in pintle and sponson mounts

### DIFF
--- a/src/megameklab/com/util/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/DropTargetCriticalList.java
@@ -146,8 +146,7 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
                         }
                     });
                     popup.add(info);
-                    if ((mount.getType() instanceof WeaponType)
-                            && getUnit().hasWorkingMisc(MiscType.F_SPONSON_TURRET)
+                    if (getUnit().hasWorkingMisc(MiscType.F_SPONSON_TURRET)
                             && ((mount.getLocation() == Tank.LOC_LEFT) || (mount
                                     .getLocation() == Tank.LOC_RIGHT))) {
                         if (!mount.isSponsonTurretMounted()) {

--- a/src/megameklab/com/util/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/DropTargetCriticalList.java
@@ -170,8 +170,7 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
                             popup.add(info);
                         }
                     }
-                    if ((mount.getType() instanceof WeaponType)
-                            && getUnit().countWorkingMisc(MiscType.F_PINTLE_TURRET,
+                    if (getUnit().countWorkingMisc(MiscType.F_PINTLE_TURRET,
                                     mount.getLocation()) > 0) {
                         if (!mount.isPintleTurretMounted()) {
                             info = new JMenuItem("Mount " + mount.getName()


### PR DESCRIPTION
The rules for pintle mounts (TM, 234) say they can be used for any side-mounted equipment, and only forbid heavy weapons. Since pintle mounts are only available to small support vehicles and small SVs can't use heavy weapons, that restriction is applied implicitly. Less clear is what can be placed in a sponson turret mount (TO, 346, 348). The description says they are larger versions of the pintle mount, but the construction rules only refer to weapons. I thought it better to be less retrictive, since there are a few examples of weapon-like that are not implemented as weapons in MM, such as sprayers and spot welders.

Fixes #463 