### PR TITLE
Update unit tech advancement when preview refreshes.

### DIFF
--- a/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
@@ -476,6 +476,7 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
         }
         armorTypeChanged(panArmor.getArmor());
         addAllListeners();
+        refresh.refreshPreview();
     }
 
     @Override

--- a/src/megameklab/com/ui/Infantry/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Infantry/tabs/StructureTab.java
@@ -370,6 +370,7 @@ public class StructureTab extends ITab implements InfantryBuildListener {
         armorView.refresh();
         specializationView.refresh();
         augmentationView.refresh();
+        refresh.refreshPreview();
     }
 
     @Override

--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -665,6 +665,7 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
         panPatchwork.setFromEntity(getMech());
         refresh.refreshBuild();
         addAllListeners();
+        refresh.refreshPreview();
     }
 
     @Override

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -355,6 +355,7 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
         panArmorAllocation.setFromEntity(getTank());
         panPatchwork.setFromEntity(getTank());
         addAllListeners();
+        refresh.refreshPreview();
     }
 
     @Override

--- a/src/megameklab/com/ui/protomek/ProtomekStructureTab.java
+++ b/src/megameklab/com/ui/protomek/ProtomekStructureTab.java
@@ -372,6 +372,7 @@ public class ProtomekStructureTab extends ITab implements ProtomekBuildListener,
         panArmorAllocation.setFromEntity(getProtomech());
         refresh.refreshBuild();
         addAllListeners();
+        refresh.refreshPreview();
     }
 
     @Override

--- a/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
@@ -223,6 +223,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
         panChassisMod.setFromEntity(getSV());
         refresh.refreshArmor();
         refresh.refreshTransport();
+        refresh.refreshPreview();
     }
 
     @Override

--- a/src/megameklab/com/ui/tabs/PreviewTab.java
+++ b/src/megameklab/com/ui/tabs/PreviewTab.java
@@ -59,6 +59,7 @@ public class PreviewTab extends ITab {
 	public void refresh() {
 		boolean populateTextFields = true;
 		final Entity selectedUnit = eSource.getEntity();
+		selectedUnit.recalculateTechAdvancement();
         MechView mechView = null;
         TROView troView = null;
         try {
@@ -69,7 +70,7 @@ public class PreviewTab extends ITab {
             // error unit didn't load right. this is bad news.
             populateTextFields = false;
         }
-        if (populateTextFields && (mechView != null)) {
+        if (populateTextFields) {
             panelMekView.setMech(selectedUnit, mechView);
             panelTROView.setMech(selectedUnit, troView);
         } else {

--- a/src/megameklab/com/ui/tabs/PreviewTab.java
+++ b/src/megameklab/com/ui/tabs/PreviewTab.java
@@ -57,9 +57,9 @@ public class PreviewTab extends ITab {
 	}
 	
 	public void refresh() {
-		boolean populateTextFields = true;
-		final Entity selectedUnit = eSource.getEntity();
-		selectedUnit.recalculateTechAdvancement();
+        boolean populateTextFields = true;
+        final Entity selectedUnit = eSource.getEntity();
+        selectedUnit.recalculateTechAdvancement();
         MechView mechView = null;
         TROView troView = null;
         try {

--- a/src/megameklab/com/util/RefreshListener.java
+++ b/src/megameklab/com/util/RefreshListener.java
@@ -19,18 +19,18 @@ package megameklab.com.util;
 import java.util.EventListener;
 
 public interface RefreshListener extends EventListener{
-    public void refreshHeader();
-    public void refreshStatus();
-    public void refreshAll();
-    public void refreshStructure();
-    public void refreshArmor();
-    public void refreshWeapons();
-    public void refreshEquipment();
-    public void refreshTransport();
-    public void refreshBuild();
-    public void refreshPreview();
+    void refreshHeader();
+    void refreshStatus();
+    void refreshAll();
+    void refreshStructure();
+    void refreshArmor();
+    void refreshWeapons();
+    void refreshEquipment();
+    void refreshTransport();
+    void refreshBuild();
+    void refreshPreview();
 
     // Refreshers for just one thing on a tab
-    public void refreshSummary();
-    public void refreshEquipmentTable();
+    void refreshSummary();
+    void refreshEquipmentTable();
 }


### PR DESCRIPTION
Recalculate the composite tech advancement and availability codes for the unit based on parts and construction options. Add a preview refresh when tech base/tech level/year changes for those unit types that don't already do it.

Fixes #466