### PR TITLE
Add "invalid" indicator to status bar

### DIFF
--- a/src/megameklab/com/ui/Aero/StatusBar.java
+++ b/src/megameklab/com/ui/Aero/StatusBar.java
@@ -43,22 +43,18 @@ import megameklab.com.util.UnitUtil;
 
 public class StatusBar extends ITab {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -6754327753693500675L;
 
-    private JButton btnValidate = new JButton("Validate Unit");
-    private JButton btnFluffImage = new JButton("Set Fluff Image");
-    private JLabel bvLabel = new JLabel();
-    private JLabel tons = new JLabel();
-    private JLabel heatSink = new JLabel();
-    private JLabel cost = new JLabel();
-    private EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
+    private final JLabel bvLabel = new JLabel();
+    private final JLabel tons = new JLabel();
+    private final JLabel heatSink = new JLabel();
+    private final JLabel cost = new JLabel();
+    private final JLabel invalid = new JLabel();
+    private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
             "data/mechfiles/UnitVerifierOptions.xml"));
-    private TestAero testAero = null;
-    private DecimalFormat formatter;
-    private JFrame parentFrame;
+    private TestAero testAero;
+    private final DecimalFormat formatter;
+    private final JFrame parentFrame;
 
     private RefreshListener refresh;
 
@@ -68,17 +64,13 @@ public class StatusBar extends ITab {
 
         formatter = new DecimalFormat();
         testAero = new TestAero(getAero(), entityVerifier.aeroOption, null);
-        btnValidate.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                UnitUtil.showValidation(getAero(), getParentFrame());
-            }
-        });
-        btnFluffImage.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                getFluffImage();
-            }
-        });
-        //btnFluffImage.setEnabled(false);
+        JButton btnValidate = new JButton("Validate Unit");
+        btnValidate.addActionListener(evt -> UnitUtil.showValidation(getAero(), getParentFrame()));
+        JButton btnFluffImage = new JButton("Set Fluff Image");
+        btnFluffImage.addActionListener(evt -> getFluffImage());
+        invalid.setText("Invalid");
+        invalid.setForeground(Color.RED);
+        invalid.setVisible(false);
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0;
@@ -95,6 +87,8 @@ public class StatusBar extends ITab {
         gbc.gridx = 4;
         this.add(bvLabel, gbc);
         gbc.gridx = 5;
+        this.add(invalid, gbc);
+        gbc.gridx = 6;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         this.add(cost, gbc);
@@ -104,12 +98,11 @@ public class StatusBar extends ITab {
     }
 
     public void refresh() {
-
         int heat = getAero().getHeatCapacity();
         double tonnage = getAero().getWeight();
         double currentTonnage;
         int bv = getAero().calculateBattleValue();
-        long currentCost = (long) Math.round(getAero().getCost(false));
+        long currentCost = Math.round(getAero().getCost(false));
 
         testAero = new TestAero(getAero(), entityVerifier.aeroOption, null);
 
@@ -139,6 +132,9 @@ public class StatusBar extends ITab {
         bvLabel.setToolTipText("BV 2.0");
 
         cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        StringBuffer sb = new StringBuffer();
+        invalid.setVisible(!testAero.correctEntity(sb));
+        invalid.setToolTipText(sb.toString());
     }
 
     public double calculateTotalHeat() {
@@ -205,12 +201,10 @@ public class StatusBar extends ITab {
             relativeFilePath = "."
                     + File.separatorChar
                     + relativeFilePath
-                            .substring(new File(System.getProperty("user.dir")
-                                    .toString()).getAbsolutePath().length() + 1);
+                            .substring(new File(System.getProperty("user.dir")).getAbsolutePath().length() + 1);
             getAero().getFluff().setMMLImagePath(relativeFilePath);
         }
         refresh.refreshPreview();
-        return;
     }
 
     private JFrame getParentFrame() {

--- a/src/megameklab/com/ui/Aero/StatusBar.java
+++ b/src/megameklab/com/ui/Aero/StatusBar.java
@@ -52,7 +52,6 @@ public class StatusBar extends ITab {
     private final JLabel invalid = new JLabel();
     private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
             "data/mechfiles/UnitVerifierOptions.xml"));
-    private TestAero testAero;
     private final DecimalFormat formatter;
     private final JFrame parentFrame;
 
@@ -63,7 +62,6 @@ public class StatusBar extends ITab {
         parentFrame = parent;
 
         formatter = new DecimalFormat();
-        testAero = new TestAero(getAero(), entityVerifier.aeroOption, null);
         JButton btnValidate = new JButton("Validate Unit");
         btnValidate.addActionListener(evt -> UnitUtil.showValidation(getAero(), getParentFrame()));
         JButton btnFluffImage = new JButton("Set Fluff Image");
@@ -104,7 +102,7 @@ public class StatusBar extends ITab {
         int bv = getAero().calculateBattleValue();
         long currentCost = Math.round(getAero().getCost(false));
 
-        testAero = new TestAero(getAero(), entityVerifier.aeroOption, null);
+        TestAero testAero = new TestAero(getAero(), entityVerifier.aeroOption, null);
 
         currentTonnage = testAero.calculateWeight();
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getAero());

--- a/src/megameklab/com/ui/BattleArmor/MainUI.java
+++ b/src/megameklab/com/ui/BattleArmor/MainUI.java
@@ -143,17 +143,7 @@ public class MainUI extends MegaMekLabMainUI {
 
     @Override
     public void refreshHeader() {
-
-        String title = getEntity().getChassis() + " " + getEntity().getModel() + ".blk";
-
-        if (UnitUtil.validateUnit(getEntity()).length() > 0) {
-            title += "  (Invalid)";
-            setForeground(Color.red);
-        } else {
-            setForeground(UIManager.getColor("Label.foreground"));
-        }
-        setTitle(title);
-
+        setTitle(getEntity().getChassis() + " " + getEntity().getModel() + ".blk");
     }
 
     @Override

--- a/src/megameklab/com/ui/BattleArmor/StatusBar.java
+++ b/src/megameklab/com/ui/BattleArmor/StatusBar.java
@@ -41,14 +41,8 @@ import megameklab.com.util.UnitUtil;
 
 public class StatusBar extends ITab {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -6754327753693500675L;
 
-    private final JButton btnValidate = new JButton("Validate Unit");
-    private final JButton btnFluffImage = new JButton("Set Fluff Image");
-    
     private final JPanel tonnagePanel = new JPanel();
     private final JPanel movementPanel = new JPanel();
     private final JPanel bvPanel = new JPanel();
@@ -57,31 +51,24 @@ public class StatusBar extends ITab {
     private final JLabel bvLabel = new JLabel();
     private final JLabel tons = new JLabel();
     private final JLabel cost = new JLabel();
-    
+    private final JLabel invalid = new JLabel();
     private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
             "data/mechfiles/UnitVerifierOptions.xml"));
-    
-    private TestBattleArmor testBA = null;
     private final DecimalFormat formatter;
-    private JFrame parentFrame;
+    private final JFrame parentFrame;
 
     private RefreshListener refresh;
     public StatusBar(final MegaMekLabMainUI parent) {
         super(parent);
-        
+        parentFrame = parent;
         formatter = new DecimalFormat();
-        btnValidate.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                UnitUtil.showValidation(getBattleArmor(), getParentFrame());
-            }
-        });
-        btnFluffImage.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                getFluffImage();
-            }
-        });
-        
-
+        JButton btnValidate = new JButton("Validate Unit");
+        btnValidate.addActionListener(evt -> UnitUtil.showValidation(getBattleArmor(), getParentFrame()));
+        JButton btnFluffImage = new JButton("Set Fluff Image");
+        btnFluffImage.addActionListener(evt -> getFluffImage());
+        invalid.setText("Invalid");
+        invalid.setForeground(Color.RED);
+        invalid.setVisible(false);
         setLayout(new GridBagLayout());
         this.add(movementPanel());
         this.add(bvPanel());
@@ -102,6 +89,8 @@ public class StatusBar extends ITab {
         gbc.gridx = 4;
         this.add(tonnagePanel, gbc);
         gbc.gridx = 5;
+        this.add(invalid, gbc);
+        gbc.gridx = 6;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         this.add(cost, gbc);
@@ -139,9 +128,9 @@ public class StatusBar extends ITab {
         final double maxKilos = getBattleArmor().getTrooperWeight();
         double currentKilos;
         final int bv = getBattleArmor().calculateBattleValue();
-        final long currentCost = (long) Math.round(getBattleArmor().getCost(false));
+        final long currentCost = Math.round(getBattleArmor().getCost(false));
 
-        testBA = new TestBattleArmor(getBattleArmor(), entityVerifier.baOption,
+        TestBattleArmor testBA = new TestBattleArmor(getBattleArmor(), entityVerifier.baOption,
                 null);
         currentKilos = testBA.calculateWeight(BattleArmor.LOC_SQUAD);
         currentKilos += UnitUtil.getUnallocatedAmmoTonnage(getBattleArmor());
@@ -163,6 +152,9 @@ public class StatusBar extends ITab {
         move.setToolTipText("Walk/Jump MP");
 
         cost.setText("Squad Cost: " + formatter.format(currentCost) + " C-bills");
+        StringBuffer sb = new StringBuffer();
+        invalid.setVisible(!testBA.correctEntity(sb));
+        invalid.setToolTipText(sb.toString());
     }
     
     private void getFluffImage() {
@@ -182,12 +174,10 @@ public class StatusBar extends ITab {
             relativeFilePath = "."
                     + File.separatorChar
                     + relativeFilePath
-                            .substring(new File(System.getProperty("user.dir")
-                                    .toString()).getAbsolutePath().length() + 1);
+                            .substring(new File(System.getProperty("user.dir")).getAbsolutePath().length() + 1);
             getBattleArmor().getFluff().setMMLImagePath(relativeFilePath);
         }
         refresh.refreshPreview();
-        return;
     }
 
     private JFrame getParentFrame() {

--- a/src/megameklab/com/ui/Infantry/StatusBar.java
+++ b/src/megameklab/com/ui/Infantry/StatusBar.java
@@ -16,10 +16,7 @@
 
 package megameklab.com.ui.Infantry;
 
-import java.awt.FileDialog;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
+import java.awt.*;
 import java.io.File;
 import java.text.DecimalFormat;
 
@@ -35,20 +32,16 @@ import megameklab.com.util.UnitUtil;
 
 public class StatusBar extends ITab {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -6754327753693500675L;
 
-    private JButton btnValidate = new JButton("Validate Unit");
-    private JButton btnFluffImage = new JButton("Set Fluff Image");
-    private JLabel move = new JLabel();
-    private JLabel damage = new JLabel();
-    private JLabel bvLabel = new JLabel();
-    private JLabel tons = new JLabel();
-    private JLabel cost = new JLabel();
-    private DecimalFormat formatter;
-    private JFrame parentFrame;
+    private final JLabel move = new JLabel();
+    private final JLabel damage = new JLabel();
+    private final JLabel bvLabel = new JLabel();
+    private final JLabel tons = new JLabel();
+    private final JLabel cost = new JLabel();
+    private final JLabel invalid = new JLabel();
+    private final DecimalFormat formatter;
+    private final JFrame parentFrame;
 
     private RefreshListener refresh;
 
@@ -57,17 +50,13 @@ public class StatusBar extends ITab {
         this.parentFrame = parent;
 
         formatter = new DecimalFormat();
-        btnValidate.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                UnitUtil.showValidation(getInfantry(), getParentFrame());
-            }
-        });
-        btnFluffImage.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                getFluffImage();
-            }
-        });
-
+        JButton btnValidate = new JButton("Validate Unit");
+        btnValidate.addActionListener(evt -> UnitUtil.showValidation(getInfantry(), getParentFrame()));
+        JButton btnFluffImage = new JButton("Set Fluff Image");
+        btnFluffImage.addActionListener(evt -> getFluffImage());
+        invalid.setText("Invalid");
+        invalid.setForeground(Color.RED);
+        invalid.setVisible(false);
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0;
@@ -86,20 +75,19 @@ public class StatusBar extends ITab {
         gbc.gridx = 5;
         this.add(bvLabel, gbc);
         gbc.gridx = 6;
+        this.add(invalid, gbc);
+        gbc.gridx = 7;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         this.add(cost, gbc);
-
-
         refresh();
     }
 
     public void refresh() {
-
         DecimalFormat roundFormat = new DecimalFormat("#.##");
         double currentTonnage;
         int bv = getInfantry().calculateBattleValue();
-        long currentCost = (long) Math.round(getInfantry().getCost(false));
+        long currentCost = Math.round(getInfantry().getCost(false));
 
         currentTonnage = getInfantry().getWeight();
 
@@ -113,7 +101,9 @@ public class StatusBar extends ITab {
         bvLabel.setToolTipText("BV 2.0");
 
         cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
-
+        String str = UnitUtil.validateUnit(getInfantry());
+        invalid.setVisible(!str.isEmpty());
+        invalid.setToolTipText(str);
     }
 
     private void getFluffImage() {
@@ -139,11 +129,10 @@ public class StatusBar extends ITab {
 
         if (fDialog.getFile() != null) {
             String relativeFilePath = new File(fDialog.getDirectory() + fDialog.getFile()).getAbsolutePath();
-            relativeFilePath = "." + File.separatorChar + relativeFilePath.substring(new File(System.getProperty("user.dir").toString()).getAbsolutePath().length() + 1);
+            relativeFilePath = "." + File.separatorChar + relativeFilePath.substring(new File(System.getProperty("user.dir")).getAbsolutePath().length() + 1);
             getInfantry().getFluff().setMMLImagePath(relativeFilePath);
         }
         refresh.refreshPreview();
-        return;
     }
 
     private JFrame getParentFrame() {

--- a/src/megameklab/com/ui/Mek/StatusBar.java
+++ b/src/megameklab/com/ui/Mek/StatusBar.java
@@ -46,22 +46,18 @@ import megameklab.com.util.UnitUtil;
 
 public class StatusBar extends ITab {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -6754327753693500675L;
 
-    private JButton btnValidate = new JButton("Validate Unit");
-    private JButton btnFluffImage = new JButton("Set Fluff Image");
-    private JLabel crits = new JLabel();
-    private JLabel bvLabel = new JLabel();
-    private JLabel tons = new JLabel();
-    private JLabel heatSink = new JLabel();
-    private JLabel cost = new JLabel();
-    private EntityVerifier entityVerifier = EntityVerifier.getInstance(new File("data/mechfiles/UnitVerifierOptions.xml"));
-    private TestMech testEntity = null;
-    private DecimalFormat formatter;
-    private JFrame parentFrame;
+    private final JLabel crits = new JLabel();
+    private final JLabel bvLabel = new JLabel();
+    private final JLabel tons = new JLabel();
+    private final JLabel heatSink = new JLabel();
+    private final JLabel cost = new JLabel();
+    private final JLabel invalid = new JLabel();
+    private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File("data/mechfiles/UnitVerifierOptions.xml"));
+    private TestMech testEntity;
+    private final DecimalFormat formatter;
+    private final JFrame parentFrame;
 
     private RefreshListener refresh;
 
@@ -71,17 +67,13 @@ public class StatusBar extends ITab {
 
         formatter = new DecimalFormat();
         testEntity = new TestMech(getMech(), entityVerifier.mechOption, null);
-        btnValidate.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                UnitUtil.showValidation(getMech(), getParentFrame());
-            }
-        });
-        btnFluffImage.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                getFluffImage();
-            }
-        });
-        //btnFluffImage.setEnabled(false);
+        JButton btnValidate = new JButton("Validate Unit");
+        btnValidate.addActionListener(evt -> UnitUtil.showValidation(getMech(), getParentFrame()));
+        JButton btnFluffImage = new JButton("Set Fluff Image");
+        btnFluffImage.addActionListener(evt -> getFluffImage());
+        invalid.setText("Invalid");
+        invalid.setForeground(Color.RED);
+        invalid.setVisible(false);
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0;
@@ -100,16 +92,15 @@ public class StatusBar extends ITab {
         gbc.gridx = 5;
         this.add(bvLabel, gbc);
         gbc.gridx = 6;
+        this.add(invalid, gbc);
+        gbc.gridx = 7;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         this.add(cost, gbc);
-
-
         refresh();
     }
 
     public void refresh() {
-
         int heat = getMech().getHeatCapacity();
         double tonnage = getMech().getWeight();
         double currentTonnage;
@@ -123,7 +114,7 @@ public class StatusBar extends ITab {
             maxCrits = 78;
         }
         int currentCrits = UnitUtil.countUsedCriticals(getMech());
-        long currentCost = (long) Math.round(getMech().getCost(false));
+        long currentCost = Math.round(getMech().getCost(false));
 
         testEntity = new TestMech(getMech(), entityVerifier.mechOption, null);
 
@@ -159,7 +150,9 @@ public class StatusBar extends ITab {
         } else {
             crits.setForeground(UIManager.getColor("Label.foreground"));
         }
-
+        StringBuffer sb = new StringBuffer();
+        invalid.setVisible(!testEntity.correctEntity(sb));
+        invalid.setToolTipText(sb.toString());
     }
 
     public double calculateTotalHeat() {
@@ -242,11 +235,10 @@ public class StatusBar extends ITab {
 
         if (fDialog.getFile() != null) {
             String relativeFilePath = new File(fDialog.getDirectory() + fDialog.getFile()).getAbsolutePath();
-            relativeFilePath = "." + File.separatorChar + relativeFilePath.substring(new File(System.getProperty("user.dir").toString()).getAbsolutePath().length() + 1);
+            relativeFilePath = "." + File.separatorChar + relativeFilePath.substring(new File(System.getProperty("user.dir")).getAbsolutePath().length() + 1);
             getMech().getFluff().setMMLImagePath(relativeFilePath);
         }
         refresh.refreshPreview();
-        return;
     }
 
     private JFrame getParentFrame() {

--- a/src/megameklab/com/ui/Vehicle/MainUI.java
+++ b/src/megameklab/com/ui/Vehicle/MainUI.java
@@ -17,12 +17,10 @@
 package megameklab.com.ui.Vehicle;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingConstants;
-import javax.swing.UIManager;
 
 import megamek.common.Engine;
 import megamek.common.Entity;
@@ -41,7 +39,6 @@ import megameklab.com.ui.Vehicle.tabs.EquipmentTab;
 import megameklab.com.ui.Vehicle.tabs.StructureTab;
 import megameklab.com.ui.tabs.FluffTab;
 import megameklab.com.ui.tabs.PreviewTab;
-import megameklab.com.util.UnitUtil;
 
 public class MainUI extends MegaMekLabMainUI {
 
@@ -83,6 +80,7 @@ public class MainUI extends MegaMekLabMainUI {
         equipmentTab.addRefreshedListener(this);
         buildTab.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
+        statusbar.setRefreshListener(this);
         
         previewTab = new PreviewTab(this);
 
@@ -132,16 +130,7 @@ public class MainUI extends MegaMekLabMainUI {
 
     @Override
     public void refreshHeader() {
-        String title = getEntity().getChassis() + " " + getEntity().getModel()
-                + ".blk";
-
-        if (UnitUtil.validateUnit(getEntity()).length() > 0) {
-            title += "  (Invalid)";
-            setForeground(Color.red);
-        } else {
-            setForeground(UIManager.getColor("Label.foreground"));
-        }
-        setTitle(title);
+        setTitle(getEntity().getChassis() + " " + getEntity().getModel() + ".blk");
     }
 
     @Override

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
@@ -45,23 +45,20 @@ import megameklab.com.util.UnitUtil;
  *
  */
 public class AdvancedAeroStatusBar extends ITab {
-    /**
-     * 
-     */
+
     private static final long serialVersionUID = -6303444326796852470L;
-    
-    private JButton btnValidate = new JButton("Validate Unit");
-    private JButton btnFluffImage = new JButton("Set Fluff Image");
-    private JLabel bvLabel = new JLabel();
-    private JLabel tons = new JLabel();
-    private JLabel remainingTons = new JLabel();
-    private JLabel heatSink = new JLabel();
-    private JLabel cost = new JLabel();
-    private EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
+
+    private final JLabel bvLabel = new JLabel();
+    private final JLabel tons = new JLabel();
+    private final JLabel remainingTons = new JLabel();
+    private final JLabel heatSink = new JLabel();
+    private final JLabel cost = new JLabel();
+    private final JLabel invalid = new JLabel();
+    private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
             "data/mechfiles/UnitVerifierOptions.xml"));
-    private TestAdvancedAerospace testAdvAero = null;
-    private DecimalFormat formatter;
-    private JFrame parentFrame;
+    private TestAdvancedAerospace testAdvAero;
+    private final DecimalFormat formatter;
+    private final JFrame parentFrame;
 
     private RefreshListener refresh;
 
@@ -71,9 +68,13 @@ public class AdvancedAeroStatusBar extends ITab {
 
         formatter = new DecimalFormat();
         testAdvAero = new TestAdvancedAerospace(getJumpship(), entityVerifier.aeroOption, null);
+        JButton btnValidate = new JButton("Validate Unit");
         btnValidate.addActionListener(e -> UnitUtil.showValidation(getJumpship(), getParentFrame()));
+        JButton btnFluffImage = new JButton("Set Fluff Image");
         btnFluffImage.addActionListener(e -> getFluffImage());
-        //btnFluffImage.setEnabled(false);
+        invalid.setText("Invalid");
+        invalid.setForeground(Color.RED);
+        invalid.setVisible(false);
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0;
@@ -92,21 +93,20 @@ public class AdvancedAeroStatusBar extends ITab {
         gbc.gridx = 5;
         this.add(bvLabel, gbc);
         gbc.gridx = 6;
+        this.add(invalid, gbc);
+        gbc.gridx = 7;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         this.add(cost, gbc);
-
-
         refresh();
     }
 
     public void refresh() {
-
         int heat = getJumpship().getHeatCapacity();
         double tonnage = getJumpship().getWeight();
         double currentTonnage;
         int bv = getJumpship().calculateBattleValue();
-        long currentCost = (long) Math.round(getJumpship().getCost(false));
+        long currentCost = Math.round(getJumpship().getCost(false));
         
         testAdvAero = new TestAdvancedAerospace(getJumpship(), entityVerifier.aeroOption, null);
         currentTonnage = testAdvAero.calculateWeight();
@@ -139,6 +139,9 @@ public class AdvancedAeroStatusBar extends ITab {
         bvLabel.setToolTipText("BV 2.0");
 
         cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        StringBuffer sb = new StringBuffer();
+        invalid.setVisible(!testAdvAero.correctEntity(sb));
+        invalid.setToolTipText(sb.toString());
     }
 
     public double calculateTotalHeat() {
@@ -202,12 +205,10 @@ public class AdvancedAeroStatusBar extends ITab {
             relativeFilePath = "."
                     + File.separatorChar
                     + relativeFilePath
-                            .substring(new File(System.getProperty("user.dir")
-                                    .toString()).getAbsolutePath().length() + 1);
+                            .substring(new File(System.getProperty("user.dir")).getAbsolutePath().length() + 1);
             getJumpship().getFluff().setMMLImagePath(relativeFilePath);
         }
         refresh.refreshPreview();
-        return;
     }
 
     private JFrame getParentFrame() {

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
@@ -56,7 +56,6 @@ public class AdvancedAeroStatusBar extends ITab {
     private final JLabel invalid = new JLabel();
     private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
             "data/mechfiles/UnitVerifierOptions.xml"));
-    private TestAdvancedAerospace testAdvAero;
     private final DecimalFormat formatter;
     private final JFrame parentFrame;
 
@@ -67,7 +66,6 @@ public class AdvancedAeroStatusBar extends ITab {
         parentFrame = parent;
 
         formatter = new DecimalFormat();
-        testAdvAero = new TestAdvancedAerospace(getJumpship(), entityVerifier.aeroOption, null);
         JButton btnValidate = new JButton("Validate Unit");
         btnValidate.addActionListener(e -> UnitUtil.showValidation(getJumpship(), getParentFrame()));
         JButton btnFluffImage = new JButton("Set Fluff Image");
@@ -108,7 +106,7 @@ public class AdvancedAeroStatusBar extends ITab {
         int bv = getJumpship().calculateBattleValue();
         long currentCost = Math.round(getJumpship().getCost(false));
         
-        testAdvAero = new TestAdvancedAerospace(getJumpship(), entityVerifier.aeroOption, null);
+        TestAdvancedAerospace testAdvAero = new TestAdvancedAerospace(getJumpship(), entityVerifier.aeroOption, null);
         currentTonnage = testAdvAero.calculateWeight();
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getJumpship());
 

--- a/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
@@ -55,7 +55,6 @@ public class DropshipStatusBar extends ITab {
     private final JLabel invalid = new JLabel();
     private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
             "data/mechfiles/UnitVerifierOptions.xml"));
-    private TestSmallCraft testSmallCraft;
     private final DecimalFormat formatter;
     private final JFrame parentFrame;
 
@@ -66,7 +65,6 @@ public class DropshipStatusBar extends ITab {
         parentFrame = parent;
 
         formatter = new DecimalFormat();
-        testSmallCraft = new TestSmallCraft(getSmallCraft(), entityVerifier.aeroOption, null);
         JButton btnValidate = new JButton("Validate Unit");
         btnValidate.addActionListener(e -> UnitUtil.showValidation(getSmallCraft(), getParentFrame()));
         JButton btnFluffImage = new JButton("Set Fluff Image");
@@ -107,7 +105,7 @@ public class DropshipStatusBar extends ITab {
         int bv = getSmallCraft().calculateBattleValue();
         long currentCost = Math.round(getSmallCraft().getCost(false));
 
-        testSmallCraft = new TestSmallCraft(getSmallCraft(), entityVerifier.aeroOption, null);
+        TestSmallCraft testSmallCraft = new TestSmallCraft(getSmallCraft(), entityVerifier.aeroOption, null);
 
         currentTonnage = testSmallCraft.calculateWeight();
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getSmallCraft());

--- a/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
@@ -45,22 +45,19 @@ import megameklab.com.util.UnitUtil;
  *
  */
 public class DropshipStatusBar extends ITab {
-    /**
-     * 
-     */
+
     private static final long serialVersionUID = -6303444326796852470L;
-    
-    private JButton btnValidate = new JButton("Validate Unit");
-    private JButton btnFluffImage = new JButton("Set Fluff Image");
-    private JLabel bvLabel = new JLabel();
-    private JLabel tons = new JLabel();
-    private JLabel heatSink = new JLabel();
-    private JLabel cost = new JLabel();
-    private EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
+
+    private final JLabel bvLabel = new JLabel();
+    private final JLabel tons = new JLabel();
+    private final JLabel heatSink = new JLabel();
+    private final JLabel cost = new JLabel();
+    private final JLabel invalid = new JLabel();
+    private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
             "data/mechfiles/UnitVerifierOptions.xml"));
-    private TestSmallCraft testSmallCraft = null;
-    private DecimalFormat formatter;
-    private JFrame parentFrame;
+    private TestSmallCraft testSmallCraft;
+    private final DecimalFormat formatter;
+    private final JFrame parentFrame;
 
     private RefreshListener refresh;
 
@@ -70,9 +67,13 @@ public class DropshipStatusBar extends ITab {
 
         formatter = new DecimalFormat();
         testSmallCraft = new TestSmallCraft(getSmallCraft(), entityVerifier.aeroOption, null);
+        JButton btnValidate = new JButton("Validate Unit");
         btnValidate.addActionListener(e -> UnitUtil.showValidation(getSmallCraft(), getParentFrame()));
+        JButton btnFluffImage = new JButton("Set Fluff Image");
         btnFluffImage.addActionListener(e -> getFluffImage());
-        //btnFluffImage.setEnabled(false);
+        invalid.setText("Invalid");
+        invalid.setForeground(Color.RED);
+        invalid.setVisible(false);
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0;
@@ -89,6 +90,8 @@ public class DropshipStatusBar extends ITab {
         gbc.gridx = 4;
         this.add(bvLabel, gbc);
         gbc.gridx = 5;
+        this.add(invalid, gbc);
+        gbc.gridx = 6;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         this.add(cost, gbc);
@@ -98,12 +101,11 @@ public class DropshipStatusBar extends ITab {
     }
 
     public void refresh() {
-
         int heat = getSmallCraft().getHeatCapacity();
         double tonnage = getSmallCraft().getWeight();
         double currentTonnage;
         int bv = getSmallCraft().calculateBattleValue();
-        long currentCost = (long) Math.round(getSmallCraft().getCost(false));
+        long currentCost = Math.round(getSmallCraft().getCost(false));
 
         testSmallCraft = new TestSmallCraft(getSmallCraft(), entityVerifier.aeroOption, null);
 
@@ -133,6 +135,9 @@ public class DropshipStatusBar extends ITab {
         bvLabel.setToolTipText("BV 2.0");
 
         cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        StringBuffer sb = new StringBuffer();
+        invalid.setVisible(!testSmallCraft.correctEntity(sb));
+        invalid.setToolTipText(sb.toString());
     }
 
     public double calculateTotalHeat() {
@@ -196,12 +201,10 @@ public class DropshipStatusBar extends ITab {
             relativeFilePath = "."
                     + File.separatorChar
                     + relativeFilePath
-                            .substring(new File(System.getProperty("user.dir")
-                                    .toString()).getAbsolutePath().length() + 1);
+                            .substring(new File(System.getProperty("user.dir")).getAbsolutePath().length() + 1);
             getSmallCraft().getFluff().setMMLImagePath(relativeFilePath);
         }
         refresh.refreshPreview();
-        return;
     }
 
     private JFrame getParentFrame() {

--- a/src/megameklab/com/ui/supportvehicle/SVMainUI.java
+++ b/src/megameklab/com/ui/supportvehicle/SVMainUI.java
@@ -124,16 +124,7 @@ public class SVMainUI extends MegaMekLabMainUI {
 
     @Override
     public void refreshHeader() {
-        String title = getEntity().getChassis() + " " + getEntity().getModel()
-                + ".blk";
-
-        if (UnitUtil.validateUnit(getEntity()).length() > 0) {
-            title += "  (Invalid)";
-            setForeground(Color.red);
-        } else {
-            setForeground(UIManager.getColor("Label.foreground"));
-        }
-        setTitle(title);
+        setTitle(getEntity().getChassis() + " " + getEntity().getModel() + ".blk");
     }
 
     @Override

--- a/src/megameklab/com/ui/supportvehicle/SVStatusBar.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStatusBar.java
@@ -41,6 +41,7 @@ class SVStatusBar extends ITab {
     private final JLabel tons = new JLabel();
     private final JLabel slots = new JLabel();
     private final JLabel cost = new JLabel();
+    private final JLabel invalid = new JLabel();
     private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
             "data/mechfiles/UnitVerifierOptions.xml"));
     private TestSupportVehicle testEntity;
@@ -58,6 +59,9 @@ class SVStatusBar extends ITab {
         btnValidate.addActionListener(evt -> UnitUtil.showValidation(parent.getEntity(), getParentFrame()));
         JButton btnFluffImage = new JButton("Set Fluff Image");
         btnFluffImage.addActionListener(evt -> getFluffImage());
+        invalid.setText("Invalid");
+        invalid.setForeground(Color.RED);
+        invalid.setVisible(false);
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0;
@@ -76,10 +80,12 @@ class SVStatusBar extends ITab {
         gbc.gridx = 5;
         this.add(bvLabel, gbc);
         gbc.gridx = 6;
-        this.add(tonnageLabel());
+        this.add(tonnageLabel(), gbc);
         gbc.gridx = 7;
-        this.add(slotsPanel());
+        this.add(slotsPanel(), gbc);
         gbc.gridx = 8;
+        this.add(invalid, gbc);
+        gbc.gridx = 9;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.weightx = 1.0;
         this.add(cost, gbc);
@@ -161,7 +167,9 @@ class SVStatusBar extends ITab {
 
         move.setText("Movement: " + walk + "/" + run + "/" + jump);
         move.setToolTipText("Walk/Run/Jump MP");
-
+        StringBuffer sb = new StringBuffer();
+        invalid.setVisible(!testEntity.correctEntity(sb));
+        invalid.setToolTipText(sb.toString());
     }
 
     private void getFluffImage() {


### PR DESCRIPTION
Currently the title bar shows "(invalid)" after the file name in the title bar, but only for some unit types and only updates when the chassis or model name changes. Rather than implement it with the remaining unit types and adding `refresh.refreshHeader()` calls all over the place, I moved it to the status bar where I think it more naturally belongs. It will also set the tooltip to indicate why it's flagged as invalid.

Then I did some removing of redundant casts and converting member fields to local variables.

Fixes #471