### PR TITLE
Ignore OS launchers when filtering ammo on equipment tab.

### DIFF
--- a/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
@@ -648,8 +648,8 @@ public class EquipmentTab extends ITab implements ActionListener {
                                 && (wtype != null) && (wtype.isCapital()
                                         || (wtype.getAmmoType() == AmmoType.T_SCREEN_LAUNCHER)))
                         || ((nType == T_ARTILLERY) && UnitUtil.isAeroWeapon(etype, aero)
-                                && (wtype != null) && (wtype instanceof ArtilleryWeapon))
-                        || (((nType == T_AMMO) & (atype != null)) && UnitUtil.canUseAmmo(aero, atype))) {
+                                && (wtype instanceof ArtilleryWeapon))
+                        || (((nType == T_AMMO) & (atype != null)) && UnitUtil.canUseAmmo(aero, atype, false))) {
                     if (!eSource.getTechManager().isLegal(etype) && !chkShowAll.isSelected()) {
                         return false;
                     }

--- a/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
@@ -597,8 +597,8 @@ public class EquipmentTab extends ITab implements ActionListener {
                                     && (wtype.getAmmoType() != AmmoType.T_NA))
                                     || (wtype.getAmmoType() == AmmoType.T_C3_REMOTE_SENSOR)))
                         || ((nType == T_ARTILLERY) && UnitUtil.isUnitWeapon(etype, ba)
-                            && (wtype != null) && (wtype instanceof ArtilleryWeapon))
-                        || (((nType == T_AMMO) && (atype != null)) && UnitUtil.canUseAmmo(ba, atype))
+                            && (wtype instanceof ArtilleryWeapon))
+                        || (((nType == T_AMMO) && (atype != null)) && UnitUtil.canUseAmmo(ba, atype, false))
                         || ((nType == T_AP) && UnitUtil.isBattleArmorAPWeapon(etype))) {
                     if (eSource.getTechManager() != null
                             && !eSource.getTechManager().isLegal(etype)

--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -579,9 +579,9 @@ public class EquipmentTab extends ITab implements ActionListener {
                             && (wtype != null) && ((wtype.hasFlag(WeaponType.F_MISSILE)
                                     && (wtype.getAmmoType() != AmmoType.T_NA)) || (wtype.getAmmoType() == AmmoType.T_C3_REMOTE_SENSOR)))
                         || ((nType == T_ARTILLERY) && UnitUtil.isMechWeapon(etype, mech)
-                            && (wtype != null) && (wtype instanceof ArtilleryWeapon))
+                            && (wtype instanceof ArtilleryWeapon))
                         || ((nType == T_PHYSICAL) && UnitUtil.isPhysicalWeapon(etype))
-                        || (((nType == T_AMMO) & (atype != null)) && UnitUtil.canUseAmmo(mech, atype))) {
+                        || (((nType == T_AMMO) & (atype != null)) && UnitUtil.canUseAmmo(mech, atype, false))) {
                     if (!eSource.getTechManager().isLegal(etype) && !chkShowAll.isSelected()) {
                         return false;
                     }

--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -575,8 +575,8 @@ public class EquipmentTab extends ITab implements ActionListener {
                             && (wtype != null) && ((wtype.hasFlag(WeaponType.F_MISSILE)
                                     && (wtype.getAmmoType() != AmmoType.T_NA)) || (wtype.getAmmoType() == AmmoType.T_C3_REMOTE_SENSOR)))
                         || ((nType == T_ARTILLERY) && UnitUtil.isTankWeapon(etype, tank)
-                            && (wtype != null) && (wtype instanceof ArtilleryWeapon))
-                        || (((nType == T_AMMO) & (atype != null)) && UnitUtil.canUseAmmo(tank, atype))) {
+                            && (wtype instanceof ArtilleryWeapon))
+                        || (((nType == T_AMMO) & (atype != null)) && UnitUtil.canUseAmmo(tank, atype, false))) {
                     if (!eSource.getTechManager().isLegal(etype)
                             && !chkShowAll.isSelected()) {
                         return false;

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -4096,18 +4096,6 @@ public class UnitUtil {
 
     /**
      * Checks whether the unit has an weapon that uses the ammo type and the munition is legal for the
-     * type of unit. This includes one-shot launchers.
-     * 
-     * @param unit The unit
-     * @param atype The ammo
-     * @return Whether the unit can make use of the ammo
-     */
-    public static boolean canUseAmmo(Entity unit, AmmoType atype) {
-        return canUseAmmo(unit, atype, true);
-    }
-    
-    /**
-     * Checks whether the unit has an weapon that uses the ammo type and the munition is legal for the
      * type of unit.
      * 
      * @param unit The unit


### PR DESCRIPTION
There's even an argument to ignore oneshot. It just wasn't being used for most unit types.
Fixes #479