### PR TITLE
Disappearing jet booster

### DIFF
--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -364,7 +364,6 @@ public class EquipmentTab extends ITab implements ActionListener {
     }
 
     private void loadEquipmentTable() {
-
         for (Mounted mount : getTank().getWeaponList()) {
             equipmentList.addCrit(mount);
         }
@@ -373,32 +372,24 @@ public class EquipmentTab extends ITab implements ActionListener {
             equipmentList.addCrit(mount);
         }
 
-        List<EquipmentType> spreadAlreadyAdded = new ArrayList<EquipmentType>();
+        List<EquipmentType> spreadAlreadyAdded = new ArrayList<>();
 
         for (Mounted mount : getTank().getMisc()) {
 
             EquipmentType etype = mount.getType();
-            if (UnitUtil.isHeatSink(mount)
-                    || etype.hasFlag(MiscType.F_JUMP_JET)
-                    || etype.hasFlag(MiscType.F_JUMP_BOOSTER)
-                    || etype.hasFlag(MiscType.F_TSM)
-                    || etype.hasFlag(MiscType.F_INDUSTRIAL_TSM)
-                    || (etype.hasFlag(MiscType.F_MASC)
-                            && !etype.hasSubType(MiscType.S_SUPERCHARGER))
+            if (etype.hasFlag(MiscType.F_JUMP_JET)
                     || UnitUtil.isArmorOrStructure(etype)) {
                 continue;
             }
-            //if (UnitUtil.isUnitEquipment(mount.getType(), unit) || UnitUtil.isUn) {
-                if (UnitUtil.isFixedLocationSpreadEquipment(etype)
-                        && !spreadAlreadyAdded.contains(etype)) {
-                    equipmentList.addCrit(mount);
-                    // keep track of spreadable equipment here, so it doesn't
-                    // show up multiple times in the table
-                    spreadAlreadyAdded.add(etype);
-                } else {
-                    equipmentList.addCrit(mount);
-                }
-            //}
+            if (UnitUtil.isFixedLocationSpreadEquipment(etype)
+                    && !spreadAlreadyAdded.contains(etype)) {
+                equipmentList.addCrit(mount);
+                // keep track of spreadable equipment here, so it doesn't
+                // show up multiple times in the table
+                spreadAlreadyAdded.add(etype);
+            } else {
+                equipmentList.addCrit(mount);
+            }
         }
     }
 
@@ -553,14 +544,6 @@ public class EquipmentTab extends ITab implements ActionListener {
                     atype = (AmmoType)etype;
                 }
                 if (UnitUtil.isHeatSink(etype) || UnitUtil.isJumpJet(etype)) {
-                    return false;
-                }
-                if ((etype instanceof MiscType)
-                        && (etype.hasFlag(MiscType.F_TSM)
-                                || etype.hasFlag(MiscType.F_INDUSTRIAL_TSM)
-                                || (etype.hasFlag(MiscType.F_MASC)
-                                        && !etype.hasSubType(MiscType.S_SUPERCHARGER)
-                                        && !etype.hasSubType(MiscType.S_JETBOOSTER)))) {
                     return false;
                 }
                 if (((nType == T_OTHER) && UnitUtil.isTankMiscEquipment(etype, tank))

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -187,8 +187,7 @@ public class UnitUtil {
      */
     public static boolean isMASC(EquipmentType eq) {
         return (eq instanceof MiscType)
-                && (eq.hasFlag(MiscType.F_MASC) && !eq
-                        .hasSubType(MiscType.S_SUPERCHARGER));
+                && (eq.hasFlag(MiscType.F_MASC) && eq.hasSubType(MiscType.S_STANDARD));
     }
 
     /**
@@ -4245,8 +4244,15 @@ public class UnitUtil {
         }
     }
 
+    /**
+     * Checks for any equipment that is added on the equipment tab and removes any that is
+     * no longer legal for the current year/tech base/tech level
+     * @param unit         The unit to check
+     * @param techManager  The manager that handles the checking
+     * @return             Whether any changes were made
+     */
     public static boolean checkEquipmentByTechLevel(Entity unit, ITechManager techManager) {
-        Vector<Mounted> toRemove = new Vector<Mounted>();
+        List<Mounted> toRemove = new ArrayList<>();
         ITechnology acTA = Entity.getArmoredComponentTechAdvancement();
         boolean dirty = false;
         for (Mounted m : unit.getEquipment()) {
@@ -4260,10 +4266,12 @@ public class UnitUtil {
                     || UnitUtil.isHeatSink(etype) || UnitUtil.isJumpJet(etype)) {
                 continue;
             }
-            if (etype.hasFlag(MiscType.F_TSM)
+            if (etype instanceof MiscType
+                    && (etype.hasFlag(MiscType.F_TSM)
                     || etype.hasFlag(MiscType.F_INDUSTRIAL_TSM)
-                    || (etype.hasFlag(MiscType.F_MASC) && !etype.hasSubType(MiscType.S_SUPERCHARGER))
-                    || etype.hasFlag(MiscType.F_SCM)) {
+                    || (etype.hasFlag(MiscType.F_MASC)
+                        && !etype.hasSubType(MiscType.S_SUPERCHARGER) && !etype.hasSubType(MiscType.S_JETBOOSTER))
+                    || etype.hasFlag(MiscType.F_SCM))) {
                 continue;
             }
             if (!techManager.isLegal(etype)) {


### PR DESCRIPTION
The VTOL jet booster disappears from the installed equipment on the equipment tab during refresh because it's falsely being flagged as MASC. But the most of the equipment that gets filtered out in that block is only relevant to mechs, and this class only handles vehicles, so those checks are redundant. 

This is the second time recently I've found the check for MASC including a jet booster when it shouldn't so I went looking for other places that superchargers are excluded but jet boosters aren't and I found another case in the method that removes equipment that is invalid for the year/tech base/tech level. This time the check is letting jet boosters slip through.

Fixes #483 