### PR TITLE
Gradle properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,8 +121,8 @@ task compileMM (type: GradleBuild) {
 
 task mmJar (type: Jar, dependsOn: compileMM) {
     archiveFileName = "MegaMek.jar"
-    from "${mmDir}/megamek/megamek/build/classes/java/main"
-    from "${mmDir}/megamek/megamek/build/resources/main"
+    from "${mmDir}/megamek/build/classes/java/main"
+    from "${mmDir}/megamek/build/resources/main"
     manifest {
         attributes "Main-Class": mainClassName
         attributes 'Class-Path' : (project.sourceSets.main.runtimeClasspath.files

--- a/build.gradle
+++ b/build.gradle
@@ -130,14 +130,14 @@ task mmJar (type: Jar, dependsOn: compileMM) {
     }
     inputs.dir "${mmDir}/megamek/build/classes/java/main"
     inputs.dir "${mmDir}/megamek/build/resources/main"
-    outputs.file "${buildDir}/libs/${archiveFileName}"
+    outputs.file "${buildDir}/libs/${archiveFileName.get()}"
 }
 
 jar {
-    archiveFileName = "${rootProject.name}.${archiveExtension}"
+    archiveFileName = "${rootProject.name}.${archiveExtension.get()}"
     manifest {
         attributes "Main-Class": mainClassName
-        attributes 'Class-Path' : "${lib}/${mmJar.archiveFileName} " + (project.sourceSets.main.runtimeClasspath.files
+        attributes 'Class-Path' : "${lib}/${mmJar.archiveFileName.get()} " + (project.sourceSets.main.runtimeClasspath.files
             .findAll { it.name.endsWith(".jar") }.collect { "${lib}/${it.name}" }.join(' '))
     }
 }
@@ -225,7 +225,7 @@ task createOSXBundle (dependsOn: jar) {
                 mainClass: project.mainClassName,
                 stubfile: osxApplicationStub,
                 dir: osxBundleDir,
-                jar: "${jar.destinationDirectory}/${jar.archiveFileName}",
+                jar: "${jar.destinationDirectory.get()}/${jar.archiveFileName.get()}",
                 jvmversion: '1.8+',
                 icon: "${projectDir}/${data}/images/misc/megameklab.icns",
                 useJavaXKey: 'true',


### PR DESCRIPTION
When I replaced deprecated field names I didn't realize that they also changed from strings to properties, which require the `get()` method to access the string value. Expressions that evaluated to MegaMekLab.jar and MegaMek.jar under 4.9 are now evaluating as MegaMekLab.property(class java.lang.String, fixed(class java.lang.String, jar), which is causing problems in the start script and the classpath in the jar manifests. I also got carried away and added one too many megamek subdirectories. My previous testing only went as far as making sure the distribution packages built. This time I extracted the package and made sure it runs.

Fixes #482