### PR TITLE
Indicate variable equipment stats

### DIFF
--- a/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
@@ -575,7 +575,9 @@ public class EquipmentTab extends ITab implements ActionListener {
                             || etype.hasFlag(MiscType.F_PARTIAL_WING)
                             || etype.hasFlag(MiscType.F_JUMP_BOOSTER)
                             || etype.hasFlag(MiscType.F_MECHANICAL_JUMP_BOOSTER)
-                            || etype.hasFlag(MiscType.F_MASC))){
+                            || etype.hasFlag(MiscType.F_MASC)
+                            || UnitUtil.isArmorOrStructure(etype)
+                            || UnitUtil.isJumpJet(etype))) {
                     return false;
                 }
 
@@ -584,7 +586,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                     return false;
                 }
                 BattleArmor ba = getBattleArmor();
-                if (((nType == T_OTHER) && UnitUtil.isBAEquipment(etype, ba))
+                if (((nType == T_OTHER) && UnitUtil.isBAEquipment(etype, ba) && !UnitUtil.isBattleArmorWeapon(etype, ba))
                         || (((nType == T_WEAPON) && (UnitUtil.isUnitWeapon(etype, ba))))
                         || ((nType == T_ENERGY) && UnitUtil.isUnitWeapon(etype, ba)
                             && (wtype != null) && (wtype.hasFlag(WeaponType.F_ENERGY)

--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -28,6 +28,7 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 
 import megamek.common.*;
+import megamek.common.verifier.TestEntity;
 import megamek.common.verifier.TestProtomech;
 import megamek.common.weapons.autocannons.UACWeapon;
 import megamek.common.weapons.gaussrifles.HAGWeapon;
@@ -345,10 +346,10 @@ public class EquipmentTableModel extends AbstractTableModel {
             final double weight = type.getTonnage(entity);
             if ((atype != null) && (entity.hasETypeFlag(Entity.ETYPE_BATTLEARMOR)
                     || entity.hasETypeFlag(Entity.ETYPE_PROTOMECH))) {
-                return atype.getKgPerShot() + " kg/shot";
+                return String.format("%.2f kg/shot", atype.getKgPerShot());
             } else if (type.isVariableTonnage()) {
                 return "variable";
-            } else if (weight > 0.0 && weight < 0.1) {
+            } else if (TestEntity.usesKgStandard(entity) || ((weight > 0.0) && (weight < 0.1))) {
                 return String.format("%.0f kg", type.getTonnage(entity) * 1000);
             } else {
                 return formatter.format(weight);

--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -16,7 +16,6 @@
 
 package megameklab.com.util;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -98,7 +97,6 @@ public class EquipmentTableModel extends AbstractTableModel {
             case COL_NAME:
                 return "Name";
             case COL_DAMAGE:
-                return "Damage";
             case COL_DIVISOR:
                 return "Damage";
             case COL_SPECIAL:
@@ -426,9 +424,10 @@ public class EquipmentTableModel extends AbstractTableModel {
             attackValue[RangeType.RANGE_LONG] = (int)wtype.getLongAV();
             attackValue[RangeType.RANGE_EXTREME] = (int)wtype.getExtAV();
             boolean allEq = true;
-            for (int i = 2; i <= wtype.maxRange && allEq; i++) {
+            for (int i = 2; i <= wtype.maxRange; i++) {
                 if (attackValue[i - 1] != attackValue[i]) {
                     allEq = false;
+                    break;
                 }                    
             }
             StringBuilder avString = new StringBuilder();

--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -97,8 +97,9 @@ public class EquipmentTableModel extends AbstractTableModel {
             case COL_NAME:
                 return "Name";
             case COL_DAMAGE:
-            case COL_DIVISOR:
                 return "Damage";
+            case COL_DIVISOR:
+                return "Divisor";
             case COL_SPECIAL:
                 return "Special";
             case COL_HEAT:

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -63,8 +63,6 @@ import megamek.common.weapons.autocannons.HVACWeapon;
 import megamek.common.weapons.autocannons.LBXACWeapon;
 import megamek.common.weapons.autocannons.UACWeapon;
 import megamek.common.weapons.battlearmor.CLBALBX;
-import megamek.common.weapons.battlearmor.CLBALightTAG;
-import megamek.common.weapons.battlearmor.ISBALightTAG;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.capitalweapons.CapitalMissileWeapon;
 import megamek.common.weapons.defensivepods.BPodWeapon;
@@ -2081,7 +2079,8 @@ public class UnitUtil {
     public static boolean isJumpJet(EquipmentType eq) {
         if ((eq instanceof MiscType)
                 && (eq.hasFlag(MiscType.F_JUMP_JET)
-                        || eq.hasFlag(MiscType.F_UMU))) {
+                        || eq.hasFlag(MiscType.F_UMU)
+                        || eq.hasFlag(MiscType.F_BA_VTOL))) {
             return true;
         }
 
@@ -2908,6 +2907,10 @@ public class UnitUtil {
     }
 
     public static boolean isSupportVehicleEquipment(EquipmentType eq, Entity unit) {
+        if ((unit.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT)
+                && (eq.getTonnage(unit) >= 5.0)) {
+            return false;
+        }
         if ((eq instanceof MiscType) && !eq.hasFlag(MiscType.F_SUPPORT_TANK_EQUIPMENT)) {
             return false;
         } else if ((eq instanceof WeaponType)

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2923,13 +2923,19 @@ public class UnitUtil {
         }
     }
 
+    /**
+     * @param eq A {@link WeaponType} or {@link MiscType}
+     * @param ba The BattleArmor instance
+     * @return   Whether the BA can use the equipment
+     */
     public static boolean isBAEquipment(EquipmentType eq, BattleArmor ba) {
         if (eq instanceof MiscType) {
                 return eq.hasFlag(MiscType.F_BA_EQUIPMENT);
         } else if (eq instanceof WeaponType) {
             return isBattleArmorWeapon(eq, ba);
         }
-        return true;
+        // This leaves ammotype, which is filtered according to having a weapon that can use it
+        return false;
     }
 
     public static boolean isBattleArmorAPWeapon(EquipmentType etype){


### PR DESCRIPTION
Depends on MegaMek/megamek#1715

1. Makes a distinction between equipment that has a weight/cost/BV/critical slots requirement of zero and equipment that is variable.
2. BA, ProtoMechs, and small support vehicles show equipment weight by kg for everything rather than just what is < 0.1 tons. Anything >= 5 tons is filtered out for small support vehicles.
3. Equipment shown as kg is shown as a whole number, with the exception of BA ammo, has official weights of partial kg.
4. Fixed a bug introduced in my last equipment tab fix that had ammo, weapons, and structural components showing on the BA equipment tab in the "other" category.

Fixes #487 