### PR TITLE
Supercharger restrictions

### DIFF
--- a/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
@@ -390,8 +390,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
                 && !getSV().hasMisc(MiscType.F_PROP)) {
             setChassisMod(TestSupportVehicle.ChassisModification.PROP.equipment, true);
         }
-        // MagLev trains cannot use the external power pickup mod.
-        if (engine.getEngineType() == Engine.MAGLEV) {
+        if (engine.getEngineType() != Engine.EXTERNAL) {
             setChassisMod(TestSupportVehicle.ChassisModification.EXTERNAL_POWER_PICKUP.equipment, false);
         }
         // The chassis view needs to refresh the available engine rating combobox

--- a/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
@@ -401,6 +401,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
         refreshFuel();
         panChassisMod.setFromEntity(getSV());
         panSummary.refresh();
+        refresh.refreshEquipment();
         refresh.refreshStatus();
         refresh.refreshPreview();
     }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -3046,6 +3046,12 @@ public class UnitUtil {
             if (!TestTank.legalForMotiveType(eq, tank.getMovementMode())) {
                 return false;
             }
+            // Can't use supercharger with solar or external power pickup
+            if (eq.hasFlag(MiscType.F_MASC) && (!tank.hasEngine()
+                    || tank.getEngine().getEngineType() == Engine.SOLAR
+                    || tank.getEngine().getEngineType() == Engine.EXTERNAL)) {
+                return false;
+            }
             if (eq.hasFlag(MiscType.F_VTOL_EQUIPMENT) && (tank instanceof VTOL)) {
                 return true;
             }


### PR DESCRIPTION
Remove supercharger from equipment list for support vehicles with solar or external engines. Restrict rail external power pickup to vehicles with external engine.

Along with MegaMek/megamek#1725 fixes #497