### PR TITLE
No dual turrets for WiGE vehicles.

### DIFF
--- a/src/megameklab/com/ui/view/CVChassisView.java
+++ b/src/megameklab/com/ui/view/CVChassisView.java
@@ -330,7 +330,7 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
             }
         } else {
             cbTurrets.addItem(TURRET_SINGLE);
-            if (techManager.isLegal(TA_DUAL_TURRET)) {
+            if (!EntityMovementMode.WIGE.equals(getMovementMode()) && techManager.isLegal(TA_DUAL_TURRET)) {
                 cbTurrets.addItem(TURRET_DUAL);
             }
         }

--- a/src/megameklab/com/ui/view/SVChassisView.java
+++ b/src/megameklab/com/ui/view/SVChassisView.java
@@ -529,7 +529,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
             }
         } else if (!isAeroType()) {
             cbTurrets.addItem(SVBuildListener.TURRET_SINGLE);
-            if (techManager.isLegal(TA_DUAL_TURRET)) {
+            if (!TestSupportVehicle.SVType.WIGE.equals(cbType.getSelectedItem())
+                    && techManager.isLegal(TA_DUAL_TURRET)) {
                 cbTurrets.addItem(SVBuildListener.TURRET_DUAL);
             }
         }


### PR DESCRIPTION
Per TacOps, p. 347 (2018 printing), WiGE vehicles cannot mount dual turrets. This is a change from previous printing.

Fixes #505