### PR TITLE
Add sorting by weight to generic equipment tab

### DIFF
--- a/src/megameklab/com/ui/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/tabs/EquipmentTab.java
@@ -26,6 +26,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.text.DecimalFormat;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Enumeration;
@@ -212,6 +213,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         equipmentSorter.setComparator(EquipmentTableModel.COL_DAMAGE, new WeaponDamageSorter());
         equipmentSorter.setComparator(EquipmentTableModel.COL_RANGE, new WeaponRangeSorter());
         equipmentSorter.setComparator(EquipmentTableModel.COL_COST, new FormattedNumberSorter());
+        equipmentSorter.setComparator(EquipmentTableModel.COL_TON, new FormattedNumberSorter());
         masterEquipmentTable.setRowSorter(equipmentSorter);
         ArrayList<RowSorter.SortKey> sortKeys = new ArrayList<>();
         sortKeys.add(new RowSorter.SortKey(EquipmentTableModel.COL_NAME, SortOrder.ASCENDING));
@@ -896,26 +898,27 @@ public class EquipmentTab extends ITab implements ActionListener {
      *
      */
     public static class FormattedNumberSorter implements Comparator<String> {
+        private final DecimalFormat format = new DecimalFormat();
 
         @Override
         public int compare(String s0, String s1) {
-            //lets find the weight class integer for each name
-            DecimalFormat format = new DecimalFormat();
-            double l0 = 0.0;
             try {
-                l0 = format.parse(s0).doubleValue();
+                return Double.compare(parseValue(s0), parseValue(s1));
             } catch (java.text.ParseException e) {
                 MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
                         "Parse error comparing " + s0 + " and " + s1, e);
+                return 0;
             }
-            double l1 = 0.0;
-            try {
-                l1 = format.parse(s1).doubleValue();
-            } catch (java.text.ParseException e) {
-                MegaMekLab.getLogger().error(getClass(), "compare(String, String)",
-                        "Parse error comparing " + s0 + " and " + s1, e);
+        }
+
+        private double parseValue(String str) throws ParseException {
+            if (str.endsWith(" kg")) {
+                return format.parse(str.replace(" kg", "")).doubleValue() * 1000;
+            } else if (str.equals(EquipmentTableModel.VARIABLE)) {
+                return 0.0;
+            } else {
+                return format.parse(str).doubleValue();
             }
-            return Double.compare(l0, l1);
         }
     }
 

--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -48,6 +48,8 @@ public class EquipmentTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = -5207167419079014157L;
 
+    public final static String VARIABLE = "variable";
+
     public final static int COL_NAME = 0;
     public final static int COL_DAMAGE = 1;
     public final static int COL_DIVISOR = 2;
@@ -347,7 +349,7 @@ public class EquipmentTableModel extends AbstractTableModel {
                     || entity.hasETypeFlag(Entity.ETYPE_PROTOMECH))) {
                 return String.format("%.2f kg/shot", atype.getKgPerShot());
             } else if (type.isVariableTonnage()) {
-                return "variable";
+                return VARIABLE;
             } else if (TestEntity.usesKgStandard(entity) || ((weight > 0.0) && (weight < 0.1))) {
                 return String.format("%.0f kg", type.getTonnage(entity) * 1000);
             } else {


### PR DESCRIPTION
The generic equipment tab, which is used for protomechs and support vehicles (and my intention is to consolidate all units into the same tab instead of duplicating the same code all over the place)...where was I?

Right. The generic tab didn't have a specific Comparator for the weight column, which resulted in sorting by string value. I added the Comparator for formatted numbers and added the ability to recognize the difference between weights in tons and kg, as well as treating all variable weight equipment as zero.

Fixes #502 