### PR TITLE
Don't allow deleting heat sinks or jump jets on the build tab.

### DIFF
--- a/src/megameklab/com/util/Mech/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/Mech/DropTargetCriticalList.java
@@ -148,19 +148,13 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
                         });
                         popup.add(info);
                     }
-
-                    info = new JMenuItem("Delete " + mount.getName());
-                    info.addActionListener(new ActionListener() {
-                        public void actionPerformed(ActionEvent e) {
-                            removeMount();
-                        }
-                    });
-                    if (!((getUnit() instanceof BattleArmor) 
-                            && UnitUtil.isFixedLocationSpreadEquipment(mount
-                                    .getType()))){
+                    if (!((getUnit() instanceof BattleArmor)
+                            && UnitUtil.isFixedLocationSpreadEquipment(mount.getType()))
+                            && !UnitUtil.isHeatSink(mount) && !UnitUtil.isJumpJet(mount)) {
+                        info = new JMenuItem("Delete " + mount.getName());
+                        info.addActionListener(ev -> removeMount());
                         popup.add(info);
                     }
-                    
                     // Allow making this a sort weapon
                     if ((mount.getType() instanceof WeaponType)
                             && !mount.isSquadSupportWeapon()

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -943,8 +943,9 @@ public class UnitUtil {
     }
 
     public static boolean isJumpJet(Mounted m) {
-        return m.getType().hasFlag(MiscType.F_JUMP_JET)
-                || m.getType().hasFlag(MiscType.F_JUMP_BOOSTER);
+        return (m.getType() instanceof MiscType) &&
+                (m.getType().hasFlag(MiscType.F_JUMP_JET)
+                || m.getType().hasFlag(MiscType.F_JUMP_BOOSTER));
     }
 
     /**


### PR DESCRIPTION
The number of heat sinks and jump jets is set on the structure tab. Letting them be deleted on the build tab causes problems. I also discovered quite by accident during testing that UnitUtil#isJumpJet does not check for instanceof MiscType, which causes a false positive on lasers, because MiscType.F_JUMP_JET == WeaponType.F_LASER.

I also found another file that had CR/LF endings.

Fixes #501