### PR TITLE
External fuel tank filtering

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -825,6 +825,7 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
             panMovement.setFromEntity(getMech());
             panHeat.setFromMech(getMech());
             refreshSummary();
+            refresh.refreshEquipment();
             refresh.refreshPreview();
             refresh.refreshStatus();
         }

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -614,6 +614,7 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
             walkChanged(panMovement.getWalk());
         }
         refreshSummary();
+        refresh.refreshEquipment();
         refresh.refreshPreview();
         refresh.refreshStatus();
     }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2805,6 +2805,15 @@ public class UnitUtil {
                 return false;
             }
 
+            if (eq.hasFlag(MiscType.F_FUEL)) {
+                return unit.isIndustrial()
+                        && ((unit.getEngine().getEngineType() == Engine.COMBUSTION_ENGINE)
+                            || (unit.getEngine().getEngineType() == Engine.FUEL_CELL));
+            }
+            if (eq.hasFlag(MiscType.F_ENVIRONMENTAL_SEALING)) {
+                return unit.isIndustrial();
+            }
+
             if (eq.hasFlag(MiscType.F_MECH_EQUIPMENT)
                     && !eq.hasFlag(MiscType.F_CLUB)
                     && !eq.hasFlag(MiscType.F_HAND_WEAPON)
@@ -2815,6 +2824,7 @@ public class UnitUtil {
             if (eq.hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)) {
                 return true;
             }
+
         }
 
         return false;
@@ -3522,14 +3532,14 @@ public class UnitUtil {
                 return location == Protomech.LOC_BODY;
             }
         }
-        if ((unit instanceof Mech) && (eq instanceof MiscType)) {
-            if (((eq.hasFlag(MiscType.F_CLUB) || eq
-                    .hasFlag(MiscType.F_HAND_WEAPON)))) {
+        if (eq instanceof MiscType) {
+            if ((unit instanceof Mech)
+                    && ((eq.hasFlag(MiscType.F_CLUB) || eq.hasFlag(MiscType.F_HAND_WEAPON)))) {
                 if (unit.entityIsQuad()) {
                     return ((location == Mech.LOC_LT)
                             || (location == Mech.LOC_RT))
-                            && ((eq.getSubType() & 
-                                    (MiscType.S_DUAL_SAW | MiscType.S_PILE_DRIVER
+                            && ((eq.getSubType() &
+                            (MiscType.S_DUAL_SAW | MiscType.S_PILE_DRIVER
                                     | MiscType.S_WRECKING_BALL | MiscType.S_BACKHOE
                                     | MiscType.S_COMBINE | MiscType.S_CHAINSAW
                                     | MiscType.S_ROCK_CUTTER | MiscType.S_BUZZSAW
@@ -3538,12 +3548,11 @@ public class UnitUtil {
                     return (location == Mech.LOC_RARM) || (location == Mech.LOC_LARM);
                 }
             }
-
             if (eq.hasFlag(MiscType.F_ACTUATOR_ENHANCEMENT_SYSTEM)) {
                 if ((location != Mech.LOC_RARM) && (location != Mech.LOC_LARM)
                         && (location != Mech.LOC_LLEG)
                         && (location != Mech.LOC_RLEG)
-                        && ((unit instanceof TripodMech) 
+                        && ((unit instanceof TripodMech)
                                 && location != Mech.LOC_CLEG)) {
                     return false;
                 }
@@ -3566,87 +3575,91 @@ public class UnitUtil {
                         || ((location != Mech.LOC_RT) && (location != Mech.LOC_LT)))) {
                 return false;
             }
-            
+            if (eq.hasFlag(MiscType.F_FUEL) && (unit instanceof Mech)) {
+                return location == Mech.LOC_CT
+                        || location == Mech.LOC_RT
+                        || location == Mech.LOC_LT;
+            }
+
             //vehicular jump jets are auto-assigned to the body
             if (eq.hasFlag(MiscType.F_JUMP_JET) && unit instanceof Mech) {
-            	if (location == Mech.LOC_HEAD) {
-            		return false;
-            	}
-            	if (!(unit instanceof QuadMech)
-            			&& (location == Mech.LOC_LARM || location == Mech.LOC_RARM)) {
-            		return false;
-            	}
+                if (location == Mech.LOC_HEAD) {
+                    return false;
+                }
+                if (!(unit instanceof QuadMech)
+                        && (location == Mech.LOC_LARM || location == Mech.LOC_RARM)) {
+                    return false;
+                }
             }
-            
+
             if (eq.hasFlag(MiscType.F_AP_POD) && unit instanceof Mech) {
-            	if (!(unit instanceof QuadMech)
-            			&& (location == Mech.LOC_LARM || location == Mech.LOC_RARM)) {
-            		return false;
-            	}
-            	if (location != Mech.LOC_LLEG
-            			&& location != Mech.LOC_RLEG
-            			&& location != Mech.LOC_CLEG) {
-            		return false;
-            	}
+                if (!(unit instanceof QuadMech)
+                        && (location == Mech.LOC_LARM || location == Mech.LOC_RARM)) {
+                    return false;
+                }
+                if (location != Mech.LOC_LLEG
+                        && location != Mech.LOC_RLEG
+                        && location != Mech.LOC_CLEG) {
+                    return false;
+                }
             }
-            
+
             if (eq.hasFlag(MiscType.F_MODULAR_ARMOR)) {
-            	if (unit instanceof Mech && location == Mech.LOC_HEAD) {
-            		return false;
-            	}
-            	if (unit instanceof VTOL && location == VTOL.LOC_ROTOR) {
-            		return false;
-            	}
+                if (unit instanceof Mech && location == Mech.LOC_HEAD) {
+                    return false;
+                }
+                if (unit instanceof VTOL && location == VTOL.LOC_ROTOR) {
+                    return false;
+                }
             }
-            
+
             if (eq.hasFlag(MiscType.F_CASE)) {
-            	if (unit instanceof Mech
-            			&& location != Mech.LOC_LT
-            			&& location != Mech.LOC_RT
-            			&& location != Mech.LOC_CT) {
-            		return false;
-            	}
-            	if (unit instanceof Tank && location != Tank.LOC_BODY) {
-            		return false;
-            	}
+                if (unit instanceof Mech
+                        && location != Mech.LOC_LT
+                        && location != Mech.LOC_RT
+                        && location != Mech.LOC_CT) {
+                    return false;
+                }
+                if (unit instanceof Tank && location != Tank.LOC_BODY) {
+                    return false;
+                }
             }
-            
+
             if (unit.hasETypeFlag(Entity.ETYPE_TANK)) {
-            	if (location == Tank.LOC_BODY) {
-            		//Equipment which cannot be installed in the body
-            		if (eq.hasFlag(MiscType.F_HARJEL)
-            				|| eq.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM)) {
-            			return false;
-            		}
-            	} else {
-            		//Equipment which must be installed in the body
-            		if (eq.hasFlag(MiscType.F_CASE) || eq.hasFlag(MiscType.F_BLUE_SHIELD)) {
-            			return false;
-            		}
-            	}
-            	if (eq.hasFlag(MiscType.F_BULLDOZER) && location != Tank.LOC_FRONT) {
-            		return false;
-            	}
-            	
-            	if (unit instanceof VTOL) {
-            		/* Per Tech Manual, no equipment can be installed in the rotor, but TacOps
-            		 * allows some. This is equipment which is specifically disallowed. 
-            		 */
-            		if (location == VTOL.LOC_ROTOR) {
-            			if (eq.hasFlag(MiscType.F_HARJEL)
-            					|| eq.hasFlag(MiscType.F_MODULAR_ARMOR)
-            					|| eq.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM)) {
-            				return false;
-            			}
-            		} else {
-            			//Equipment which must be installed in the rotor.
-            			if (eq.hasFlag(MiscType.F_MAST_MOUNT)) {
-            				return false;
-            			}
-            		}
-            	}
+                if (location == Tank.LOC_BODY) {
+                    //Equipment which cannot be installed in the body
+                    if (eq.hasFlag(MiscType.F_HARJEL)
+                            || eq.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM)) {
+                        return false;
+                    }
+                } else {
+                    //Equipment which must be installed in the body
+                    if (eq.hasFlag(MiscType.F_CASE) || eq.hasFlag(MiscType.F_BLUE_SHIELD)) {
+                        return false;
+                    }
+                }
+                if (eq.hasFlag(MiscType.F_BULLDOZER) && location != Tank.LOC_FRONT) {
+                    return false;
+                }
+
+                if (unit instanceof VTOL) {
+                    /* Per Tech Manual, no equipment can be installed in the rotor, but TacOps
+                     * allows some. This is equipment which is specifically disallowed.
+                     */
+                    if (location == VTOL.LOC_ROTOR) {
+                        if (eq.hasFlag(MiscType.F_HARJEL)
+                                || eq.hasFlag(MiscType.F_MODULAR_ARMOR)
+                                || eq.hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM)) {
+                            return false;
+                        }
+                    } else {
+                        //Equipment which must be installed in the rotor.
+                        if (eq.hasFlag(MiscType.F_MAST_MOUNT)) {
+                            return false;
+                        }
+                    }
+                }
             }
-            
         } else if (eq instanceof WeaponType) {
             if (eq.hasFlag(WeaponType.F_VGL)) {
                 if ((unit instanceof Mech)

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -3052,6 +3052,12 @@ public class UnitUtil {
                     || tank.getEngine().getEngineType() == Engine.EXTERNAL)) {
                 return false;
             }
+            // External fuel tanks are only allowed on ICE and fuel cell engines
+            if (eq.hasFlag(MiscType.F_FUEL) && (!tank.hasEngine()
+                    || (tank.getEngine().getEngineType() != Engine.COMBUSTION_ENGINE
+                        && tank.getEngine().getEngineType() != Engine.FUEL_CELL))) {
+                return false;
+            }
             if (eq.hasFlag(MiscType.F_VTOL_EQUIPMENT) && (tank instanceof VTOL)) {
                 return true;
             }


### PR DESCRIPTION
Companion of MegaMek/megamek#1734
Helpfully filters external fuel tanks from the equipment list for non-industrial mechs or any unit without a combustion or fuel cell engine. Limits placement in IndustrialMechs to the torso locations.

I discovered a misplaced closing brace in UnitUtil#isValidLocation and fixed it. That is likely at least part of the cause of #500.