### PR TITLE
Add line breaks to invalid indicator tooltip.

### DIFF
--- a/src/megameklab/com/ui/Aero/StatusBar.java
+++ b/src/megameklab/com/ui/Aero/StatusBar.java
@@ -132,7 +132,7 @@ public class StatusBar extends ITab {
         cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testAero.correctEntity(sb));
-        invalid.setToolTipText(sb.toString());
+        invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");
     }
 
     public double calculateTotalHeat() {

--- a/src/megameklab/com/ui/BattleArmor/StatusBar.java
+++ b/src/megameklab/com/ui/BattleArmor/StatusBar.java
@@ -154,7 +154,7 @@ public class StatusBar extends ITab {
         cost.setText("Squad Cost: " + formatter.format(currentCost) + " C-bills");
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testBA.correctEntity(sb));
-        invalid.setToolTipText(sb.toString());
+        invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");
     }
     
     private void getFluffImage() {

--- a/src/megameklab/com/ui/Infantry/StatusBar.java
+++ b/src/megameklab/com/ui/Infantry/StatusBar.java
@@ -103,7 +103,7 @@ public class StatusBar extends ITab {
         cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
         String str = UnitUtil.validateUnit(getInfantry());
         invalid.setVisible(!str.isEmpty());
-        invalid.setToolTipText(str);
+        invalid.setToolTipText("<html>" + str.replaceAll("\n", "<br/>") + "</html>");
     }
 
     private void getFluffImage() {

--- a/src/megameklab/com/ui/Mek/StatusBar.java
+++ b/src/megameklab/com/ui/Mek/StatusBar.java
@@ -152,7 +152,7 @@ public class StatusBar extends ITab {
         }
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testEntity.correctEntity(sb));
-        invalid.setToolTipText(sb.toString());
+        invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");
     }
 
     public double calculateTotalHeat() {

--- a/src/megameklab/com/ui/Vehicle/StatusBar.java
+++ b/src/megameklab/com/ui/Vehicle/StatusBar.java
@@ -182,7 +182,7 @@ public class StatusBar extends ITab {
         move.setToolTipText("Walk/Run/Jump MP");
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testEntity.correctEntity(sb));
-        invalid.setToolTipText(sb.toString());
+        invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");
     }
 
     private void getFluffImage() {

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
@@ -139,7 +139,7 @@ public class AdvancedAeroStatusBar extends ITab {
         cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testAdvAero.correctEntity(sb));
-        invalid.setToolTipText(sb.toString());
+        invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");
     }
 
     public double calculateTotalHeat() {

--- a/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
@@ -135,7 +135,7 @@ public class DropshipStatusBar extends ITab {
         cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testSmallCraft.correctEntity(sb));
-        invalid.setToolTipText(sb.toString());
+        invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");
     }
 
     public double calculateTotalHeat() {

--- a/src/megameklab/com/ui/protomek/ProtomekStatusBar.java
+++ b/src/megameklab/com/ui/protomek/ProtomekStatusBar.java
@@ -131,7 +131,7 @@ public class ProtomekStatusBar extends ITab {
         }
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testEntity.correctEntity(sb));
-        invalid.setToolTipText(sb.toString());
+        invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");
     }
 
     private void getFluffImage() {

--- a/src/megameklab/com/ui/supportvehicle/SVStatusBar.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStatusBar.java
@@ -169,7 +169,7 @@ class SVStatusBar extends ITab {
         move.setToolTipText("Walk/Run/Jump MP");
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testEntity.correctEntity(sb));
-        invalid.setToolTipText(sb.toString());
+        invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");
     }
 
     private void getFluffImage() {


### PR DESCRIPTION
This little indicator that now shows up in the status bar also has a tooltip that lists all the reasons the unit is flagged as invalid. But they are currently shown on a single line. So I added line breaks to make it more useful.
![Screenshot from 2020-03-09 22-41-47](https://user-images.githubusercontent.com/16927464/76277706-7e5e2f80-6257-11ea-8815-98ccdb616027.png)
