### PR TITLE
Fix check for MASC

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -185,7 +185,7 @@ public class UnitUtil {
      */
     public static boolean isMASC(EquipmentType eq) {
         return (eq instanceof MiscType)
-                && (eq.hasFlag(MiscType.F_MASC) && eq.hasSubType(MiscType.S_STANDARD));
+                && (eq.hasFlag(MiscType.F_MASC) && !eq.hasSubType(MiscType.S_SUPERCHARGER));
     }
 
     /**


### PR DESCRIPTION
When the combo box for mech myomer/MASC is changed, the previous enhancement is supposed to be removed. It is not removing MASC because the check for MASC expects the MiscType to have a subtype of S_STANDARD, but that flag is intended for jump jets and has the same value as S_SUPERCHARGER.

Fixes #545 