### PR TITLE
Fix bounds on location iteration when expanding equipment mounts.

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1774,7 +1774,7 @@ public class UnitUtil {
      * @param unit
      */
     public static void expandUnitMounts(Mech unit) {
-        for (int location = 0; location <= unit.locations(); location++) {
+        for (int location = 0; location < unit.locations(); location++) {
             for (int slot = 0; slot < unit.getNumberOfCriticals(location); slot++) {
                 CriticalSlot cs = unit.getCritical(location, slot);
                 if ((cs == null) || (cs.getType() == CriticalSlot.TYPE_SYSTEM)) {


### PR DESCRIPTION
I touched this a month or so ago to deal with inability to remove spreadable equipment slots from a tripod center leg and didn't notice that it had <= instead of <. This doesn't usually cause a problem because Entity#getNumberOfCriticals returns 0 for non-existent locations and the inner loop is skipped with the invalid index. But LAMs have virtual locations for weapon groups that allow them to be included in capital fighter squadrons, and they enter the inner loop and throw an exception.

Fixes #553 