### PR TITLE
Dependency update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -390,6 +390,7 @@ task assemble(overwrite: true) {
 task assembleDist(overwrite: true) {
     description = 'Build unix, Windows, and source packages'
     group = 'distribution'
+    dependsOn test
     dependsOn unixDistTar
     dependsOn windowsDistZip
 //    dependsOn macDistTar

--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,6 @@ configurations {
 dependencies {
     implementation "org.megamek:megamek${mmBranchTag}:${version}"
     
-    implementation 'log4j:log4j:1.2.17'
     implementation 'org.apache.xmlgraphics:batik-dom:1.10'
     implementation 'org.apache.xmlgraphics:batik-codec:1.10'
     implementation 'org.apache.xmlgraphics:batik-rasterizer:1.10'


### PR DESCRIPTION
Removes the explicit declaration of the log4j dependency, which is inherited from the MM dependency. This avoids potential library conflicts if the version is changed in one but not the other.

Also adds `test` as a dependency of the `assembleDist` Gradle task to ensure unit tests must pass before the `release` task can run. MML.

