### PR TITLE
Don't flag ammo as invalid for support vehicles.

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2944,6 +2944,8 @@ public class UnitUtil {
             // Small support vehicles can only mount infantry weapons
             return (eq instanceof InfantryWeapon)
                     && !eq.hasFlag(WeaponType.F_INF_ARCHAIC);
+        } else if (eq instanceof AmmoType) {
+            return true;
         }
         if (unit.isAero()) {
             return isAeroEquipment(eq, (Aero) unit);


### PR DESCRIPTION
All the work I did filtering the equipment table was focused on MiscType and WeaponType and I didn't pay attention to AmmoType. Since the filtering method is based on white-listing approved equipment, AmmoType gets filtered out. I changed it to white-list ammo automatically at this stage, since the actual ammo filtering is done later in the process.

Fixes #555 