### PR TITLE
Limit VTOL rotor armor to two points.

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1652,6 +1652,8 @@ public class UnitUtil {
             }
         } else if (entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
             return TestProtomech.maxArmorFactor((Protomech) entity, location);
+        } else if ((entity instanceof VTOL) && (location == VTOL.LOC_ROTOR)) {
+            return 2;
         }
         return null;
     }


### PR DESCRIPTION
VTOLs with more than two points of armor on the rotors already fail validation, but this enforces the maximum in the armor points spinner.

Closes #581.