### PR TITLE
Transport tab fixes

### DIFF
--- a/src/megameklab/com/ui/tabs/TransportTab.java
+++ b/src/megameklab/com/ui/tabs/TransportTab.java
@@ -871,21 +871,19 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                 spinner.setModel(model);
                 spinner.addChangeListener(this);
                 return spinner;
-            } else if (column == InstalledBaysModel.COL_SIZE) {
-                SpinnerNumberModel model = new SpinnerNumberModel(modelInstalled.bayList.get(row).getUnusedSlots(),
-                        1.0, null, 1.0);
-                spinner.removeChangeListener(this);
-                spinner.setModel(model);
-                spinner.addChangeListener(this);
-                return spinner;
-            } else if (column == InstalledBaysModel.COL_TONNAGE) {
-                double step = useKilogramStandard() ? 1.0 : 0.5;
-                double current = modelInstalled.bayList.get(row).getWeight();
+            } else if ((column == InstalledBaysModel.COL_SIZE)
+                    || (column == InstalledBaysModel.COL_TONNAGE)) {
+                double step = (isCargo && !useKilogramStandard()) ? 0.5 : 1.0;
+                double current;
+                if (column == InstalledBaysModel.COL_SIZE) {
+                    current = modelInstalled.bayList.get(row).getUnusedSlots();
+                } else {
+                    current = modelInstalled.bayList.get(row).getWeight();
+                }
                 if (useKilogramStandard()) {
                     current *= 1000;
                 }
-                SpinnerNumberModel model = new SpinnerNumberModel(current, step,
-                        null, step);
+                SpinnerNumberModel model = new SpinnerNumberModel(current, step, null, step);
                 spinner.removeChangeListener(this);
                 spinner.setModel(model);
                 spinner.addChangeListener(this);

--- a/src/megameklab/com/ui/tabs/TransportTab.java
+++ b/src/megameklab/com/ui/tabs/TransportTab.java
@@ -746,7 +746,8 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
             bayList.clear();
             for (BayData bay : BayData.values()) {
                 if (eSource.getTechManager().isLegal(bay.getTechAdvancement())
-                        && bay.isLegalFor(getEntity())) {
+                        && bay.isLegalFor(getEntity())
+                        && (!useKilogramStandard() || bay.isCargoBay())) {
                     bayList.add(bay);
                 }
             }
@@ -880,6 +881,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                 } else {
                     current = modelInstalled.bayList.get(row).getWeight();
                 }
+                // We're assuming that the only bays available for kg-standard units are cargo.
                 if (useKilogramStandard()) {
                     current *= 1000;
                 }

--- a/src/megameklab/com/ui/tabs/TransportTab.java
+++ b/src/megameklab/com/ui/tabs/TransportTab.java
@@ -656,7 +656,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                     if (!bayTypeList.get(rowIndex).isCargoBay()) {
                         return (int) bayList.get(rowIndex).getUnusedSlots();
                     } else if (useKilogramStandard()) {
-                        return RoundWeight.nearestKg(bayList.get(rowIndex).getUnusedSlots()) * 1000.0;
+                        return RoundWeight.nearestKg(bayList.get(rowIndex).getUnusedSlots() * 1000.0);
                     }
                     return RoundWeight.nearestKg(bayList.get(rowIndex).getUnusedSlots());
                 case COL_DOORS:
@@ -670,7 +670,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                 case COL_TONNAGE:
                     final double weight = TestEntity.round(bayList.get(rowIndex).getWeight(), TestEntity.Ceil.KILO);
                     if (useKilogramStandard()) {
-                        return weight * 1000.0;
+                        return RoundWeight.nearestKg(weight * 1000.0);
                     } else {
                         return weight;
                     }
@@ -836,6 +836,10 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                     size /= 1000.0;
                 } else if ((column == InstalledBaysModel.COL_SIZE) && bayType.isCargoBay()) {
                     size *= bayType.getWeight();
+                    if (useKilogramStandard()) {
+                        size /= 1000.0;
+                    }
+                    size = RoundWeight.nearestKg(size);
                 }
                 Bay newBay = bayType.newBay(size, bay.getBayNumber());
                 newBay.setDoors(bay.getDoors());


### PR DESCRIPTION
Fixes two bugs introduced by adding the option to set cargo bay size by capacity or overall bay tonnage.

1. The size spinner uses a step size of 1,000 kg instead of 1 kg.
2. The minimum size is also set to 1,000 kg, which throws an exception if the bay size is less than that.
3. Unit transport bays have the same 0.5 step size as cargo bays, allowing you to add half a cubicle.

I also filtered out all non-cargo bays for units using the kg standard (i.e. small support vehicles) since they exceed the maximum tonnage for those units.

Fixes #583
Fixes #587 