### PR TITLE
Update crew size when adding or removing a bay

### DIFF
--- a/src/megameklab/com/ui/tabs/TransportTab.java
+++ b/src/megameklab/com/ui/tabs/TransportTab.java
@@ -375,6 +375,8 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
         int personnel = bay.getPersonnel(getEntity().isClan());
         if (getEntity().hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)) {
             getSmallCraft().setNCrew(getSmallCraft().getNCrew() - personnel);
+        } else if (getEntity().hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+            getJumpship().setNCrew(getJumpship().getNCrew() - personnel);
         }
         getEntity().removeTransporter(bay);
     }
@@ -389,6 +391,8 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
         int personnel = bay.getPersonnel(getEntity().isClan());
         if (getEntity().hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)) {
             getSmallCraft().setNCrew(getSmallCraft().getNCrew() + personnel);
+        } else if (getEntity().hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+            getJumpship().setNCrew(getJumpship().getNCrew() + personnel);
         }
     }
     


### PR DESCRIPTION
This is done for small craft and dropships, but not advanced aerospace units. Though bay personnel are not considered in minimum crew or accomodations calculations, they are included in Aero#getNCrew.

Fixes #552