### PR TITLE
Don't show capital fighter weapon groups on record sheet

### DIFF
--- a/src/megameklab/com/printing/InventoryWriter.java
+++ b/src/megameklab/com/printing/InventoryWriter.java
@@ -210,6 +210,9 @@ public class InventoryWriter {
 
     private void parseEquipment() {
         for (Mounted m : sheet.getEntity().getEquipment()) {
+            if (m.isWeaponGroup()) {
+                continue;
+            }
             if ((m.getType() instanceof AmmoType)
                     && (((AmmoType) m.getType()).getAmmoType() != AmmoType.T_COOLANT_POD)) {
                 if (m.getLocation() != Entity.LOC_NONE) {


### PR DESCRIPTION
Somehow I never noticed it was doing this.

Fixes #598