### PR TITLE
Update armor panel when SI changes

### DIFF
--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
@@ -498,6 +498,7 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
     @Override
     public void siChanged(int si) {
         getJumpship().set0SI(si);
+        panArmor.setFromEntity(getJumpship());
         panArmorAllocation.setFromEntity(getJumpship());
         refresh.refreshStatus();
         refresh.refreshSummary();

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStructureTab.java
@@ -499,6 +499,10 @@ public class AdvancedAeroStructureTab extends ITab implements AdvancedAeroBuildL
     public void siChanged(int si) {
         getJumpship().set0SI(si);
         panArmor.setFromEntity(getJumpship());
+        // Change in SI can reduce the maximum armor tonnage
+        if (getJumpship().getLabArmorTonnage() != panArmor.getArmorTonnage()) {
+            armorTonnageChanged(panArmor.getArmorTonnage());
+        }
         panArmorAllocation.setFromEntity(getJumpship());
         refresh.refreshStatus();
         refresh.refreshSummary();

--- a/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
@@ -455,6 +455,10 @@ public class DropshipStructureTab extends ITab implements DropshipBuildListener,
     public void siChanged(int si) {
         getSmallCraft().set0SI(si);
         panArmor.setFromEntity(getSmallCraft());
+        // Change in SI can reduce the maximum armor tonnage
+        if (getSmallCraft().getLabArmorTonnage() != panArmor.getArmorTonnage()) {
+            armorTonnageChanged(panArmor.getArmorTonnage());
+        }
         panArmorAllocation.setFromEntity(getSmallCraft());
         refresh.refreshStatus();
         refresh.refreshSummary();

--- a/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
@@ -454,6 +454,7 @@ public class DropshipStructureTab extends ITab implements DropshipBuildListener,
     @Override
     public void siChanged(int si) {
         getSmallCraft().set0SI(si);
+        panArmor.setFromEntity(getSmallCraft());
         panArmorAllocation.setFromEntity(getSmallCraft());
         refresh.refreshStatus();
         refresh.refreshSummary();

--- a/src/megameklab/com/ui/view/MVFArmorView.java
+++ b/src/megameklab/com/ui/view/MVFArmorView.java
@@ -364,6 +364,10 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
         return 2;
     }
 
+    public double getArmorTonnage() {
+        return tonnageModel.getNumber().doubleValue();
+    }
+
     @Override
     public void stateChanged(ChangeEvent e) {
         if (e.getSource() == spnTonnage) {


### PR DESCRIPTION
The maximum armor tonnage on non-fighter aerospace units is determined by the SI. When the SI changes (either directly or through increasing the thrust value) the armor tonnage spinner isn't being updated. This PR adds an update to the armor panel when the SI changes (works whether direct or indirect), and also reducing the armor tonnage when an SI reduction drops the maximum below the current value.

Fixes #543 