### PR TITLE
Remove standard armor from primitive jumpship options.

### DIFF
--- a/src/megameklab/com/ui/view/MVFArmorView.java
+++ b/src/megameklab/com/ui/view/MVFArmorView.java
@@ -70,6 +70,7 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
     
     private long etype;
     private boolean industrial;
+    private boolean primitive;
     private EntityMovementMode movementMode;
     private boolean svLimitedArmor;
 
@@ -206,6 +207,7 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
     public void setFromEntity(Entity en, boolean ignoreEntityPatchwork) {
         etype = en.getEntityType();
         industrial = (en instanceof Mech) && ((Mech)en).isIndustrial();
+        primitive = en.isPrimitive();
         movementMode = en.getMovementMode();
         svLimitedArmor = en.isSupportVehicle() && !en.hasArmoredChassis();
         refresh();
@@ -281,7 +283,8 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
         cbArmorType.removeActionListener(this);
         cbArmorType.removeAllItems();
         if (!svLimitedArmor) {
-            List<EquipmentType> allArmors = TestEntity.legalArmorsFor(etype, industrial, movementMode, techManager);
+            List<EquipmentType> allArmors = TestEntity.legalArmorsFor(etype, industrial, primitive,
+                    movementMode, techManager);
             allArmors.forEach(cbArmorType::addItem);
         } else {
             cbArmorType.addItem(EquipmentType.get(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_STANDARD)));

--- a/src/megameklab/com/ui/view/PatchworkArmorView.java
+++ b/src/megameklab/com/ui/view/PatchworkArmorView.java
@@ -102,6 +102,7 @@ public class PatchworkArmorView extends BuildView implements ActionListener {
     public void setFromEntity(Entity en) {
         List<EquipmentType> armors = TestEntity.legalArmorsFor(en.getEntityType(),
                 (en instanceof Mech) && ((Mech)en).isIndustrial(),
+                en.isPrimitive(),
                 en.getMovementMode(), techManager);
         ignoreEvents = true;
         for (int loc = 0; loc < combos.size(); loc++) {


### PR DESCRIPTION
Companion to MegaMek/megamek#1895, reflecting the API changes.