### PR TITLE
Fix appearance of custom combo box list renderers.

### DIFF
--- a/src/megameklab/com/ui/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/tabs/EquipmentTab.java
@@ -928,7 +928,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         @Override
         public Component getListCellRendererComponent(JList<? extends EquipmentCategory> list,
                 EquipmentCategory value, int index, boolean isSelected, boolean cellHasFocus) {
-            setOpaque(true);
+            setOpaque(list.isOpaque());
             if (isSelected) {
                 setBackground(list.getSelectionBackground());
                 setForeground(list.getSelectionForeground());

--- a/src/megameklab/com/ui/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/tabs/EquipmentTab.java
@@ -928,7 +928,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         @Override
         public Component getListCellRendererComponent(JList<? extends EquipmentCategory> list,
                 EquipmentCategory value, int index, boolean isSelected, boolean cellHasFocus) {
-            
+            setOpaque(true);
             if (isSelected) {
                 setBackground(list.getSelectionBackground());
                 setForeground(list.getSelectionForeground());

--- a/src/megameklab/com/ui/util/CustomComboBox.java
+++ b/src/megameklab/com/ui/util/CustomComboBox.java
@@ -83,6 +83,17 @@ public class CustomComboBox<T> extends JComboBox<T> {
         @Override
         public Component getListCellRendererComponent(JList<? extends U> list, U value, int index, boolean isSelected,
                 boolean cellHasFocus) {
+            setOpaque(true);
+            if (isSelected) {
+                setBackground(list.getSelectionBackground());
+                setForeground(list.getSelectionForeground());
+            } else {
+                setBackground(list.getBackground());
+                setForeground(list.getForeground());
+            }
+            setEnabled(list.isEnabled());
+            setFont(list.getFont());
+
             try {
                 setText(toString.apply(value));
             } catch (Exception ex) {

--- a/src/megameklab/com/ui/util/CustomComboBox.java
+++ b/src/megameklab/com/ui/util/CustomComboBox.java
@@ -83,7 +83,7 @@ public class CustomComboBox<T> extends JComboBox<T> {
         @Override
         public Component getListCellRendererComponent(JList<? extends U> list, U value, int index, boolean isSelected,
                 boolean cellHasFocus) {
-            setOpaque(true);
+            setOpaque(list.isOpaque());
             if (isSelected) {
                 setBackground(list.getSelectionBackground());
                 setForeground(list.getSelectionForeground());


### PR DESCRIPTION
This fixes one combo box rendering issue that I observed and probably another that has been reported that I was not able to duplicate. On my machine using the GTK+ theme, the category selection ComboBox does on the equipment tab used by protomechs and support vehicles does not display the selected item in the list when it is visible. I fixed this by setting the opaque field of the cell renderer to the same value as the List component. A similar issue of disappearing text has been reported for many of the ComboBoxes on the structure tab, which I was not able to reproduce. But I assume that setting the opacity and the foreground and background colors will resolve that as well.

(Presumably) fixes #546 