### PR TITLE
Fix text overlap in vehicle record sheet tables

### DIFF
--- a/data/images/recordsheets/naval_dualturret_standard.svg
+++ b/data/images/recordsheets/naval_dualturret_standard.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,7 +423,7 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
                                       >Turret Locked</text
                                       ><path fill="none" d="M 52.800,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="56.800" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="2.780" lengthAdjust="spacingAndGlyphs"
@@ -433,12 +433,12 @@
                                       >R</text
                                     ></g
                                     ><g transform="translate (84.600 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -454,7 +454,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -469,32 +469,32 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="22.854" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="22.854" lengthAdjust="spacingAndGlyphs"
                                       >F Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="23.760" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="23.760" lengthAdjust="spacingAndGlyphs"
                                       >R Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1124,9 +1124,7 @@
                                                                         >ATTACK DIRECTION</text
                                                                         ><g transform="translate (0.000 32.000)"
                                                                         ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                                          ><tspan x="20.800" y="0.000"
-                                                                            >2D6 ROLL</tspan
-                                                                            ><tspan x="62.400" y="0.000"
+                                                                          ><tspan x="62.400" y="0.000"
                                                                             >FRONT</tspan
                                                                             ><tspan x="114.400" y="0.000"
                                                                             >REAR</tspan
@@ -1228,21 +1226,21 @@
                                                                         ></g
                                                                         ><g transform="translate(0,115.800)"
                                                                         ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                                          >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                                           ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                           >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                                           ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                           >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                                          ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                                          ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                                           >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                                          ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                                          >Total Warfare </text
-                                                                          ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                                          ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                                          >Total Warfare</text
+                                                                          ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                                           > </text
                                                                           ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                           >for more information).</text
                                                                           ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                                          >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                                           ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                           >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                           ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1251,11 +1249,11 @@
                                                                           >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                                           ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                           >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                                          ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                                          ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                                           >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                                          ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                                          >Total Warfare </text
-                                                                          ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                                          ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                                          >Total Warfare</text
+                                                                          ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                                           > </text
                                                                           ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                           >for more information).</text
@@ -1300,13 +1298,13 @@
                                                                           ><tspan x="37.530" y="7.000"
                                                                             >No Effect</tspan
                                                                             ><tspan x="37.530" y="14.000"
-                                                                            >Minor damage; +1 modifer to all</tspan
+                                                                            >Minor damage; +1 modifier to all</tspan
                                                                             ><tspan x="37.530" y="21.000"
                                                                             >Driving Skill Rolls</tspan
                                                                             ><tspan x="37.530" y="28.000"
                                                                             >Moderate damage; -1 Cruising</tspan
                                                                             ><tspan x="37.530" y="35.000"
-                                                                            >MP, +2 modifer to all Driving Skill</tspan
+                                                                            >MP, +2 modifier to all Driving Skill</tspan
                                                                             ><tspan x="37.530" y="42.000"
                                                                             >Rolls</tspan
                                                                             ><tspan x="37.530" y="49.000"
@@ -1314,7 +1312,7 @@
                                                                             ><tspan x="37.530" y="56.000"
                                                                             >MP (round fractions up), +3</tspan
                                                                             ><tspan x="37.530" y="63.000"
-                                                                            >modifer to all Driving Skill Rolls</tspan
+                                                                            >modifier to all Driving Skill Rolls</tspan
                                                                             ><tspan x="37.530" y="70.000"
                                                                             >Major damage; no movement for</tspan
                                                                             ><tspan x="37.530" y="77.000"
@@ -1358,15 +1356,15 @@
                                                                         ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                         >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                                         ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                        >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                                        >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                                         ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                        >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                                        >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                                         ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                         >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                                         ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                         >has no additional effect. This means the maximum Driving Skill Roll</text
                                                                         ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                        >modifer that can be inficted from the Motive System Damage Table is</text
+                                                                        >modifier that can be inflicted from the Motive System Damage Table is</text
                                                                         ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                         >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                                         ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1390,9 +1388,7 @@
                                                                         >LOCATION HIT</text
                                                                         ><g transform="translate (0.000 34.000)"
                                                                         ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                                          ><tspan x="53.250" y="0.000"
-                                                                            >2D6 ROLL</tspan
-                                                                            ><tspan x="95.850" y="0.000"
+                                                                          ><tspan x="95.850" y="0.000"
                                                                             >FRONT</tspan
                                                                             ><tspan x="159.750" y="0.000"
                                                                             >SIDE</tspan

--- a/data/images/recordsheets/naval_dualturret_superheavy.svg
+++ b/data/images/recordsheets/naval_dualturret_superheavy.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,7 +423,7 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
                                       >Turret Locked</text
                                       ><path fill="none" d="M 52.800,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="56.800" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="2.780" lengthAdjust="spacingAndGlyphs"
@@ -433,12 +433,12 @@
                                       >R</text
                                     ></g
                                     ><g transform="translate (84.600 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -454,7 +454,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -469,32 +469,32 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="22.854" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="22.854" lengthAdjust="spacingAndGlyphs"
                                       >F Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="23.760" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="23.760" lengthAdjust="spacingAndGlyphs"
                                       >R Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1121,9 +1121,7 @@
                                                                           >ATTACK DIRECTION</text
                                                                           ><g transform="translate (0.000 32.000)"
                                                                           ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                                            ><tspan x="20.800" y="0.000"
-                                                                              >2D6 ROLL</tspan
-                                                                              ><tspan x="62.400" y="0.000"
+                                                                            ><tspan x="62.400" y="0.000"
                                                                               >FRONT</tspan
                                                                               ><tspan x="114.400" y="0.000"
                                                                               >REAR</tspan
@@ -1225,21 +1223,21 @@
                                                                           ></g
                                                                           ><g transform="translate(0,115.800)"
                                                                           ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                            >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                                            >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                                             ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                             >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                                             ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                             >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                                            ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                                            ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                                             >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                                            ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                                            >Total Warfare </text
-                                                                            ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                                            ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                                            >Total Warfare</text
+                                                                            ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                                             > </text
                                                                             ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                             >for more information).</text
                                                                             ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                            >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                                            >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                                             ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                             >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                             ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1248,11 +1246,11 @@
                                                                             >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                                             ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                             >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                                            ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                                            ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                                             >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                                            ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                                            >Total Warfare </text
-                                                                            ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                                            ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                                            >Total Warfare</text
+                                                                            ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                                             > </text
                                                                             ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                             >for more information).</text
@@ -1297,13 +1295,13 @@
                                                                             ><tspan x="37.530" y="7.000"
                                                                               >No Effect</tspan
                                                                               ><tspan x="37.530" y="14.000"
-                                                                              >Minor damage; +1 modifer to all</tspan
+                                                                              >Minor damage; +1 modifier to all</tspan
                                                                               ><tspan x="37.530" y="21.000"
                                                                               >Driving Skill Rolls</tspan
                                                                               ><tspan x="37.530" y="28.000"
                                                                               >Moderate damage; -1 Cruising</tspan
                                                                               ><tspan x="37.530" y="35.000"
-                                                                              >MP, +2 modifer to all Driving Skill</tspan
+                                                                              >MP, +2 modifier to all Driving Skill</tspan
                                                                               ><tspan x="37.530" y="42.000"
                                                                               >Rolls</tspan
                                                                               ><tspan x="37.530" y="49.000"
@@ -1311,7 +1309,7 @@
                                                                               ><tspan x="37.530" y="56.000"
                                                                               >MP (round fractions up), +3</tspan
                                                                               ><tspan x="37.530" y="63.000"
-                                                                              >modifer to all Driving Skill Rolls</tspan
+                                                                              >modifier to all Driving Skill Rolls</tspan
                                                                               ><tspan x="37.530" y="70.000"
                                                                               >Major damage; no movement for</tspan
                                                                               ><tspan x="37.530" y="77.000"
@@ -1355,15 +1353,15 @@
                                                                           ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                           >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                                           ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                                          >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                                           ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                                          >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                                           ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                           >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                                           ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                           >has no additional effect. This means the maximum Driving Skill Roll</text
                                                                           ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >modifer that can be inficted from the Motive System Damage Table is</text
+                                                                          >modifier that can be inflicted from the Motive System Damage Table is</text
                                                                           ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                           >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                                           ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1387,9 +1385,7 @@
                                                                           >LOCATION HIT</text
                                                                           ><g transform="translate (0.000 34.000)"
                                                                           ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                                            ><tspan x="53.250" y="0.000"
-                                                                              >2D6 ROLL</tspan
-                                                                              ><tspan x="95.850" y="0.000"
+                                                                            ><tspan x="95.850" y="0.000"
                                                                               >FRONT</tspan
                                                                               ><tspan x="159.750" y="0.000"
                                                                               >SIDE</tspan

--- a/data/images/recordsheets/naval_noturret_standard.svg
+++ b/data/images/recordsheets/naval_noturret_standard.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,12 +423,12 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -444,7 +444,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -459,22 +459,22 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1138,9 +1138,7 @@
                                                             >ATTACK DIRECTION</text
                                                             ><g transform="translate (0.000 32.000)"
                                                             ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                              ><tspan x="20.800" y="0.000"
-                                                                >2D6 ROLL</tspan
-                                                                ><tspan x="62.400" y="0.000"
+                                                              ><tspan x="62.400" y="0.000"
                                                                 >FRONT</tspan
                                                                 ><tspan x="114.400" y="0.000"
                                                                 >REAR</tspan
@@ -1242,21 +1240,21 @@
                                                             ></g
                                                             ><g transform="translate(0,115.800)"
                                                             ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                              >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                              >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                               ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                               >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                               ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                               >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                              ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                              ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                               >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                              ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                              >Total Warfare </text
-                                                              ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                              ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                              >Total Warfare</text
+                                                              ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                               > </text
                                                               ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                               >for more information).</text
                                                               ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                              >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                              >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                               ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                               >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                               ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1265,11 +1263,11 @@
                                                               >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                               ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                               >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                              ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                              ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                               >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                              ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                              >Total Warfare </text
-                                                              ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                              ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                              >Total Warfare</text
+                                                              ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                               > </text
                                                               ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                               >for more information).</text
@@ -1314,13 +1312,13 @@
                                                               ><tspan x="37.530" y="7.000"
                                                                 >No Effect</tspan
                                                                 ><tspan x="37.530" y="14.000"
-                                                                >Minor damage; +1 modifer to all</tspan
+                                                                >Minor damage; +1 modifier to all</tspan
                                                                 ><tspan x="37.530" y="21.000"
                                                                 >Driving Skill Rolls</tspan
                                                                 ><tspan x="37.530" y="28.000"
                                                                 >Moderate damage; -1 Cruising</tspan
                                                                 ><tspan x="37.530" y="35.000"
-                                                                >MP, +2 modifer to all Driving Skill</tspan
+                                                                >MP, +2 modifier to all Driving Skill</tspan
                                                                 ><tspan x="37.530" y="42.000"
                                                                 >Rolls</tspan
                                                                 ><tspan x="37.530" y="49.000"
@@ -1328,7 +1326,7 @@
                                                                 ><tspan x="37.530" y="56.000"
                                                                 >MP (round fractions up), +3</tspan
                                                                 ><tspan x="37.530" y="63.000"
-                                                                >modifer to all Driving Skill Rolls</tspan
+                                                                >modifier to all Driving Skill Rolls</tspan
                                                                 ><tspan x="37.530" y="70.000"
                                                                 >Major damage; no movement for</tspan
                                                                 ><tspan x="37.530" y="77.000"
@@ -1372,15 +1370,15 @@
                                                             ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                             >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                             ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                            >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                            >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                             ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                            >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                            >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                             ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                             >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                             ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                             >has no additional effect. This means the maximum Driving Skill Roll</text
                                                             ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                            >modifer that can be inficted from the Motive System Damage Table is</text
+                                                            >modifier that can be inflicted from the Motive System Damage Table is</text
                                                             ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                             >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                             ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1404,9 +1402,7 @@
                                                             >LOCATION HIT</text
                                                             ><g transform="translate (0.000 34.000)"
                                                             ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                              ><tspan x="53.250" y="0.000"
-                                                                >2D6 ROLL</tspan
-                                                                ><tspan x="95.850" y="0.000"
+                                                              ><tspan x="95.850" y="0.000"
                                                                 >FRONT</tspan
                                                                 ><tspan x="159.750" y="0.000"
                                                                 >SIDE</tspan

--- a/data/images/recordsheets/naval_noturret_superheavy.svg
+++ b/data/images/recordsheets/naval_noturret_superheavy.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,12 +423,12 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -444,7 +444,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -459,22 +459,22 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1108,9 +1108,7 @@
                                                                 >ATTACK DIRECTION</text
                                                                 ><g transform="translate (0.000 32.000)"
                                                                 ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                                  ><tspan x="20.800" y="0.000"
-                                                                    >2D6 ROLL</tspan
-                                                                    ><tspan x="62.400" y="0.000"
+                                                                  ><tspan x="62.400" y="0.000"
                                                                     >FRONT</tspan
                                                                     ><tspan x="114.400" y="0.000"
                                                                     >REAR</tspan
@@ -1212,21 +1210,21 @@
                                                                 ></g
                                                                 ><g transform="translate(0,115.800)"
                                                                 ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                  >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                                  >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                                   ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                   >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                                   ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                   >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                                  ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                                  ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                                   >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                                  ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                                  >Total Warfare </text
-                                                                  ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                                  ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                                  >Total Warfare</text
+                                                                  ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                                   > </text
                                                                   ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                   >for more information).</text
                                                                   ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                  >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                                  >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                                   ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                   >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                   ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1235,11 +1233,11 @@
                                                                   >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                                   ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                   >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                                  ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                                  ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                                   >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                                  ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                                  >Total Warfare </text
-                                                                  ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                                  ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                                  >Total Warfare</text
+                                                                  ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                                   > </text
                                                                   ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                   >for more information).</text
@@ -1284,13 +1282,13 @@
                                                                   ><tspan x="37.530" y="7.000"
                                                                     >No Effect</tspan
                                                                     ><tspan x="37.530" y="14.000"
-                                                                    >Minor damage; +1 modifer to all</tspan
+                                                                    >Minor damage; +1 modifier to all</tspan
                                                                     ><tspan x="37.530" y="21.000"
                                                                     >Driving Skill Rolls</tspan
                                                                     ><tspan x="37.530" y="28.000"
                                                                     >Moderate damage; -1 Cruising</tspan
                                                                     ><tspan x="37.530" y="35.000"
-                                                                    >MP, +2 modifer to all Driving Skill</tspan
+                                                                    >MP, +2 modifier to all Driving Skill</tspan
                                                                     ><tspan x="37.530" y="42.000"
                                                                     >Rolls</tspan
                                                                     ><tspan x="37.530" y="49.000"
@@ -1298,7 +1296,7 @@
                                                                     ><tspan x="37.530" y="56.000"
                                                                     >MP (round fractions up), +3</tspan
                                                                     ><tspan x="37.530" y="63.000"
-                                                                    >modifer to all Driving Skill Rolls</tspan
+                                                                    >modifier to all Driving Skill Rolls</tspan
                                                                     ><tspan x="37.530" y="70.000"
                                                                     >Major damage; no movement for</tspan
                                                                     ><tspan x="37.530" y="77.000"
@@ -1342,15 +1340,15 @@
                                                                 ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                 >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                                 ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                                >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                                 ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                                >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                                 ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                 >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                                 ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                 >has no additional effect. This means the maximum Driving Skill Roll</text
                                                                 ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                >modifer that can be inficted from the Motive System Damage Table is</text
+                                                                >modifier that can be inflicted from the Motive System Damage Table is</text
                                                                 ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                 >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                                 ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1374,9 +1372,7 @@
                                                                 >LOCATION HIT</text
                                                                 ><g transform="translate (0.000 34.000)"
                                                                 ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                                  ><tspan x="53.250" y="0.000"
-                                                                    >2D6 ROLL</tspan
-                                                                    ><tspan x="95.850" y="0.000"
+                                                                  ><tspan x="95.850" y="0.000"
                                                                     >FRONT</tspan
                                                                     ><tspan x="159.750" y="0.000"
                                                                     >SIDE</tspan

--- a/data/images/recordsheets/naval_turret_standard.svg
+++ b/data/images/recordsheets/naval_turret_standard.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,17 +423,17 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
                                       >Turret Locked</text
                                       ><path fill="none" d="M 63.800,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (84.600 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -449,7 +449,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -464,27 +464,27 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="17.867" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="17.867" lengthAdjust="spacingAndGlyphs"
                                       >Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1115,9 +1115,7 @@
                                                                   >ATTACK DIRECTION</text
                                                                   ><g transform="translate (0.000 32.000)"
                                                                   ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                                    ><tspan x="20.800" y="0.000"
-                                                                      >2D6 ROLL</tspan
-                                                                      ><tspan x="62.400" y="0.000"
+                                                                    ><tspan x="62.400" y="0.000"
                                                                       >FRONT</tspan
                                                                       ><tspan x="114.400" y="0.000"
                                                                       >REAR</tspan
@@ -1219,21 +1217,21 @@
                                                                   ></g
                                                                   ><g transform="translate(0,115.800)"
                                                                   ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                    >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                                    >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                                     ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                     >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                                     ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                     >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                                    ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                                    ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                                     >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                                    ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                                    >Total Warfare </text
-                                                                    ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                                    ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                                    >Total Warfare</text
+                                                                    ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                                     > </text
                                                                     ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                     >for more information).</text
                                                                     ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                    >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                                    >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                                     ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                     >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                     ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1242,11 +1240,11 @@
                                                                     >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                                     ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                     >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                                    ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                                    ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                                     >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                                    ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                                    >Total Warfare </text
-                                                                    ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                                    ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                                    >Total Warfare</text
+                                                                    ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                                     > </text
                                                                     ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                     >for more information).</text
@@ -1291,13 +1289,13 @@
                                                                     ><tspan x="37.530" y="7.000"
                                                                       >No Effect</tspan
                                                                       ><tspan x="37.530" y="14.000"
-                                                                      >Minor damage; +1 modifer to all</tspan
+                                                                      >Minor damage; +1 modifier to all</tspan
                                                                       ><tspan x="37.530" y="21.000"
                                                                       >Driving Skill Rolls</tspan
                                                                       ><tspan x="37.530" y="28.000"
                                                                       >Moderate damage; -1 Cruising</tspan
                                                                       ><tspan x="37.530" y="35.000"
-                                                                      >MP, +2 modifer to all Driving Skill</tspan
+                                                                      >MP, +2 modifier to all Driving Skill</tspan
                                                                       ><tspan x="37.530" y="42.000"
                                                                       >Rolls</tspan
                                                                       ><tspan x="37.530" y="49.000"
@@ -1305,7 +1303,7 @@
                                                                       ><tspan x="37.530" y="56.000"
                                                                       >MP (round fractions up), +3</tspan
                                                                       ><tspan x="37.530" y="63.000"
-                                                                      >modifer to all Driving Skill Rolls</tspan
+                                                                      >modifier to all Driving Skill Rolls</tspan
                                                                       ><tspan x="37.530" y="70.000"
                                                                       >Major damage; no movement for</tspan
                                                                       ><tspan x="37.530" y="77.000"
@@ -1349,15 +1347,15 @@
                                                                   ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                   >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                                   ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                  >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                                  >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                                   ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                  >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                                  >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                                   ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                   >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                                   ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                   >has no additional effect. This means the maximum Driving Skill Roll</text
                                                                   ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                  >modifer that can be inficted from the Motive System Damage Table is</text
+                                                                  >modifier that can be inflicted from the Motive System Damage Table is</text
                                                                   ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                   >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                                   ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1381,9 +1379,7 @@
                                                                   >LOCATION HIT</text
                                                                   ><g transform="translate (0.000 34.000)"
                                                                   ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                                    ><tspan x="53.250" y="0.000"
-                                                                      >2D6 ROLL</tspan
-                                                                      ><tspan x="95.850" y="0.000"
+                                                                    ><tspan x="95.850" y="0.000"
                                                                       >FRONT</tspan
                                                                       ><tspan x="159.750" y="0.000"
                                                                       >SIDE</tspan

--- a/data/images/recordsheets/naval_turret_superheavy.svg
+++ b/data/images/recordsheets/naval_turret_superheavy.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,17 +423,17 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
                                       >Turret Locked</text
                                       ><path fill="none" d="M 63.800,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (84.600 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -449,7 +449,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -464,27 +464,27 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="17.867" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="17.867" lengthAdjust="spacingAndGlyphs"
                                       >Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1119,9 +1119,7 @@
                                                                       >ATTACK DIRECTION</text
                                                                       ><g transform="translate (0.000 32.000)"
                                                                       ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                                        ><tspan x="20.800" y="0.000"
-                                                                          >2D6 ROLL</tspan
-                                                                          ><tspan x="62.400" y="0.000"
+                                                                        ><tspan x="62.400" y="0.000"
                                                                           >FRONT</tspan
                                                                           ><tspan x="114.400" y="0.000"
                                                                           >REAR</tspan
@@ -1223,21 +1221,21 @@
                                                                       ></g
                                                                       ><g transform="translate(0,115.800)"
                                                                       ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                        >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                                        >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                                         ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                         >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                                         ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                         >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                                        ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                                        ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                                         >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                                        ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                                        >Total Warfare </text
-                                                                        ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                                        ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                                        >Total Warfare</text
+                                                                        ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                                         > </text
                                                                         ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                         >for more information).</text
                                                                         ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                        >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                                        >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                                         ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                         >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                         ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1246,11 +1244,11 @@
                                                                         >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                                         ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                         >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                                        ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                                        ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                                         >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                                        ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                                        >Total Warfare </text
-                                                                        ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                                        ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                                        >Total Warfare</text
+                                                                        ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                                         > </text
                                                                         ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                         >for more information).</text
@@ -1295,13 +1293,13 @@
                                                                         ><tspan x="37.530" y="7.000"
                                                                           >No Effect</tspan
                                                                           ><tspan x="37.530" y="14.000"
-                                                                          >Minor damage; +1 modifer to all</tspan
+                                                                          >Minor damage; +1 modifier to all</tspan
                                                                           ><tspan x="37.530" y="21.000"
                                                                           >Driving Skill Rolls</tspan
                                                                           ><tspan x="37.530" y="28.000"
                                                                           >Moderate damage; -1 Cruising</tspan
                                                                           ><tspan x="37.530" y="35.000"
-                                                                          >MP, +2 modifer to all Driving Skill</tspan
+                                                                          >MP, +2 modifier to all Driving Skill</tspan
                                                                           ><tspan x="37.530" y="42.000"
                                                                           >Rolls</tspan
                                                                           ><tspan x="37.530" y="49.000"
@@ -1309,7 +1307,7 @@
                                                                           ><tspan x="37.530" y="56.000"
                                                                           >MP (round fractions up), +3</tspan
                                                                           ><tspan x="37.530" y="63.000"
-                                                                          >modifer to all Driving Skill Rolls</tspan
+                                                                          >modifier to all Driving Skill Rolls</tspan
                                                                           ><tspan x="37.530" y="70.000"
                                                                           >Major damage; no movement for</tspan
                                                                           ><tspan x="37.530" y="77.000"
@@ -1353,15 +1351,15 @@
                                                                       ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                       >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                                       ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                      >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                                      >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                                       ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                      >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                                      >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                                       ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                       >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                                       ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                       >has no additional effect. This means the maximum Driving Skill Roll</text
                                                                       ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                      >modifer that can be inficted from the Motive System Damage Table is</text
+                                                                      >modifier that can be inflicted from the Motive System Damage Table is</text
                                                                       ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                       >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                                       ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1385,9 +1383,7 @@
                                                                       >LOCATION HIT</text
                                                                       ><g transform="translate (0.000 34.000)"
                                                                       ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                                        ><tspan x="53.250" y="0.000"
-                                                                          >2D6 ROLL</tspan
-                                                                          ><tspan x="95.850" y="0.000"
+                                                                        ><tspan x="95.850" y="0.000"
                                                                           >FRONT</tspan
                                                                           ><tspan x="159.750" y="0.000"
                                                                           >SIDE</tspan

--- a/data/images/recordsheets/submarine_dualturret_standard.svg
+++ b/data/images/recordsheets/submarine_dualturret_standard.svg
@@ -1303,7 +1303,7 @@
                                                                           ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                           >for more information).</text
                                                                           ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
+                                                                          >A result of 12 on the Naval Combat Vehicles Hit Location Table may a inflict critical hit</text
                                                                           ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                           >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                           ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"

--- a/data/images/recordsheets/submarine_dualturret_standard.svg
+++ b/data/images/recordsheets/submarine_dualturret_standard.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,7 +423,7 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
                                       >Turret Locked</text
                                       ><path fill="none" d="M 52.800,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="56.800" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="2.780" lengthAdjust="spacingAndGlyphs"
@@ -433,12 +433,12 @@
                                       >R</text
                                     ></g
                                     ><g transform="translate (84.600 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -454,7 +454,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -469,32 +469,32 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="22.854" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="22.854" lengthAdjust="spacingAndGlyphs"
                                       >F Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="23.760" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="23.760" lengthAdjust="spacingAndGlyphs"
                                       >R Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1187,9 +1187,7 @@
                                                                         >ATTACK DIRECTION</text
                                                                         ><g transform="translate (0.000 32.000)"
                                                                         ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                                          ><tspan x="20.800" y="0.000"
-                                                                            >2D6 ROLL</tspan
-                                                                            ><tspan x="62.400" y="0.000"
+                                                                          ><tspan x="62.400" y="0.000"
                                                                             >FRONT</tspan
                                                                             ><tspan x="114.400" y="0.000"
                                                                             >REAR</tspan
@@ -1291,21 +1289,21 @@
                                                                         ></g
                                                                         ><g transform="translate(0,115.800)"
                                                                         ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                                          >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                                           ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                           >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                                           ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                           >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                                          ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                                          ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                                           >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                                          ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                                          >Total Warfare </text
-                                                                          ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                                          ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                                          >Total Warfare</text
+                                                                          ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                                           > </text
                                                                           ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                           >for more information).</text
                                                                           ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                                          >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                                           ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                           >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                           ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1314,11 +1312,11 @@
                                                                           >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                                           ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                           >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                                          ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                                          ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                                           >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                                          ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                                          >Total Warfare </text
-                                                                          ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                                          ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                                          >Total Warfare</text
+                                                                          ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                                           > </text
                                                                           ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                           >for more information).</text
@@ -1363,13 +1361,13 @@
                                                                           ><tspan x="37.530" y="7.000"
                                                                             >No Effect</tspan
                                                                             ><tspan x="37.530" y="14.000"
-                                                                            >Minor damage; +1 modifer to all</tspan
+                                                                            >Minor damage; +1 modifier to all</tspan
                                                                             ><tspan x="37.530" y="21.000"
                                                                             >Driving Skill Rolls</tspan
                                                                             ><tspan x="37.530" y="28.000"
                                                                             >Moderate damage; -1 Cruising</tspan
                                                                             ><tspan x="37.530" y="35.000"
-                                                                            >MP, +2 modifer to all Driving Skill</tspan
+                                                                            >MP, +2 modifier to all Driving Skill</tspan
                                                                             ><tspan x="37.530" y="42.000"
                                                                             >Rolls</tspan
                                                                             ><tspan x="37.530" y="49.000"
@@ -1377,7 +1375,7 @@
                                                                             ><tspan x="37.530" y="56.000"
                                                                             >MP (round fractions up), +3</tspan
                                                                             ><tspan x="37.530" y="63.000"
-                                                                            >modifer to all Driving Skill Rolls</tspan
+                                                                            >modifier to all Driving Skill Rolls</tspan
                                                                             ><tspan x="37.530" y="70.000"
                                                                             >Major damage; no movement for</tspan
                                                                             ><tspan x="37.530" y="77.000"
@@ -1421,15 +1419,15 @@
                                                                         ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                         >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                                         ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                        >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                                        >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                                         ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                        >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                                        >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                                         ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                         >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                                         ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                         >has no additional effect. This means the maximum Driving Skill Roll</text
                                                                         ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                        >modifer that can be inficted from the Motive System Damage Table is</text
+                                                                        >modifier that can be inflicted from the Motive System Damage Table is</text
                                                                         ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                         >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                                         ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1453,9 +1451,7 @@
                                                                         >LOCATION HIT</text
                                                                         ><g transform="translate (0.000 34.000)"
                                                                         ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                                          ><tspan x="53.250" y="0.000"
-                                                                            >2D6 ROLL</tspan
-                                                                            ><tspan x="95.850" y="0.000"
+                                                                          ><tspan x="95.850" y="0.000"
                                                                             >FRONT</tspan
                                                                             ><tspan x="159.750" y="0.000"
                                                                             >SIDE</tspan

--- a/data/images/recordsheets/submarine_dualturret_superheavy.svg
+++ b/data/images/recordsheets/submarine_dualturret_superheavy.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,7 +423,7 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
                                       >Turret Locked</text
                                       ><path fill="none" d="M 52.800,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="56.800" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="2.780" lengthAdjust="spacingAndGlyphs"
@@ -433,12 +433,12 @@
                                       >R</text
                                     ></g
                                     ><g transform="translate (84.600 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -454,7 +454,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -469,32 +469,32 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="22.854" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="22.854" lengthAdjust="spacingAndGlyphs"
                                       >F Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="23.760" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="23.760" lengthAdjust="spacingAndGlyphs"
                                       >R Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1184,9 +1184,7 @@
                                                                           >ATTACK DIRECTION</text
                                                                           ><g transform="translate (0.000 32.000)"
                                                                           ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                                            ><tspan x="20.800" y="0.000"
-                                                                              >2D6 ROLL</tspan
-                                                                              ><tspan x="62.400" y="0.000"
+                                                                            ><tspan x="62.400" y="0.000"
                                                                               >FRONT</tspan
                                                                               ><tspan x="114.400" y="0.000"
                                                                               >REAR</tspan
@@ -1288,21 +1286,21 @@
                                                                           ></g
                                                                           ><g transform="translate(0,115.800)"
                                                                           ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                            >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                                            >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                                             ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                             >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                                             ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                             >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                                            ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                                            ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                                             >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                                            ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                                            >Total Warfare </text
-                                                                            ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                                            ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                                            >Total Warfare</text
+                                                                            ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                                             > </text
                                                                             ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                             >for more information).</text
                                                                             ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                            >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                                            >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                                             ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                             >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                             ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1311,11 +1309,11 @@
                                                                             >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                                             ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                             >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                                            ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                                            ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                                             >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                                            ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                                            >Total Warfare </text
-                                                                            ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                                            ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                                            >Total Warfare</text
+                                                                            ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                                             > </text
                                                                             ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                             >for more information).</text
@@ -1360,13 +1358,13 @@
                                                                             ><tspan x="37.530" y="7.000"
                                                                               >No Effect</tspan
                                                                               ><tspan x="37.530" y="14.000"
-                                                                              >Minor damage; +1 modifer to all</tspan
+                                                                              >Minor damage; +1 modifier to all</tspan
                                                                               ><tspan x="37.530" y="21.000"
                                                                               >Driving Skill Rolls</tspan
                                                                               ><tspan x="37.530" y="28.000"
                                                                               >Moderate damage; -1 Cruising</tspan
                                                                               ><tspan x="37.530" y="35.000"
-                                                                              >MP, +2 modifer to all Driving Skill</tspan
+                                                                              >MP, +2 modifier to all Driving Skill</tspan
                                                                               ><tspan x="37.530" y="42.000"
                                                                               >Rolls</tspan
                                                                               ><tspan x="37.530" y="49.000"
@@ -1374,7 +1372,7 @@
                                                                               ><tspan x="37.530" y="56.000"
                                                                               >MP (round fractions up), +3</tspan
                                                                               ><tspan x="37.530" y="63.000"
-                                                                              >modifer to all Driving Skill Rolls</tspan
+                                                                              >modifier to all Driving Skill Rolls</tspan
                                                                               ><tspan x="37.530" y="70.000"
                                                                               >Major damage; no movement for</tspan
                                                                               ><tspan x="37.530" y="77.000"
@@ -1418,15 +1416,15 @@
                                                                           ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                           >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                                           ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                                          >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                                           ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                                          >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                                           ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                           >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                                           ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                           >has no additional effect. This means the maximum Driving Skill Roll</text
                                                                           ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                          >modifer that can be inficted from the Motive System Damage Table is</text
+                                                                          >modifier that can be inflicted from the Motive System Damage Table is</text
                                                                           ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                           >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                                           ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1450,9 +1448,7 @@
                                                                           >LOCATION HIT</text
                                                                           ><g transform="translate (0.000 34.000)"
                                                                           ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                                            ><tspan x="53.250" y="0.000"
-                                                                              >2D6 ROLL</tspan
-                                                                              ><tspan x="95.850" y="0.000"
+                                                                            ><tspan x="95.850" y="0.000"
                                                                               >FRONT</tspan
                                                                               ><tspan x="159.750" y="0.000"
                                                                               >SIDE</tspan

--- a/data/images/recordsheets/submarine_noturret_standard.svg
+++ b/data/images/recordsheets/submarine_noturret_standard.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,12 +423,12 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -444,7 +444,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -459,22 +459,22 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1201,9 +1201,7 @@
                                                             >ATTACK DIRECTION</text
                                                             ><g transform="translate (0.000 32.000)"
                                                             ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                              ><tspan x="20.800" y="0.000"
-                                                                >2D6 ROLL</tspan
-                                                                ><tspan x="62.400" y="0.000"
+                                                              ><tspan x="62.400" y="0.000"
                                                                 >FRONT</tspan
                                                                 ><tspan x="114.400" y="0.000"
                                                                 >REAR</tspan
@@ -1305,21 +1303,21 @@
                                                             ></g
                                                             ><g transform="translate(0,115.800)"
                                                             ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                              >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                              >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                               ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                               >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                               ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                               >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                              ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                              ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                               >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                              ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                              >Total Warfare </text
-                                                              ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                              ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                              >Total Warfare</text
+                                                              ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                               > </text
                                                               ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                               >for more information).</text
                                                               ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                              >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                              >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                               ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                               >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                               ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1328,11 +1326,11 @@
                                                               >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                               ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                               >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                              ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                              ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                               >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                              ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                              >Total Warfare </text
-                                                              ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                              ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                              >Total Warfare</text
+                                                              ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                               > </text
                                                               ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                               >for more information).</text
@@ -1377,13 +1375,13 @@
                                                               ><tspan x="37.530" y="7.000"
                                                                 >No Effect</tspan
                                                                 ><tspan x="37.530" y="14.000"
-                                                                >Minor damage; +1 modifer to all</tspan
+                                                                >Minor damage; +1 modifier to all</tspan
                                                                 ><tspan x="37.530" y="21.000"
                                                                 >Driving Skill Rolls</tspan
                                                                 ><tspan x="37.530" y="28.000"
                                                                 >Moderate damage; -1 Cruising</tspan
                                                                 ><tspan x="37.530" y="35.000"
-                                                                >MP, +2 modifer to all Driving Skill</tspan
+                                                                >MP, +2 modifier to all Driving Skill</tspan
                                                                 ><tspan x="37.530" y="42.000"
                                                                 >Rolls</tspan
                                                                 ><tspan x="37.530" y="49.000"
@@ -1391,7 +1389,7 @@
                                                                 ><tspan x="37.530" y="56.000"
                                                                 >MP (round fractions up), +3</tspan
                                                                 ><tspan x="37.530" y="63.000"
-                                                                >modifer to all Driving Skill Rolls</tspan
+                                                                >modifier to all Driving Skill Rolls</tspan
                                                                 ><tspan x="37.530" y="70.000"
                                                                 >Major damage; no movement for</tspan
                                                                 ><tspan x="37.530" y="77.000"
@@ -1435,15 +1433,15 @@
                                                             ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                             >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                             ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                            >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                            >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                             ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                            >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                            >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                             ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                             >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                             ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                             >has no additional effect. This means the maximum Driving Skill Roll</text
                                                             ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                            >modifer that can be inficted from the Motive System Damage Table is</text
+                                                            >modifier that can be inflicted from the Motive System Damage Table is</text
                                                             ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                             >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                             ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1467,9 +1465,7 @@
                                                             >LOCATION HIT</text
                                                             ><g transform="translate (0.000 34.000)"
                                                             ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                              ><tspan x="53.250" y="0.000"
-                                                                >2D6 ROLL</tspan
-                                                                ><tspan x="95.850" y="0.000"
+                                                              ><tspan x="95.850" y="0.000"
                                                                 >FRONT</tspan
                                                                 ><tspan x="159.750" y="0.000"
                                                                 >SIDE</tspan

--- a/data/images/recordsheets/submarine_noturret_superheavy.svg
+++ b/data/images/recordsheets/submarine_noturret_superheavy.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,12 +423,12 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -444,7 +444,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -459,22 +459,22 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1171,9 +1171,7 @@
                                                                 >ATTACK DIRECTION</text
                                                                 ><g transform="translate (0.000 32.000)"
                                                                 ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                                  ><tspan x="20.800" y="0.000"
-                                                                    >2D6 ROLL</tspan
-                                                                    ><tspan x="62.400" y="0.000"
+                                                                  ><tspan x="62.400" y="0.000"
                                                                     >FRONT</tspan
                                                                     ><tspan x="114.400" y="0.000"
                                                                     >REAR</tspan
@@ -1275,21 +1273,21 @@
                                                                 ></g
                                                                 ><g transform="translate(0,115.800)"
                                                                 ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                  >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                                  >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                                   ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                   >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                                   ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                   >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                                  ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                                  ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                                   >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                                  ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                                  >Total Warfare </text
-                                                                  ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                                  ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                                  >Total Warfare</text
+                                                                  ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                                   > </text
                                                                   ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                   >for more information).</text
                                                                   ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                  >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                                  >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                                   ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                   >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                   ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1298,11 +1296,11 @@
                                                                   >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                                   ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                   >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                                  ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                                  ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                                   >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                                  ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                                  >Total Warfare </text
-                                                                  ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                                  ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                                  >Total Warfare</text
+                                                                  ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                                   > </text
                                                                   ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                   >for more information).</text
@@ -1347,13 +1345,13 @@
                                                                   ><tspan x="37.530" y="7.000"
                                                                     >No Effect</tspan
                                                                     ><tspan x="37.530" y="14.000"
-                                                                    >Minor damage; +1 modifer to all</tspan
+                                                                    >Minor damage; +1 modifier to all</tspan
                                                                     ><tspan x="37.530" y="21.000"
                                                                     >Driving Skill Rolls</tspan
                                                                     ><tspan x="37.530" y="28.000"
                                                                     >Moderate damage; -1 Cruising</tspan
                                                                     ><tspan x="37.530" y="35.000"
-                                                                    >MP, +2 modifer to all Driving Skill</tspan
+                                                                    >MP, +2 modifier to all Driving Skill</tspan
                                                                     ><tspan x="37.530" y="42.000"
                                                                     >Rolls</tspan
                                                                     ><tspan x="37.530" y="49.000"
@@ -1361,7 +1359,7 @@
                                                                     ><tspan x="37.530" y="56.000"
                                                                     >MP (round fractions up), +3</tspan
                                                                     ><tspan x="37.530" y="63.000"
-                                                                    >modifer to all Driving Skill Rolls</tspan
+                                                                    >modifier to all Driving Skill Rolls</tspan
                                                                     ><tspan x="37.530" y="70.000"
                                                                     >Major damage; no movement for</tspan
                                                                     ><tspan x="37.530" y="77.000"
@@ -1405,15 +1403,15 @@
                                                                 ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                 >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                                 ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                                >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                                 ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                                >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                                 ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                 >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                                 ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                 >has no additional effect. This means the maximum Driving Skill Roll</text
                                                                 ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                >modifer that can be inficted from the Motive System Damage Table is</text
+                                                                >modifier that can be inflicted from the Motive System Damage Table is</text
                                                                 ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                 >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                                 ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1437,9 +1435,7 @@
                                                                 >LOCATION HIT</text
                                                                 ><g transform="translate (0.000 34.000)"
                                                                 ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                                  ><tspan x="53.250" y="0.000"
-                                                                    >2D6 ROLL</tspan
-                                                                    ><tspan x="95.850" y="0.000"
+                                                                  ><tspan x="95.850" y="0.000"
                                                                     >FRONT</tspan
                                                                     ><tspan x="159.750" y="0.000"
                                                                     >SIDE</tspan

--- a/data/images/recordsheets/submarine_turret_standard.svg
+++ b/data/images/recordsheets/submarine_turret_standard.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,17 +423,17 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
                                       >Turret Locked</text
                                       ><path fill="none" d="M 63.800,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (84.600 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -449,7 +449,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -464,27 +464,27 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="17.867" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="17.867" lengthAdjust="spacingAndGlyphs"
                                       >Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1178,9 +1178,7 @@
                                                                   >ATTACK DIRECTION</text
                                                                   ><g transform="translate (0.000 32.000)"
                                                                   ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                                    ><tspan x="20.800" y="0.000"
-                                                                      >2D6 ROLL</tspan
-                                                                      ><tspan x="62.400" y="0.000"
+                                                                    ><tspan x="62.400" y="0.000"
                                                                       >FRONT</tspan
                                                                       ><tspan x="114.400" y="0.000"
                                                                       >REAR</tspan
@@ -1282,21 +1280,21 @@
                                                                   ></g
                                                                   ><g transform="translate(0,115.800)"
                                                                   ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                    >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                                    >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                                     ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                     >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                                     ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                     >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                                    ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                                    ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                                     >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                                    ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                                    >Total Warfare </text
-                                                                    ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                                    ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                                    >Total Warfare</text
+                                                                    ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                                     > </text
                                                                     ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                     >for more information).</text
                                                                     ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                    >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                                    >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                                     ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                     >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                     ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1305,11 +1303,11 @@
                                                                     >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                                     ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                     >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                                    ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                                    ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                                     >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                                    ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                                    >Total Warfare </text
-                                                                    ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                                    ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                                    >Total Warfare</text
+                                                                    ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                                     > </text
                                                                     ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                     >for more information).</text
@@ -1354,13 +1352,13 @@
                                                                     ><tspan x="37.530" y="7.000"
                                                                       >No Effect</tspan
                                                                       ><tspan x="37.530" y="14.000"
-                                                                      >Minor damage; +1 modifer to all</tspan
+                                                                      >Minor damage; +1 modifier to all</tspan
                                                                       ><tspan x="37.530" y="21.000"
                                                                       >Driving Skill Rolls</tspan
                                                                       ><tspan x="37.530" y="28.000"
                                                                       >Moderate damage; -1 Cruising</tspan
                                                                       ><tspan x="37.530" y="35.000"
-                                                                      >MP, +2 modifer to all Driving Skill</tspan
+                                                                      >MP, +2 modifier to all Driving Skill</tspan
                                                                       ><tspan x="37.530" y="42.000"
                                                                       >Rolls</tspan
                                                                       ><tspan x="37.530" y="49.000"
@@ -1368,7 +1366,7 @@
                                                                       ><tspan x="37.530" y="56.000"
                                                                       >MP (round fractions up), +3</tspan
                                                                       ><tspan x="37.530" y="63.000"
-                                                                      >modifer to all Driving Skill Rolls</tspan
+                                                                      >modifier to all Driving Skill Rolls</tspan
                                                                       ><tspan x="37.530" y="70.000"
                                                                       >Major damage; no movement for</tspan
                                                                       ><tspan x="37.530" y="77.000"
@@ -1412,15 +1410,15 @@
                                                                   ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                   >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                                   ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                  >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                                  >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                                   ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                  >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                                  >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                                   ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                   >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                                   ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                   >has no additional effect. This means the maximum Driving Skill Roll</text
                                                                   ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                  >modifer that can be inficted from the Motive System Damage Table is</text
+                                                                  >modifier that can be inflicted from the Motive System Damage Table is</text
                                                                   ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                   >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                                   ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1444,9 +1442,7 @@
                                                                   >LOCATION HIT</text
                                                                   ><g transform="translate (0.000 34.000)"
                                                                   ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                                    ><tspan x="53.250" y="0.000"
-                                                                      >2D6 ROLL</tspan
-                                                                      ><tspan x="95.850" y="0.000"
+                                                                    ><tspan x="95.850" y="0.000"
                                                                       >FRONT</tspan
                                                                       ><tspan x="159.750" y="0.000"
                                                                       >SIDE</tspan

--- a/data/images/recordsheets/submarine_turret_superheavy.svg
+++ b/data/images/recordsheets/submarine_turret_superheavy.svg
@@ -297,16 +297,16 @@
 </g
                                   ><text font-size="11.59px" transform="translate (216.0 96.18497778535291)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
                                   >RECORD SHEET</text
-                                  ><text font-size="5.7px" transform="translate (306.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-                                  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+                                  ><text font-size="5.7px" transform="translate (270.0 756.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+                                  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
                                     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-                                    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+                                    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
                                     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
                                   ></text
                                   ><g id="unitDataPanel" transform="translate (36.000,102.685)"
                                   ><g
-                                    ><path fill="#ffffff" d="M 2.5,10.714 L 7.975,2.500 l 79.324,0.000 l 5.475,8.214 L 209.500,10.714 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
-                                      /><path fill="#ffffff" d="M 0.0,8.214 L 5.475,0.000 l 79.324,0.000 l 5.475,8.214 L 208.000,8.214 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
+                                    ><path fill="#ffffff" d="M 2.5,2.5 l 79.324,0.000 l 5.475,8.214 L 201.655,10.714 l 7.845,7.600 L 209.500,279.815 l -5.475,8.214 L 106.000,288.029 l -5.475,-8.214 L 10.345,279.815 l -7.845,-7.600 Z" stroke-width="5.2" stroke-linejoin="round" stroke="#c8c7c7"
+                                      /><path fill="#ffffff" d="M 0.0,0.0 l 79.324,0.000 l 5.475,8.214 L 200.155,8.214 l 7.845,7.600 L 208.000,278.315 l -5.475,8.214 L 104.000,286.529 l -5.475,-8.214 L 7.845,278.315 l -7.845,-7.600 Z" stroke-width="1.932" stroke-linejoin="round" stroke="#231f20"
                                       /><g transform="translate (2.5,3.0)"
                                       ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 l 75.324,0 l 4.999,7.500 l -4.999,7.500 l -75.324,0 Z"
                                         /><text x="42.661" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="68.477" lengthAdjust="spacingAndGlyphs"
@@ -394,14 +394,14 @@
                                     >0</text
                                     ><path id="blankPilotingSkill0" d="M 111.520,43.000 L 133.000,43.000" stroke-width="0.720" stroke-linejoin="round" stroke="#231f20"
                                     /><g transform="translate (3.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="44.689" lengthAdjust="spacingAndGlyphs"
                                       >Commander Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
                                       >+1</text
                                     ></g
                                     ><g transform="translate (71.000 58.000)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="26.819" lengthAdjust="spacingAndGlyphs"
                                       >Driver Hit</text
                                       ><path fill="none" d="M 50.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="54.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -423,17 +423,17 @@
                                       ></g
                                     ></g
                                     ><g transform="translate (6.000 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="39.254" lengthAdjust="spacingAndGlyphs"
                                       >Turret Locked</text
                                       ><path fill="none" d="M 63.800,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (84.600 22.960)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="28.081" lengthAdjust="spacingAndGlyphs"
                                       >Engine Hit</text
                                       ><path fill="none" d="M 36.600,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 32.880)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="32.801" lengthAdjust="spacingAndGlyphs"
                                       >Sensor Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -449,7 +449,7 @@
                                       >D</text
                                     ></g
                                     ><g transform="translate (6.000 42.799)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="54.079" lengthAdjust="spacingAndGlyphs"
                                       >Motive System Hits</text
                                       ><path fill="none" d="M 82.200,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                       /><text x="86.200" y="6.000" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="4.800" lengthAdjust="spacingAndGlyphs"
@@ -464,27 +464,27 @@
                                     ><text fill="#231f20" x="71.000" y="57.679" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="middle"
                                     >Stabilizers</text
                                     ><g transform="translate (6.000 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="15.082" lengthAdjust="spacingAndGlyphs"
                                       >Front</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="10.652" lengthAdjust="spacingAndGlyphs"
                                       >Left</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (91.884 62.639)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="14.588" lengthAdjust="spacingAndGlyphs"
                                       >Right</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (6.000 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="13.727" lengthAdjust="spacingAndGlyphs"
                                       >Rear</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
                                     ><g transform="translate (47.880 72.559)"
-                                    ><text x="0.000" y="7.200" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="17.867" lengthAdjust="spacingAndGlyphs"
+                                    ><text x="0.000" y="6.400" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:#231f20" textLength="17.867" lengthAdjust="spacingAndGlyphs"
                                       >Turret</text
                                       ><path fill="none" d="M 28.440,1.315 c 0,-0.726 0.589,-1.315 1.315,-1.315 l 5.370,0 c 0.726,0 1.315,0.589, 1.315,1.315 l 0,5.370 c 0,0.726 -0.589,1.315, -1.315,1.315 l -5.370,0 c -0.726,0 -1.315,-0.589, -1.315,-1.315Z" stroke-width="0.96" stroke-linejoin="round" stroke="#231f20"
                                     /></g
@@ -1182,9 +1182,7 @@
                                                                       >ATTACK DIRECTION</text
                                                                       ><g transform="translate (0.000 32.000)"
                                                                       ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-                                                                        ><tspan x="20.800" y="0.000"
-                                                                          >2D6 ROLL</tspan
-                                                                          ><tspan x="62.400" y="0.000"
+                                                                        ><tspan x="62.400" y="0.000"
                                                                           >FRONT</tspan
                                                                           ><tspan x="114.400" y="0.000"
                                                                           >REAR</tspan
@@ -1286,21 +1284,21 @@
                                                                       ></g
                                                                       ><g transform="translate(0,115.800)"
                                                                       ><text x="6.000" y="5.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                        >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on</text
+                                                                        >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on</text
                                                                         ><text x="6.000" y="10.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                         >the vehicle. For each result of 2 or 12 (or 8 for side attacks), apply damage normally to</text
                                                                         ><text x="6.000" y="15.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                         >the armor in that section. The attacking player then automatically rolls once on the</text
-                                                                        ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.431" lengthAdjust="spacingAndGlyphs"
+                                                                        ><text x="6.000" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="138.399" lengthAdjust="spacingAndGlyphs"
                                                                         >Naval Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-                                                                        ><text x="143.431" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="28.690" lengthAdjust="spacingAndGlyphs"
-                                                                        >Total Warfare </text
-                                                                        ><text x="172.121" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.171" lengthAdjust="spacingAndGlyphs"
+                                                                        ><text x="144.399" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.071" lengthAdjust="spacingAndGlyphs"
+                                                                        >Total Warfare</text
+                                                                        ><text x="174.470" y="20.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.179" lengthAdjust="spacingAndGlyphs"
                                                                         > </text
                                                                         ><text fill="#231f20" x="6.000" y="25.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                         >for more information).</text
                                                                         ><text x="6.000" y="30.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
-                                                                        >A result of 12 on the Naval Combat Vehicles Hit Location Table may infict critical hit</text
+                                                                        >A result of 12 on the Naval Combat Vehicles Hit Location Table may inflict critical hit</text
                                                                         ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                         >against the turret; if the vehicle has no turret, a 12 indicates the chance of a critical hit</text
                                                                         ><text fill="#231f20" x="6.000" y="40.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -1309,11 +1307,11 @@
                                                                         >† The vehicle may suffer motive system damage even if its armor remains intact. Apply</text
                                                                         ><text x="6.000" y="50.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="199.000" lengthAdjust="spacingAndGlyphs"
                                                                         >damage normally to the armor in that section, but the attacking player also rolls once</text
-                                                                        ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="136.842" lengthAdjust="spacingAndGlyphs"
+                                                                        ><text x="6.000" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="137.825" lengthAdjust="spacingAndGlyphs"
                                                                         >on the Motive System Damage Table at right (see Combat, p. 192, in </text
-                                                                        ><text x="142.842" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="29.256" lengthAdjust="spacingAndGlyphs"
-                                                                        >Total Warfare </text
-                                                                        ><text x="172.097" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.194" lengthAdjust="spacingAndGlyphs"
+                                                                        ><text x="143.825" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:italic" textLength="30.668" lengthAdjust="spacingAndGlyphs"
+                                                                        >Total Warfare</text
+                                                                        ><text x="174.494" y="55.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="1.202" lengthAdjust="spacingAndGlyphs"
                                                                         > </text
                                                                         ><text fill="#231f20" x="6.000" y="60.000" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                         >for more information).</text
@@ -1358,13 +1356,13 @@
                                                                         ><tspan x="37.530" y="7.000"
                                                                           >No Effect</tspan
                                                                           ><tspan x="37.530" y="14.000"
-                                                                          >Minor damage; +1 modifer to all</tspan
+                                                                          >Minor damage; +1 modifier to all</tspan
                                                                           ><tspan x="37.530" y="21.000"
                                                                           >Driving Skill Rolls</tspan
                                                                           ><tspan x="37.530" y="28.000"
                                                                           >Moderate damage; -1 Cruising</tspan
                                                                           ><tspan x="37.530" y="35.000"
-                                                                          >MP, +2 modifer to all Driving Skill</tspan
+                                                                          >MP, +2 modifier to all Driving Skill</tspan
                                                                           ><tspan x="37.530" y="42.000"
                                                                           >Rolls</tspan
                                                                           ><tspan x="37.530" y="49.000"
@@ -1372,7 +1370,7 @@
                                                                           ><tspan x="37.530" y="56.000"
                                                                           >MP (round fractions up), +3</tspan
                                                                           ><tspan x="37.530" y="63.000"
-                                                                          >modifer to all Driving Skill Rolls</tspan
+                                                                          >modifier to all Driving Skill Rolls</tspan
                                                                           ><tspan x="37.530" y="70.000"
                                                                           >Major damage; no movement for</tspan
                                                                           ><tspan x="37.530" y="77.000"
@@ -1416,15 +1414,15 @@
                                                                       ><text x="6.000" y="162.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                       >*All movement and Driving Skill Roll penalties are cumulative. However,</text
                                                                       ><text x="6.000" y="166.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                      >each Driving Skill Roll modifer can only be applied once. For example,</text
+                                                                      >each Driving Skill Roll modifier can only be applied once. For example,</text
                                                                       ><text x="6.000" y="170.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                      >if a roll of 6-7 is made for a vehicle, inficting a +1 modifer, that is the</text
+                                                                      >if a roll of 6-7 is made for a vehicle, inflicting a +1 modifier, that is the</text
                                                                       ><text x="6.000" y="174.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                       >only time that particular +1 can be applied; a subsequent roll of 6-7</text
                                                                       ><text x="6.000" y="178.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                       >has no additional effect. This means the maximum Driving Skill Roll</text
                                                                       ><text x="6.000" y="182.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
-                                                                      >modifer that can be inficted from the Motive System Damage Table is</text
+                                                                      >modifier that can be inflicted from the Motive System Damage Table is</text
                                                                       ><text x="6.000" y="186.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
                                                                       >+6. If a unit’s Cruising MP is reduced to 0, it cannot move for the rest</text
                                                                       ><text x="6.000" y="190.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:3.800px;font-weight:normal;font-style:normal" textLength="130.000" lengthAdjust="spacingAndGlyphs"
@@ -1448,9 +1446,7 @@
                                                                       >LOCATION HIT</text
                                                                       ><g transform="translate (0.000 34.000)"
                                                                       ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-                                                                        ><tspan x="53.250" y="0.000"
-                                                                          >2D6 ROLL</tspan
-                                                                          ><tspan x="95.850" y="0.000"
+                                                                        ><tspan x="95.850" y="0.000"
                                                                           >FRONT</tspan
                                                                           ><tspan x="159.750" y="0.000"
                                                                           >SIDE</tspan

--- a/data/images/recordsheets/tables_tank.svg
+++ b/data/images/recordsheets/tables_tank.svg
@@ -2,12 +2,10 @@
 <!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.0//EN'
           'http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd'>
 <svg contentScriptType="text/ecmascript" width="612" xmlns:xlink="http://www.w3.org/1999/xlink" zoomAndPan="magnify" contentStyleType="text/css" height="357.0" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" version="1.0"
-><text font-size="11.59px" transform="translate (216.0 13.0)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
-  >RECORD SHEET</text
-  ><text font-size="5.7px" transform="translate (306.0 357.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+><text font-size="5.7px" transform="translate (270.0 357.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
   ></text
   ><g transform="translate (36.000 3.000)"
@@ -24,9 +22,7 @@
     >ATTACK DIRECTION</text
     ><g transform="translate (0.000 32.000)"
     ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-      ><tspan x="29.980" y="0.000"
-        >2D6 ROLL</tspan
-        ><tspan x="89.940" y="0.000"
+      ><tspan x="89.940" y="0.000"
         >FRONT</tspan
         ><tspan x="164.890" y="0.000"
         >REAR</tspan
@@ -128,26 +124,26 @@
     ></g
     ><g transform="translate(0,114.800)"
     ><text x="6.000" y="7.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="290.800" lengthAdjust="spacingAndGlyphs"
-      >* A result of 2 or 12 (or an 8 if the attack strikes the side) may infict a critical hit on the vehicle. For each result of 2 or</text
+      >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on the vehicle. For each result of 2 or</text
       ><text x="6.000" y="14.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="290.800" lengthAdjust="spacingAndGlyphs"
       >12 (or 8 for side attacks), apply damage normally to the armor in that section. The attacking player then automatically rolls</text
-      ><text fill="#231f20" x="6.000" y="21.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" text-anchor="start"
+      ><text x="6.000" y="21.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="200.326" lengthAdjust="spacingAndGlyphs"
       >once on the Ground Combat Vehicle Critical Hits Table below (see Combat, p. 192, in </text
-      ><text fill="#231f20" x="206.326" y="21.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:italic" text-anchor="start"
-      >Total Warfare </text
-      ><text fill="#231f20" x="241.173" y="21.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" text-anchor="start"
+      ><text x="206.326" y="21.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:italic" textLength="33.425" lengthAdjust="spacingAndGlyphs"
+      >Total Warfare</text
+      ><text x="242.595" y="21.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="53.281" lengthAdjust="spacingAndGlyphs"
       > for more information).</text
       ><text x="6.000" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="290.800" lengthAdjust="spacingAndGlyphs"
-      >A result of 12 on the Ground Combat Vehicles Hit Location Table may infict critical hit against the turret; if the vehicle has</text
+      >A result of 12 on the Ground Combat Vehicles Hit Location Table may inflict critical hit against the turret; if the vehicle has</text
       ><text fill="#231f20" x="6.000" y="35.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" text-anchor="start"
       >no turret, a 12 indicates the chance of a critical hit on the side corresponding to the attack direction.</text
       ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="290.800" lengthAdjust="spacingAndGlyphs"
       >† The vehicle may suffer motive system damage even if its armor remains intact. Apply damage normally to the armor in</text
       ><text x="6.000" y="49.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="290.800" lengthAdjust="spacingAndGlyphs"
       >that section, but the attacking player also rolls once on the Motive System Damage Table at right (see Combat, p. 192, in</text
-      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:italic" text-anchor="start"
-      >Total Warfare </text
-      ><text fill="#231f20" x="40.847" y="56.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" text-anchor="start"
+      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:italic" textLength="33.425" lengthAdjust="spacingAndGlyphs"
+      >Total Warfare</text
+      ><text x="42.269" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="53.281" lengthAdjust="spacingAndGlyphs"
       > for more information).</text
       ><text x="6.000" y="63.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="290.800" lengthAdjust="spacingAndGlyphs"
       >§ Side hits strike the side as indicated by the attack direction. For example, if an attack hits the right side, all Side results</text
@@ -188,15 +184,15 @@
       ><tspan x="59.724" y="7.000"
         >No Effect</tspan
         ><tspan x="59.724" y="14.000"
-        >Minor damage; +1 modifer to all Driving Skill Rolls</tspan
+        >Minor damage; +1 modifier to all Driving Skill Rolls</tspan
         ><tspan x="59.724" y="21.000"
-        >Moderate damage; -1 Cruising MP, +2 modifer to all</tspan
+        >Moderate damage; -1 Cruising MP, +2 modifier to all</tspan
         ><tspan x="59.724" y="28.000"
         >Driving Skill Rolls</tspan
         ><tspan x="59.724" y="35.000"
         >Heavy damage; only half Cruising MP (round fractions up),</tspan
         ><tspan x="59.724" y="42.000"
-        >+3 modifer to all Driving Skill Rolls</tspan
+        >+3 modifier to all Driving Skill Rolls</tspan
         ><tspan x="59.724" y="49.000"
         >Major damage; no movement for the rest of the game</tspan
         ><tspan x="59.724" y="56.000"
@@ -246,13 +242,13 @@
     ><text x="6.000" y="131.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
     >*All movement and Driving Skill Roll penalties are cumulative. However, each Driving Skill Roll</text
     ><text x="6.000" y="136.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
-    >modifer can only be applied once. For example, if a roll of 6-7 is made for a vehicle, inficting</text
+    >modifier can only be applied once. For example, if a roll of 6-7 is made for a vehicle, inflicting</text
     ><text x="6.000" y="141.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
-    >a +1 modifer, that is the only time that particular +1 can be applied; a subsequent roll of 6-7</text
+    >a +1 modifier, that is the only time that particular +1 can be applied; a subsequent roll of 6-7</text
     ><text x="6.000" y="146.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
-    >has no additional effect. This means the maximum Driving Skill Roll modifer that can be</text
+    >has no additional effect. This means the maximum Driving Skill Roll modifier that can be</text
     ><text x="6.000" y="151.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
-    >inficted from the Motive System Damage Table is +6. If a unit’s Cruising MP is reduced</text
+    >inflicted from the Motive System Damage Table is +6. If a unit’s Cruising MP is reduced</text
     ><text x="6.000" y="156.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
     >to 0, it cannot move for the rest of the game, but is not considered an immobile target. In</text
     ><text x="6.000" y="161.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
@@ -260,9 +256,9 @@
     ><text x="6.000" y="166.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
     >occurred. For example, if two units are attacking the same Combat Vehicle during the</text
     ><text x="6.000" y="171.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
-    >Weapon Attack Phase and the frst unit inficts motive system damage and rolls a 12, the -4</text
+    >Weapon Attack Phase and the frst unit inflicts motive system damage and rolls a 12, the -4</text
     ><text x="6.000" y="176.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
-    >immobile target modifer would not apply for the second unit. However, the -4 modifer would</text
+    >immobile target modifier would not apply for the second unit. However, the -4 modifier would</text
     ><text x="6.000" y="181.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" textLength="212.200" lengthAdjust="spacingAndGlyphs"
     >take effect during the Physical Attack Phase. If a hover vehicle is rendered immobile while</text
     ><text fill="#231f20" x="6.000" y="186.500" style="font-family:Eurostile;font-size:4.800px;font-weight:normal;font-style:normal" text-anchor="start"
@@ -282,9 +278,7 @@
     >LOCATION HIT</text
     ><g transform="translate (0.000 34.000)"
     ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-      ><tspan x="79.800" y="0.000"
-        >2D6 ROLL</tspan
-        ><tspan x="143.640" y="0.000"
+      ><tspan x="143.640" y="0.000"
         >FRONT</tspan
         ><tspan x="239.400" y="0.000"
         >SIDE</tspan

--- a/data/images/recordsheets/tables_vtol.svg
+++ b/data/images/recordsheets/tables_vtol.svg
@@ -2,12 +2,10 @@
 <!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.0//EN'
           'http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd'>
 <svg contentScriptType="text/ecmascript" width="612" xmlns:xlink="http://www.w3.org/1999/xlink" zoomAndPan="magnify" contentStyleType="text/css" height="357.0" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" version="1.0"
-><text font-size="11.59px" transform="translate (216.0 13.0)" fill="#000000" text-anchor="middle" font-family="Eurostile" id="title" font-weight="bold"
-  >RECORD SHEET</text
-  ><text font-size="5.7px" transform="translate (306.0 357.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
-  ><tspan lengthAdjust="spacingAndGlyphs" x="0" id="tspanCopyright" y="-7.000" textLength="513.000"
+><text font-size="5.7px" transform="translate (270.0 357.0)" fill="#231f20" text-anchor="middle" font-family="Eurostile" id="footer" font-weight="bold"
+  ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" id="tspanCopyright" y="-7.000" textLength="513.000"
     >© %d The Topps Company, Inc. Classic BattleTech, BattleTech, 'Mech and BattleMech are trademarks of The Topps Company, Inc. All rights reserved.</tspan
-    ><tspan lengthAdjust="spacingAndGlyphs" x="0" y="0" textLength="486.000"
+    ><tspan lengthAdjust="spacingAndGlyphs" x="36.0" y="0" textLength="486.000"
     >Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of InMediaRes Production, LLC. Permission to photocopy for personal use.</tspan
   ></text
   ><g transform="translate (36.000 3.000)"
@@ -24,9 +22,7 @@
     >ATTACK DIRECTION</text
     ><g transform="translate (0.000 32.000)"
     ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
-      ><tspan x="29.980" y="0.000"
-        >2D6 ROLL</tspan
-        ><tspan x="89.940" y="0.000"
+      ><tspan x="89.940" y="0.000"
         >FRONT</tspan
         ><tspan x="164.890" y="0.000"
         >REAR</tspan
@@ -133,11 +129,11 @@
       >damage normally to the armor in that section. The attacking player then immediately rolls once on the VTOL Combat Vehicle</text
       ><text fill="#231f20" x="6.000" y="21.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" text-anchor="start"
       >Critical Hits Table, below.</text
-      ><text x="6.000" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="140.513" lengthAdjust="spacingAndGlyphs"
+      ><text x="6.000" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="141.226" lengthAdjust="spacingAndGlyphs"
       >† Damage Value / 10 (round up); see Rotor Hits, p. 197, </text
-      ><text x="146.513" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:italic" textLength="37.171" lengthAdjust="spacingAndGlyphs"
-      >Total Warfare. </text
-      ><text x="183.683" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="113.117" lengthAdjust="spacingAndGlyphs"
+      ><text x="147.226" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:italic" textLength="38.837" lengthAdjust="spacingAndGlyphs"
+      >Total Warfare.</text
+      ><text x="186.063" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="113.691" lengthAdjust="spacingAndGlyphs"
       > Additionally, damage to rotors slows down the</text
       ><text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="290.800" lengthAdjust="spacingAndGlyphs"
       >VTOL. Each hit reduces the VTOL’s Cruising MP by 1, meaning that the controlling player must also recalculate Flank MP;</text
@@ -293,9 +289,7 @@
     >LOCATION HIT</text
     ><g transform="translate (0.000 34.000)"
     ><text text-anchor="middle" style="font-family:Eurostile;font-size:7.200px;font-weight:bold;font-style:normal"
-      ><tspan x="53.200" y="0.000"
-        >2D6 ROLL</tspan
-        ><tspan x="111.720" y="0.000"
+      ><tspan x="111.720" y="0.000"
         >FRONT</tspan
         ><tspan x="186.200" y="0.000"
         >SIDE</tspan


### PR DESCRIPTION
I couldn't reproduce the issue, but going over the template generation code I found a bug that does not include fixed lengths for the segments of text in the last line of a paragraph when it includes normal and italic text. I am confident that this resolves the issue.

I also discovered several places where "inflict[ed]" is missing the L and "modifier" is missing the second I. I suspect that this is due to the way the TM PDF handles fl and fi ligatures, since I copied the text from the PDF (ironically) to avoid typos.

I'm not sure how to advise reviewing machine-generated files. There are some additional changes due to modifications of the generation code in the process of making the templates for conventional infantry and BA.

Fixes #616 