### PR TITLE
Show cockpit type on fighter record sheet if non-standard

### DIFF
--- a/src/megameklab/com/printing/PrintAero.java
+++ b/src/megameklab/com/printing/PrintAero.java
@@ -172,6 +172,10 @@ public class PrintAero extends PrintEntity {
     @Override
     public String formatFeatures() {
         StringJoiner sj = new StringJoiner(", ");
+        if ((aero.getCockpitType() != Aero.COCKPIT_STANDARD)
+                && (aero.getCockpitType() != Aero.COCKPIT_PRIMITIVE)) {
+            sj.add(aero.getCockpitTypeString());
+        }
         if (aero.isSupportVehicle()) {
             List<String> chassisMods = aero.getMisc().stream().filter(m -> m.getType().hasFlag(MiscType.F_CHASSIS_MODIFICATION))
                     .map(m -> m.getType().getShortName())


### PR DESCRIPTION
I don't see a good way to add places to record the second pilot's name, stats, and damage track for a command console. The mech sheet makes room for additional crew by shrinking the fluff image, but the fighter sheet has a different layout. I think it's enough to indicate on the sheet that it has a command console (or small cockpit). There's enough white space to make the additional notes.

Fixes #625