### PR TITLE
Fixes for grouping slots on mech record sheets

### DIFF
--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -417,6 +417,7 @@ public class PrintMech extends PrintEntity {
         float fontSize = (float) Math.floor(lineHeight * 0.85f);
         
         Mounted startingMount = null;
+        int startingSlotIndex = 0;
         double startingMountY = 0;
         double endingMountY = 0;
         double connWidth = viewWidth * 0.02;
@@ -475,15 +476,15 @@ public class PrintMech extends PrintEntity {
             }
             Mounted m = null;
             if ((null != crit) && (crit.getType() == CriticalSlot.TYPE_EQUIPMENT)
-                    && (crit.getMount().getType().isHittable())
-                    && (crit.getMount().getType().getCriticals(mech) > (mech.isSuperHeavy()? 2 : 1))) {
+                    && (crit.getMount().getType().isHittable())) {
                 m = crit.getMount();
             }
-            if ((startingMount != null) && (startingMount != m)) {
+            if ((startingMount != null) && (startingMount != m) && (slot - startingSlotIndex > 1)) {
                 connectSlots(canvas, critX - 1, startingMountY, connWidth, endingMountY - startingMountY);
             }
             if (m != startingMount) {
                 startingMount = m;
+                startingSlotIndex = slot;
                 if (null != m) {
                     startingMountY = currY - lineHeight * 0.6;
                 }

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -492,7 +492,8 @@ public class PrintMech extends PrintEntity {
                 endingMountY = currY;
             }
         }
-        if ((null != startingMount) && (mech.getNumberOfCriticals(startingMount.getType(), loc) > 1)) {
+        // Check whether we need to add a bracket for the last piece of equipment.
+        if ((null != startingMount) && (mech.getNumberOfCriticals(loc) - startingSlotIndex > 1)) {
             connectSlots(canvas, critX - 1, startingMountY, connWidth, endingMountY - startingMountY);
         }
     }


### PR DESCRIPTION
This fixes two edge cases on the brackets that group multiple slots of a single piece of equipment on mech record sheets.

The first is an edge case that only shows up when the following conditions are met:
1. There is a piece of equipment that takes a fixed number of slots in multiple locations (such as partial wing or mech tracks)
2. It takes up one slot per location
3. It is hittable
3. It doesn't occupy the last slot
The bug stems from using the total number of slots to determine whether it needs to be bracketed, which isn't necessarily the number of slots in the current location. Instead I'm using the offset from the index of the first slot.

The second occurs when the last slot is occupied by a single-slot item that has another in the same location. This is because it counts the number of slots occupied by the EquipmentType without regard to whether they are the same mount. The fix is the same.