### PR TITLE
Option to show total heat and dissipation on record sheet

### DIFF
--- a/resources/megameklab/resources/Dialogs.properties
+++ b/resources/megameklab/resources/Dialogs.properties
@@ -29,7 +29,8 @@ ConfigurationDialog.chkShowEraIcon.text=Era Icon
 ConfigurationDialog.chkShowEraIcon.tooltip=Shows the icon associated with the era the unit was constructed.
 ConfigurationDialog.chkShowRole.text=Unit Role
 ConfigurationDialog.chkShowRole.tooltip=Shows the unit's primary role.
-ConfigurationDialog.lblFeatureLimitation.text=<html><i>These options are only fully supported on Mek sheets currently.</i></html>
+ConfigurationDialog.chkHeatProfile.text=Heat Profile
+ConfigurationDialog.chkHeatProfile.tooltip=Show total weapon heat and dissipation in the inventory panel for units that track heat.
 ConfigurationDialog.chkSummaryFormatTRO.text=Use TRO format for summary
 ConfigurationDialog.chkSummaryFormatTRO.tooltip=Whether to format the export text as a technical readout or as a traditional MegaMek unit summary.
 

--- a/src/megameklab/com/printing/InventoryWriter.java
+++ b/src/megameklab/com/printing/InventoryWriter.java
@@ -388,6 +388,10 @@ public class InventoryWriter {
         if (sheet.getEntity() instanceof SmallCraft && !transportBays.isEmpty()) {
             printBayInfo(metrics[0], metrics[1], ypos);
         }
+        if (sheet.showHeatProfile()) {
+            sheet.addTextElement(canvas, viewX + viewWidth * 0.025, ypos, sheet.heatProfileText(),
+                    FONT_SIZE_MEDIUM, SVGConstants.SVG_START_VALUE, SVGConstants.SVG_NORMAL_VALUE);
+        }
         writeFooterBlock(metrics[0], metrics[1]);
     }
 
@@ -567,6 +571,9 @@ public class InventoryWriter {
             lines += transportBays.size() + 1; // add extra for header
         }
         lines += footerLines(fontSize);
+        if (sheet.showHeatProfile()) {
+            lines++;
+        }
         return lines;
     }
 

--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -78,6 +78,21 @@ public abstract class PrintEntity extends PrintRecordSheet {
     }
 
     /**
+     * @return Whether the total weapon heat and dissipation should be shown on the record sheet
+     */
+    protected boolean showHeatProfile() {
+        return getEntity().tracksHeat() && options.showHeatProfile();
+    }
+
+    /**
+     * @return A String showing the total weapon heat and dissipation.
+     */
+    protected String heatProfileText() {
+        int heat = getEntity().getEquipment().stream().mapToInt(m -> m.getType().getHeat()).sum();
+        return "Total Heat (Dissipation): " + heat + " (" + getEntity().getHeatCapacity() + ")";
+    }
+
+    /**
      * Space for misc equipment such as cargo space and SV chassis mods.
      *
      * @return A list of misc equipment, or an empty String if none

--- a/src/megameklab/com/printing/RecordSheetOptions.java
+++ b/src/megameklab/com/printing/RecordSheetOptions.java
@@ -27,12 +27,14 @@ public class RecordSheetOptions {
     private boolean pilotData;
     private boolean eraIcon;
     private boolean role;
+    private boolean heatProfile;
     
     public RecordSheetOptions() {
         this.quirks = CConfig.getBooleanParam(CConfig.RS_SHOW_QUIRKS);
         this.pilotData = CConfig.getBooleanParam(CConfig.RS_SHOW_PILOT_DATA);
         this.eraIcon = CConfig.getBooleanParam(CConfig.RS_SHOW_ERA);
         this.role = CConfig.getBooleanParam(CConfig.RS_SHOW_ROLE);
+        this.heatProfile = CConfig.getBooleanParam(CConfig.RS_HEAT_PROFILE);
     }
     
     public boolean showQuirks() {
@@ -47,6 +49,9 @@ public class RecordSheetOptions {
     public boolean showRole() {
         return role;
     }
+    public boolean showHeatProfile() {
+        return heatProfile;
+    }
     
     public void setPilotData(boolean pilotData) {
         this.pilotData = pilotData;
@@ -58,6 +63,14 @@ public class RecordSheetOptions {
     
     public void setEraIcon(boolean eraIcon) {
         this.eraIcon = eraIcon;
+    }
+
+    public void setRole(boolean role) {
+        this.role = role;
+    }
+
+    public void setHeatProfile(boolean heatProfile) {
+        this.heatProfile = heatProfile;
     }
 
 }

--- a/src/megameklab/com/util/CConfig.java
+++ b/src/megameklab/com/util/CConfig.java
@@ -212,16 +212,6 @@ public class CConfig {
     }
 
     /**
-     * See if a paramater is enabled (YES, TRUE or ON).
-     */
-    public static boolean isParam(String param) {
-        String tparam = CConfig.getParam(param);
-        return (tparam.equalsIgnoreCase("YES")
-            || tparam.equalsIgnoreCase("TRUE")
-                || tparam.equalsIgnoreCase("ON"));
-    }
-
-    /**
      * Return the int value of a given config property. Return a 0 if the
      * property is a non-number. Used mostly by the misc. mail tab checks.
      */

--- a/src/megameklab/com/util/CConfig.java
+++ b/src/megameklab/com/util/CConfig.java
@@ -77,6 +77,7 @@ public class CConfig {
     public static final String RS_SHOW_PILOT_DATA = "rs_show_pilot_data";
     public static final String RS_SHOW_ERA = "rs_show_era";
     public static final String RS_SHOW_ROLE = "rs_show_role";
+    public static final String RS_HEAT_PROFILE = "rs_heat_profile";
 
     private static Properties config;// config. player values.
 
@@ -112,7 +113,7 @@ public class CConfig {
         defaults.setProperty("WINDOWLEFT", "0");
         defaults.setProperty("WINDOWTOP", "0");
         defaults.setProperty(CONFIG_SAVE_LOC,
-                new File(System.getProperty("user.dir").toString()
+                new File(System.getProperty("user.dir")
                         + "/data/mechfiles/").getAbsolutePath());
         defaults.setProperty(SUMMARY_FORMAT_TRO, Boolean.toString(true));
         defaults.setProperty(RS_SHOW_QUIRKS, Boolean.toString(true));
@@ -183,12 +184,10 @@ public class CConfig {
      * @return           The value associated with the key
      */
     public static String getParam(String param, String defaultVal) {
-        String tparam = null;
-
         if (param.endsWith(":")) {
             param = param.substring(0, param.lastIndexOf(":"));
         }
-        tparam = config.getProperty(param);
+        String tparam = config.getProperty(param);
         if (tparam == null) {
             tparam = defaultVal;
         }
@@ -217,10 +216,9 @@ public class CConfig {
      */
     public static boolean isParam(String param) {
         String tparam = CConfig.getParam(param);
-        if (tparam.equalsIgnoreCase("YES") || tparam.equalsIgnoreCase("TRUE") || tparam.equalsIgnoreCase("ON")) {
-            return true;
-        }
-        return false;
+        return (tparam.equalsIgnoreCase("YES")
+            || tparam.equalsIgnoreCase("TRUE")
+                || tparam.equalsIgnoreCase("ON"));
     }
 
     /**
@@ -263,7 +261,7 @@ public class CConfig {
             config.store(ps, "Client Config Backup");
             fos.close();
             ps.close();
-        } catch (FileNotFoundException fnfe) {
+        } catch (FileNotFoundException ignored) {
 
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -275,7 +273,7 @@ public class CConfig {
             config.store(ps, "Client Config");
             fos.close();
             ps.close();
-        } catch (FileNotFoundException fnfe) {
+        } catch (FileNotFoundException ignored) {
 
         } catch (Exception ex) {
             ex.printStackTrace();
@@ -284,11 +282,9 @@ public class CConfig {
 
     public static Color getForegroundColor(String fieldName) {
         Color masterColor = Color.black;
-
         try {
             masterColor = Color.getColor("", Integer.parseInt(CConfig.getParam(fieldName + CConfig.CONFIG_FOREGROUND)));
-        } catch (Exception ex) {
-
+        } catch (Exception ignored) {
         }
         return masterColor;
     }
@@ -298,7 +294,7 @@ public class CConfig {
 
         try {
             masterColor = Color.getColor("", Integer.parseInt(CConfig.getParam(fieldName + CConfig.CONFIG_BACKGROUND)));
-        } catch (Exception ex) {
+        } catch (Exception ignored) {
 
         }
         return masterColor;

--- a/src/megameklab/com/util/ConfigurationDialog.java
+++ b/src/megameklab/com/util/ConfigurationDialog.java
@@ -42,9 +42,6 @@ import megameklab.com.ui.util.IntRangeTextField;
 
 public final class ConfigurationDialog extends JDialog implements ActionListener {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -6504846822457360057L;
 
     private final static String saveCommand = "Save"; //$NON-NLS-1$
@@ -69,8 +66,7 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
     private final JCheckBox chkShowEraIcon = new JCheckBox();
     private final JCheckBox chkShowRole = new JCheckBox();
     private final JCheckBox chkHeatProfile = new JCheckBox();
-    private final JLabel lblFeatureLimitation = new JLabel();
-    
+
     private final JCheckBox chkSummaryFormatTRO = new JCheckBox();
     
     //Store changes in the color configuration to write only if the user clicks save
@@ -248,9 +244,6 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
         chkHeatProfile.setToolTipText(resourceMap.getString("ConfigurationDialog.chkHeatProfile.tooltip"));
         chkHeatProfile.setSelected(CConfig.getBooleanParam(CConfig.RS_HEAT_PROFILE));
         panPrinting.add(chkHeatProfile, gbc);
-        gbc.gridy++;
-
-        panPrinting.add(lblFeatureLimitation, gbc);
     }
     
     private void loadExportPanel(ResourceBundle resourceMap) {

--- a/src/megameklab/com/util/ConfigurationDialog.java
+++ b/src/megameklab/com/util/ConfigurationDialog.java
@@ -50,12 +50,6 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
     private final static String saveCommand = "Save"; //$NON-NLS-1$
     private final static String cancelCommand = "Cancel"; //$NON-NLS-1$
 
-    // BUTTONS
-    private final JButton btnSave = new JButton(saveCommand);
-    private final JButton btnCancel = new JButton(cancelCommand);
-    private JButton baseButton;
-
-    private final JTabbedPane panMain = new JTabbedPane();
     private final JPanel panColors = new JPanel(new SpringLayout());
     private final JPanel panTech = new JPanel(new GridBagLayout());
     private final JPanel panPrinting = new JPanel(new GridBagLayout());
@@ -74,6 +68,7 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
     private final JCheckBox chkShowPilotData = new JCheckBox();
     private final JCheckBox chkShowEraIcon = new JCheckBox();
     private final JCheckBox chkShowRole = new JCheckBox();
+    private final JCheckBox chkHeatProfile = new JCheckBox();
     private final JLabel lblFeatureLimitation = new JLabel();
     
     private final JCheckBox chkSummaryFormatTRO = new JCheckBox();
@@ -88,19 +83,23 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
         setTitle(resourceMap.getString("ConfigurationDialog.windowName.text")); //$NON-NLS-1$
         
         getContentPane().setLayout(new BorderLayout());
+        JTabbedPane panMain = new JTabbedPane();
         add(panMain, BorderLayout.CENTER);
         JPanel panButtons = new JPanel();
-        btnSave.setText(resourceMap.getString("ConfigurationDialog.btnSave.text")); //$NON-NLS-1$
-        btnSave.setToolTipText(resourceMap.getString("ConfigurationDialog.btnSave.tooltip")); //$NON-NLS-1$
-        btnSave.setActionCommand(saveCommand);
-        btnSave.addActionListener(this);
-        panButtons.add(btnSave);
+        // BUTTONS
+        JButton button = new JButton(saveCommand);
+        button.setText(resourceMap.getString("ConfigurationDialog.btnSave.text")); //$NON-NLS-1$
+        button.setToolTipText(resourceMap.getString("ConfigurationDialog.btnSave.tooltip")); //$NON-NLS-1$
+        button.setActionCommand(saveCommand);
+        button.addActionListener(this);
+        panButtons.add(button);
 
-        btnCancel.setText(resourceMap.getString("ConfigurationDialog.btnCancel.text")); //$NON-NLS-1$
-        btnCancel.setToolTipText(resourceMap.getString("ConfigurationDialog.btnCancel.tooltip")); //$NON-NLS-1$
-        btnCancel.setActionCommand(cancelCommand);
-        btnCancel.addActionListener(this);
-        panButtons.add(btnCancel);
+        button = new JButton(cancelCommand);
+        button.setText(resourceMap.getString("ConfigurationDialog.btnCancel.text")); //$NON-NLS-1$
+        button.setToolTipText(resourceMap.getString("ConfigurationDialog.btnCancel.tooltip")); //$NON-NLS-1$
+        button.setActionCommand(cancelCommand);
+        button.addActionListener(this);
+        panButtons.add(button);
         add(panButtons, BorderLayout.SOUTH);
 
         panMain.addTab(resourceMap.getString("ConfigurationDialog.colorCodes.title"), panColors); //$NON-NLS-1$
@@ -133,7 +132,7 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
         baseLabel.setForeground(CConfig.getForegroundColor(fieldName));
 
         panColors.add(baseLabel);
-        baseButton = new JButton("Foreground");
+        JButton baseButton = new JButton("Foreground");
         baseButton.setName(fieldName + CConfig.CONFIG_FOREGROUND);
         baseButton.addActionListener(this);
         panColors.add(baseButton);
@@ -160,9 +159,7 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
         
         gbc.gridy++;
         gbc.gridwidth = 1;
-        chkTechUseYear.addActionListener(e -> {
-            txtTechYear.setEnabled(chkTechUseYear.isSelected());
-        });
+        chkTechUseYear.addActionListener(e -> txtTechYear.setEnabled(chkTechUseYear.isSelected()));
         chkTechUseYear.setText(resourceMap.getString("ConfigurationDialog.chkTechYear.text")); //$NON-NLS-1$
         chkTechUseYear.setToolTipText(resourceMap.getString("ConfigurationDialog.chkTechYear.tooltip")); //$NON-NLS-1$
         chkTechUseYear.setSelected(CConfig.getBooleanParam(CConfig.TECH_USE_YEAR));
@@ -247,8 +244,12 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
         panPrinting.add(chkShowRole, gbc);
         gbc.gridy++;
 
-        // Inform user that these options are not yet limited for all units
-        lblFeatureLimitation.setText(resourceMap.getString("ConfigurationDialog.lblFeatureLimitation.text"));
+        chkHeatProfile.setText(resourceMap.getString("ConfigurationDialog.chkHeatProfile.text"));
+        chkHeatProfile.setToolTipText(resourceMap.getString("ConfigurationDialog.chkHeatProfile.tooltip"));
+        chkHeatProfile.setSelected(CConfig.getBooleanParam(CConfig.RS_HEAT_PROFILE));
+        panPrinting.add(chkHeatProfile, gbc);
+        gbc.gridy++;
+
         panPrinting.add(lblFeatureLimitation, gbc);
     }
     
@@ -306,7 +307,7 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
     }
     
     private void saveConfig() {
-        colorMap.forEach((k,v) -> CConfig.setParam(k, v));
+        colorMap.forEach(CConfig::setParam);
         CConfig.setParam(CConfig.TECH_PROGRESSION, String.valueOf(chkTechProgression.isSelected()));
         CConfig.setParam(CConfig.TECH_USE_YEAR, String.valueOf(chkTechUseYear.isSelected()));
         CConfig.setParam(CConfig.TECH_YEAR, String.valueOf(txtTechYear.getIntVal()));
@@ -319,6 +320,7 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
         CConfig.setParam(CConfig.RS_SHOW_PILOT_DATA, Boolean.toString(chkShowPilotData.isSelected()));
         CConfig.setParam(CConfig.RS_SHOW_ERA, Boolean.toString(chkShowEraIcon.isSelected()));
         CConfig.setParam(CConfig.RS_SHOW_ROLE, Boolean.toString(chkShowRole.isSelected()));
+        CConfig.setParam(CConfig.RS_HEAT_PROFILE, Boolean.toString(chkHeatProfile.isSelected()));
         CConfig.setParam(CConfig.SUMMARY_FORMAT_TRO, Boolean.toString(chkSummaryFormatTRO.isSelected()));
         CConfig.saveConfig();
     }


### PR DESCRIPTION
Adds an option to the printing tab of the configuration dialog that will show total weapon heat and dissipation below the equipment list on mech and asf record sheets. Also removes the outdated message that the printing options only apply to mechs.

Examples:
[Kintaro KTO-18P.pdf](https://github.com/MegaMek/megameklab/files/4679864/Kintaro.KTO-18P.pdf)
[Chippewa CHP-W8.pdf](https://github.com/MegaMek/megameklab/files/4679865/Chippewa.CHP-W8.pdf)

Closes #227 