### PR TITLE
Early Clans and IS tech

### DIFF
--- a/src/megameklab/com/ui/util/FactionComboBox.java
+++ b/src/megameklab/com/ui/util/FactionComboBox.java
@@ -1,13 +1,19 @@
-/**
- * 
+/*
+ * MegaMekLab - Copyright (C) 2020 - The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
  */
 package megameklab.com.ui.util;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import megamek.client.ratgenerator.FactionRecord;
 import megamek.client.ratgenerator.RATGenerator;
@@ -28,30 +34,30 @@ public class FactionComboBox extends CustomComboBox<Integer> {
      */
     private static final long serialVersionUID = 4722914142736815170L;
     
-    private Map<Integer,String> displayNames = new HashMap<>();
+    private final Map<Integer,String> displayNames = new HashMap<>();
     
     public FactionComboBox() {
         super();
-        setRenderer(new Renderer<Integer>(i -> displayNames.get(i)));
+        setRenderer(new Renderer<>(displayNames::get));
         while (!RATGenerator.getInstance().isInitialized()) {
             try {
                 Thread.sleep(50);
-            } catch (InterruptedException e) {
+            } catch (InterruptedException ignored) {
             }
         }
     }
     
-    public void refresh(int year, boolean clan) {
+    public void refresh(int year) {
         displayNames.clear();
         for (int i = 0; i < ITechnology.MM_FACTION_CODES.length; i++) {
             final FactionRecord fRec = RATGenerator.getInstance().getFaction(ITechnology.MM_FACTION_CODES[i]);
             // TA will generate a null value because the RAT Generator doesn't distinguish between TH and TA.
-            if ((null != fRec) && (fRec.isClan() == clan) && (fRec.isActiveInYear(year))) {
+            if ((null != fRec) && (fRec.isActiveInYear(year))) {
                 displayNames.put(i, fRec.getName(year));
             }
         }
         List<Integer> sorted = new ArrayList<>(displayNames.keySet());
-        Collections.sort(sorted, (i1, i2) -> displayNames.get(i1).compareTo(displayNames.get(i2)));
+        sorted.sort(Comparator.comparing(displayNames::get));
         removeAllItems();
         addItem(-1);
         displayNames.put(-1, "Any");

--- a/src/megameklab/com/ui/view/BasicInfoView.java
+++ b/src/megameklab/com/ui/view/BasicInfoView.java
@@ -48,12 +48,9 @@ import megameklab.com.util.CConfig;
  */
 public class BasicInfoView extends BuildView implements ITechManager, ActionListener, FocusListener {
     
-    /**
-     * 
-     */
     private static final long serialVersionUID = -6831478201489228066L;
 
-    private List<BuildListener> listeners = new CopyOnWriteArrayList<>();
+    private final List<BuildListener> listeners = new CopyOnWriteArrayList<>();
     public void addListener(BuildListener l) {
         if (null != l) {
             listeners.add(l);
@@ -258,7 +255,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         if (cbFaction.getSelectedIndex() < 0) {
             return -1;
         }
-        return (Integer)cbFaction.getSelectedItem();
+        return retVal;
     }
     
     public void setTechFaction(int techFaction) {
@@ -298,7 +295,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         if (getTechIntroYear() < CLAN_START) {
             return false;
         } else {
-            Integer selected = (Integer)cbTechBase.getSelectedItem();
+            Integer selected = (Integer) cbTechBase.getSelectedItem();
             return ((null != selected)
                     && ((selected == TECH_BASE_CLAN) || (selected == TECH_BASE_CLAN_MIXED)));
         }
@@ -309,7 +306,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         if (getTechIntroYear() < CLAN_START) {
             return false;
         }
-        Integer selected = (Integer)cbTechBase.getSelectedItem();
+        Integer selected = (Integer) cbTechBase.getSelectedItem();
         return ((null != selected)
                 && ((selected == TECH_BASE_IS_MIXED) || (selected == TECH_BASE_CLAN_MIXED)));
     }
@@ -339,19 +336,29 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     }
     
     private void refreshTechBase() {
-        Integer prev = (Integer)cbTechBase.getSelectedItem();
+        Integer prev = (Integer) cbTechBase.getSelectedItem();
         cbTechBase.removeActionListener(this);
         cbTechBase.removeAllItems();
-        if (baseTA.getTechBase() != ITechnology.TECH_BASE_CLAN) {
+        // IS is available to anything that doesn't require a Clan tech base (e.g. QuadVee, ProtoMech).
+        // Clan is available to anything that doesn't require an IS tech base, is built after the Clans
+        // are formed, and not built by an IS faction before the Clan invasion.
+        final boolean clanFaction = (getTechFaction() >= ITechnology.F_CLAN) || (getTechFaction() < 0);
+        final boolean sphereAvailable = baseTA.getTechBase() != TECH_BASE_CLAN;
+        final boolean clanAvailable = (getTechIntroYear() >= CLAN_START)
+                && (baseTA.getTechBase() != ITechnology.TECH_BASE_IS)
+                && (clanFaction || (getTechIntroYear() >= IS_MIXED_START));
+        final boolean mixedTechAvailable = (getTechIntroYear() >= IS_MIXED_START)
+                || ((getTechIntroYear() >= CLAN_MIXED_START) && clanFaction);
+        if (sphereAvailable) {
             cbTechBase.addItem(TECH_BASE_IS);
         }
-        if ((getTechIntroYear() >= CLAN_START) && (baseTA.getTechBase() != ITechnology.TECH_BASE_IS)) {
+        if (clanAvailable) {
             cbTechBase.addItem(TECH_BASE_CLAN);
         }
-        if ((getTechIntroYear() >= IS_MIXED_START) && (baseTA.getTechBase() != ITechnology.TECH_BASE_CLAN)) {
+        if (sphereAvailable && mixedTechAvailable) {
             cbTechBase.addItem(TECH_BASE_IS_MIXED);
         }
-        if ((getTechIntroYear() >= CLAN_MIXED_START) && (baseTA.getTechBase() != ITechnology.TECH_BASE_IS)) {
+        if (clanAvailable && mixedTechAvailable) {
             cbTechBase.addItem(TECH_BASE_CLAN_MIXED);
         }
         if (null != prev) {
@@ -388,11 +395,10 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     }
     
     private void refreshFaction() {
-        
         if (CConfig.getBooleanParam(CConfig.TECH_SHOW_FACTION)) {
             cbFaction.removeActionListener(this);
-            Integer prevFaction = (Integer)cbFaction.getSelectedItem();
-            cbFaction.refresh(getTechIntroYear(), useClanTechBase());
+            Integer prevFaction = (Integer) cbFaction.getSelectedItem();
+            cbFaction.refresh(getTechIntroYear());
             cbFaction.setSelectedItem(prevFaction);
             cbFaction.addActionListener(this);
             if (cbFaction.getSelectedIndex() < 0) {
@@ -426,7 +432,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
                 int year = Math.max(getTechIntroYear(), baseTA.getIntroductionDate(useClanTechBase()));
                 listeners.forEach(l -> l.yearChanged(year));
                 prevYear = year;
-            } catch (NumberFormatException ex) {
+            } catch (NumberFormatException ignored) {
+                // If text is not a legal integer value, reset to the previous value
             } finally {
                 setYear(prevYear);
             }
@@ -440,20 +447,21 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
                 setManualBV(prevBV);
             }
         }
-        listeners.forEach(l -> l.refreshSummary());
+        listeners.forEach(BuildListener::refreshSummary);
     }
     
     @Override
     public void actionPerformed(ActionEvent e) {
         if (e.getSource() == cbFaction) {
-            listeners.forEach(l -> l.updateTechLevel());
+            listeners.forEach(BuildListener::updateTechLevel);
+            refreshTechBase();
         } else if (e.getSource() == cbTechBase) {
             listeners.forEach(l -> l.techBaseChanged(useClanTechBase(), useMixedTech()));
             refreshTechLevel();
         } else if (e.getSource() == cbTechLevel) {
             listeners.forEach(l -> l.techLevelChanged(getTechLevel()));
         }
-        listeners.forEach(l -> l.refreshSummary());
+        listeners.forEach(BuildListener::refreshSummary);
     }
     
     @Override

--- a/src/megameklab/com/ui/view/BasicInfoView.java
+++ b/src/megameklab/com/ui/view/BasicInfoView.java
@@ -252,8 +252,12 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     
     @Override
     public int getTechFaction() {
-        if (cbFaction.getSelectedIndex() < 0) {
-            return -1;
+        if (!CConfig.getBooleanParam(CConfig.TECH_SHOW_FACTION)) {
+            return ITechnology.F_NONE;
+        }
+        Integer retVal = (Integer) cbFaction.getSelectedItem();
+        if (retVal == null) {
+            return ITechnology.F_NONE;
         }
         return retVal;
     }


### PR DESCRIPTION
This changes the way tech base and mixed tech options are presented to reflect the early Clan years better. Currently the options work off the assumption that Clan factions build Clan units and IS factions build IS units, so IS mixed is not an option prior to 3050. This PR changes the behavior to allow Clan, Clan mixed, and IS mixed as long as they are available at any point in the game universe by default. When using tech-specific intro dates, Clan tech is unavailable to IS and periphery factions until the IS intro date of mixed tech.

Specific non-fluff differences this makes:
1. Using Clan mixed instead of IS mixed for the early Clan units causes MM to add Clan CASE automatically.
2. For BA, a Clan mixed chassis is heavier than an IS mixed chassis to account for the automatic HarJel.

This takes care of the code issues with MegaMek/megamek#1981. The unit file should still be set to IS/mixed.
