### PR TITLE
Fix scaling and positioning of tables on vehicle record sheet.

### DIFF
--- a/src/megameklab/com/printing/PrintCompositeTankSheet.java
+++ b/src/megameklab/com/printing/PrintCompositeTankSheet.java
@@ -20,14 +20,12 @@ package megameklab.com.printing;
 import megamek.common.Tank;
 import megamek.common.VTOL;
 import megamek.common.annotations.Nullable;
-import megameklab.com.MegaMekLab;
 import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.util.SVGConstants;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import java.awt.print.PageFormat;
-import java.util.Calendar;
 
 /**
  * Creates a single-page record sheet for two vehicles. If only one vehicle is provided,
@@ -78,9 +76,7 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
 
     @Override
     protected void processImage(int startPage, PageFormat pageFormat) {
-        final String METHOD_NAME = "processImage(int, PageFormat)";
-
-        PrintTank sheet = new PrintTank(tank1, getFirstPage(), options);
+        PrintRecordSheet sheet = new PrintTank(tank1, getFirstPage(), options);
         sheet.createDocument(startPage, pageFormat);
         Element g = getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_G_TAG);
         g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
@@ -91,34 +87,18 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
 
         if (tank2 != null) {
             sheet = new PrintTank(tank2, getFirstPage(), options);
-            sheet.createDocument(startPage, pageFormat);
-            g = getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_G_TAG);
-            g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
-                    String.format("%s(0 %f)", SVGConstants.SVG_TRANSLATE_VALUE,
-                            pageFormat.getImageableHeight() * 0.5));
-            g.appendChild(getSVGDocument().importNode(sheet.getSVGDocument().getDocumentElement(), true));
-            getSVGDocument().getDocumentElement().appendChild(g);
+        } else if (tank1 instanceof VTOL) {
+            sheet = new VTOLTables(options);
         } else {
-            String filename = (tank1 instanceof VTOL)? "tables_vtol.svg" : "tables_tank.svg";
-            Document doc = loadSVG(getSVGDirectoryName(), filename);
-            if (null != doc) {
-                Element element = doc.getElementById(COPYRIGHT);
-                if (null != element) {
-                    element.setTextContent(String.format(element.getTextContent(),
-                            Calendar.getInstance().get(Calendar.YEAR)));
-                }
-                g = getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_G_TAG);
-                g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
-                        String.format("%s(%f %f)", SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
-                                pageFormat.getImageableX(),
-                                pageFormat.getImageableY() + pageFormat.getHeight() * 0.5));
-                g.appendChild(getSVGDocument().importNode(doc.getDocumentElement(), true));
-                getSVGDocument().getDocumentElement().appendChild(g);
-            } else {
-                MegaMekLab.getLogger().warning(getClass(), METHOD_NAME,
-                        "Could not load vehicle tables file " + filename);
-            }
+            sheet = new TankTables(options);
         }
+        sheet.createDocument(startPage, pageFormat);
+        g = getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_G_TAG);
+        g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
+                String.format("%s(0 %f)", SVGConstants.SVG_TRANSLATE_VALUE,
+                        pageFormat.getImageableHeight() * 0.5));
+        g.appendChild(getSVGDocument().importNode(sheet.getSVGDocument().getDocumentElement(), true));
+        getSVGDocument().getDocumentElement().appendChild(g);
     }
 
     @Override
@@ -131,5 +111,39 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
     protected String getRecordSheetTitle() {
         // Not used by composite sheet
         return "";
+    }
+
+    private static class TankTables extends PrintRecordSheet {
+
+        TankTables(RecordSheetOptions options) {
+            super(0, options);
+        }
+
+        @Override
+        protected String getSVGFileName(int pageNumber) {
+            return "tables_tank.svg";
+        }
+
+        @Override
+        protected String getRecordSheetTitle() {
+            return "";
+        }
+    }
+
+    private static class VTOLTables extends PrintRecordSheet {
+
+        VTOLTables(RecordSheetOptions options) {
+            super(0, options);
+        }
+
+        @Override
+        protected String getSVGFileName(int pageNumber) {
+            return "tables_vtol.svg";
+        }
+
+        @Override
+        protected String getRecordSheetTitle() {
+            return "";
+        }
     }
 }

--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -150,14 +150,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
     
     @Override
     protected void processImage(int pageNum, PageFormat pageFormat) {
-        Element element;
-        
-        element = getSVGDocument().getElementById(COPYRIGHT);
-        if (null != element) {
-            element.setTextContent(String.format(element.getTextContent(),
-                    Calendar.getInstance().get(Calendar.YEAR)));
-        }
-        
+        super.processImage(pageNum, pageFormat);
         writeTextFields();
         drawArmor();
         drawStructure();

--- a/src/megameklab/com/printing/PrintRecordSheet.java
+++ b/src/megameklab/com/printing/PrintRecordSheet.java
@@ -297,7 +297,7 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
             createDocument(pageIndex, pageFormat);
             GraphicsNode node = build();
             node.paint(g2d);
-            /* Testing code that outputs the generated svg
+            /* Testing code that outputs the generated svg */
             try {
                 javax.xml.transform.Transformer transformer = javax.xml.transform.TransformerFactory.newInstance().newTransformer();
                 javax.xml.transform.Result output = new javax.xml.transform.stream.StreamResult(new File("out.svg"));
@@ -306,7 +306,7 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
             } catch (Exception ex) {
                 ex.printStackTrace();
             }
-            */
+            /* */
         }
         return Printable.PAGE_EXISTS;
     }
@@ -359,7 +359,13 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
      * 
      * @param pageNum    Indicates which page of multi-page sheets to print. The first page is 0.
      */
-    protected abstract void processImage(int pageNum, PageFormat pageFormat);
+    protected void processImage(int pageNum, PageFormat pageFormat) {
+        Element element = getSVGDocument().getElementById(COPYRIGHT);
+        if (null != element) {
+            element.setTextContent(String.format(element.getTextContent(),
+                    Calendar.getInstance().get(Calendar.YEAR)));
+        }
+    }
 
     String getSVGDirectoryName() {
         return "data/images/recordsheets/" + options.getPaperSize().dirName;

--- a/src/megameklab/com/printing/PrintRecordSheet.java
+++ b/src/megameklab/com/printing/PrintRecordSheet.java
@@ -297,7 +297,7 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
             createDocument(pageIndex, pageFormat);
             GraphicsNode node = build();
             node.paint(g2d);
-            /* Testing code that outputs the generated svg */
+            /* Testing code that outputs the generated svg
             try {
                 javax.xml.transform.Transformer transformer = javax.xml.transform.TransformerFactory.newInstance().newTransformer();
                 javax.xml.transform.Result output = new javax.xml.transform.stream.StreamResult(new File("out.svg"));
@@ -306,7 +306,7 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
             } catch (Exception ex) {
                 ex.printStackTrace();
             }
-            /* */
+            */
         }
         return Printable.PAGE_EXISTS;
     }


### PR DESCRIPTION
My recent update allowing the user to set the paper size broke vehicle record sheets with a single unit on them. It throws an exception when trying to position the tables due to an illegal attribute, (transform where it should be translate) but it also doesn't take any custom margins into account. In the process of fixing it I simplified it by using the code already in PrintRecordSheet to handle the loading and sizing.