### PR TITLE
Inventory overlap

### DIFF
--- a/src/megameklab/com/printing/InventoryWriter.java
+++ b/src/megameklab/com/printing/InventoryWriter.java
@@ -621,8 +621,8 @@ public class InventoryWriter {
     private double printEquipmentTable(List<? extends InventoryEntry> list,
                                        double ypos, float fontSize, double lineHeight, Column[] columnTypes, double[] colX) {
         for (InventoryEntry line : list) {
-            int lines = 0;
             for (int row = 0; row < line.nRows(); row++) {
+                int lines = 1;
                 for (int i = 0; i < columnTypes.length; i++) {
                     switch (columnTypes[i]) {
                         case QUANTITY:
@@ -692,10 +692,7 @@ public class InventoryWriter {
                             break;
                     }
                 }
-                ypos += lineHeight;
-            }
-            if (lines > line.nRows()) {
-                ypos += lineHeight * (lines - line.nRows());
+                ypos += lineHeight * lines;
             }
         }
         return ypos;

--- a/src/megameklab/com/printing/StandardInventoryEntry.java
+++ b/src/megameklab/com/printing/StandardInventoryEntry.java
@@ -171,8 +171,15 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
         if (eqName.length() > 20) {
             eqName = mount.getShortName();
         }
-        // Remove trailing IS or Clan tag in brackets or parentheses, including possible leading space
-        StringBuilder name = new StringBuilder(eqName.replaceAll(" ?[\\[(](Clan|IS)[])]", ""));
+        // If this is not a mixed tech unit, remove trailing IS or Clan tag in brackets or parentheses,
+        // including possible leading space. For mixed tech units this is presumably needed to remove
+        // ambiguity.
+        if (!mount.getEntity().isMixedTech()) {
+            eqName = eqName.replaceAll(" ?[\\[(](Clan|IS)[])]", "");
+        }
+        StringBuilder name = new StringBuilder(eqName);
+        // For mixed tech units, we want to append the tech base if there is ambiguity
+        // and it isn't already part of the name.
         if (showTechBase()) {
             name.append(mount.getType().isClan() ? " (Clan)" : " (IS)");
         }
@@ -201,7 +208,8 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
 
     /**
      * Determines whether we should indicate whether the equipment is IS or Clan for
-     * units with a mixed tech base. Only specify when there might be some confusion.
+     * units with a mixed tech base. Only specify when there is another piece of equipment
+     * with the same name but different tech base.
      *
      * @return Whether the tech base should be shown for the equipment
      */
@@ -216,7 +224,8 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
         final Enumeration<EquipmentType> e = EquipmentType.getAllTypes();
         while (e.hasMoreElements()) {
             final EquipmentType et = e.nextElement();
-            if (!et.equals(mount.getType()) && et.getName().equals(mount.getType().getName())) {
+            if ((et.getTechBase() != mount.getType().getTechBase())
+                    && et.getName().equals(mount.getType().getName())) {
                 showMixedTechBase.put(mount.getType(), true);
                 showMixedTechBase.put(et, true);
                 return true;

--- a/src/megameklab/com/printing/StandardInventoryEntry.java
+++ b/src/megameklab/com/printing/StandardInventoryEntry.java
@@ -27,14 +27,17 @@ import megamek.common.weapons.other.ISCenturionWeaponSystem;
 import megameklab.com.util.StringUtils;
 
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Formats text for an entry in the weapons and equipment inventory section of the record sheet.
  * This is for single pieces of equipment. WeaponBays should use {@link WeaponBayInventoryEntry}.
  */
 public class StandardInventoryEntry implements InventoryEntry, Comparable<StandardInventoryEntry> {
+    // Cache for whether equipment on a mixed tech unit needs to state explicitly whether
+    // it's IS or Clan
+    private static final Map<EquipmentType, Boolean> showMixedTechBase = new HashMap<>();
+
     private final Mounted mount;
 
     private final String[][] ranges;
@@ -170,7 +173,7 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
         }
         // Remove trailing IS or Clan tag in brackets or parentheses, including possible leading space
         StringBuilder name = new StringBuilder(eqName.replaceAll(" ?[\\[(](Clan|IS)[])]", ""));
-        if (mount.getEntity().isMixedTech() && (mount.getType().getTechBase() != ITechnology.TECH_BASE_ALL)) {
+        if (showTechBase()) {
             name.append(mount.getType().isClan() ? " (Clan)" : " (IS)");
         }
         // Spheroid Small Craft/Dropships use a different location name for aft side weapons
@@ -194,6 +197,33 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
             name.append(" ").append(StringUtils.getAeroEquipmentInfo(mount));
         }
         return name.toString();
+    }
+
+    /**
+     * Determines whether we should indicate whether the equipment is IS or Clan for
+     * units with a mixed tech base. Only specify when there might be some confusion.
+     *
+     * @return Whether the tech base should be shown for the equipment
+     */
+    private boolean showTechBase() {
+        if (!mount.getEntity().isMixedTech()
+                || (mount.getType().getTechBase() == ITechnology.TECH_BASE_ALL)) {
+            return false;
+        }
+        if (showMixedTechBase.containsKey(mount.getType())) {
+            return showMixedTechBase.get(mount.getType());
+        }
+        final Enumeration<EquipmentType> e = EquipmentType.getAllTypes();
+        while (e.hasMoreElements()) {
+            final EquipmentType et = e.nextElement();
+            if (!et.equals(mount.getType()) && et.getName().equals(mount.getType().getName())) {
+                showMixedTechBase.put(mount.getType(), true);
+                showMixedTechBase.put(et, true);
+                return true;
+            }
+        }
+        showMixedTechBase.put(mount.getType(), false);
+        return false;
     }
 
     private String formatLocation() {


### PR DESCRIPTION
Fixes a text overlap issue in the inventory section of a record sheet. When the name or damage entry is too long to fit in the space it is split over multiple lines. There is a logic error that only moves the starting y coordinate of the next row of the text the necessary extra amount if the multi-line row is the last one in the entry.
Example:
![Screenshot from 2020-06-14 13-29-11](https://user-images.githubusercontent.com/16927464/84601114-a60af800-ae43-11ea-8eb6-2465722d6ac6.png)

In additional to correcting the logic error, I reduced the need for multiline text by limiting the (IS) and (Clan) indicators used on mixed tech units to equipment that has both IS and Clan variants. So in this example the AMS shows as (IS), but there is no need to specify the improved gauss rifle, which has no Clan version, or the prototype ER small lasers or improved LRM, which have no IS version.
![Screenshot from 2020-06-14 13-29-39](https://user-images.githubusercontent.com/16927464/84601172-fb470980-ae43-11ea-8903-decb2ca17b6b.png)
