### PR TITLE
Era based tech fixes

### DIFF
--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -538,8 +538,14 @@ public abstract class PrintEntity extends PrintRecordSheet {
     }
     
     protected String formatRulesLevel() {
-        return getEntity().getStaticTechLevel().toString().substring(0, 1)
-                + getEntity().getStaticTechLevel().toString().substring(1).toLowerCase();
+        SimpleTechLevel level;
+        if (options.useEraBaseProgression()) {
+            level = getEntity().getSimpleLevel(getEntity().getYear(), getEntity().isClan());
+        } else {
+            level = getEntity().getStaticTechLevel();
+        }
+        return level.toString().substring(0, 1)
+                + level.toString().substring(1).toLowerCase();
     }
     
     private static String formatEra(int year) {

--- a/src/megameklab/com/printing/RecordSheetOptions.java
+++ b/src/megameklab/com/printing/RecordSheetOptions.java
@@ -15,8 +15,6 @@ package megameklab.com.printing;
 
 import megameklab.com.util.CConfig;
 
-import java.awt.print.Paper;
-
 /**
  * A set of options for controlling what is displayed on the record sheet
  * 
@@ -33,6 +31,7 @@ public class RecordSheetOptions {
     private boolean role;
     private boolean heatProfile;
     private boolean tacOpsHeat;
+    private boolean eraBasedProgression;
 
     public RecordSheetOptions() {
         String paper = CConfig.getParam(CConfig.RS_PAPER_SIZE, PaperSize.US_LETTER.name());
@@ -48,6 +47,7 @@ public class RecordSheetOptions {
         this.role = CConfig.getBooleanParam(CConfig.RS_SHOW_ROLE);
         this.heatProfile = CConfig.getBooleanParam(CConfig.RS_HEAT_PROFILE);
         this.tacOpsHeat = CConfig.getBooleanParam(CConfig.RS_TAC_OPS_HEAT);
+        this.eraBasedProgression = CConfig.getBooleanParam(CConfig.TECH_PROGRESSION);
     }
 
     public PaperSize getPaperSize() {
@@ -86,6 +86,10 @@ public class RecordSheetOptions {
         return tacOpsHeat;
     }
 
+    public boolean useEraBaseProgression() {
+        return eraBasedProgression;
+    }
+
     public void setPaperSize(PaperSize paperSize) {
         this.paperSize = paperSize;
     }
@@ -110,4 +114,7 @@ public class RecordSheetOptions {
         this.tacOpsHeat = tacOpsHeat;
     }
 
+    public void setEraBasedProgression(boolean eraBased) {
+        eraBasedProgression = eraBased;
+    }
 }

--- a/src/megameklab/com/ui/view/BasicInfoView.java
+++ b/src/megameklab/com/ui/view/BasicInfoView.java
@@ -380,13 +380,27 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         SimpleTechLevel prev = getTechLevel();
         cbTechLevel.removeActionListener(this);
         cbTechLevel.removeAllItems();
-        if (!useClanTechBase() && !useMixedTech() && SimpleTechLevel.INTRO.ordinal() >= baseTA.getStaticTechLevel().ordinal()) {
+        SimpleTechLevel baseLevel;
+        if (CConfig.getBooleanParam(CConfig.TECH_PROGRESSION)) {
+            baseLevel = baseTA.getSimpleLevel(getGameYear());
+            if (useMixedTech() && (baseLevel.ordinal() <
+                    Entity.getMixedTechAdvancement().getSimpleLevel(getGameYear()).ordinal())) {
+                baseLevel = Entity.getMixedTechAdvancement().getSimpleLevel(getGameYear());
+            }
+        } else {
+            baseLevel = baseTA.getStaticTechLevel();
+            if (useMixedTech()
+                    && (baseLevel.ordinal() < Entity.getMixedTechAdvancement().getStaticTechLevel().ordinal())) {
+                baseLevel = Entity.getMixedTechAdvancement().getStaticTechLevel();
+            }
+        }
+        if (!useClanTechBase() && SimpleTechLevel.INTRO.ordinal() >= baseLevel.ordinal()) {
             cbTechLevel.addItem(SimpleTechLevel.INTRO);
         }
-        if (!useMixedTech() && SimpleTechLevel.STANDARD.ordinal() >= baseTA.getStaticTechLevel().ordinal()) {
+        if (SimpleTechLevel.STANDARD.ordinal() >= baseLevel.ordinal()) {
             cbTechLevel.addItem(SimpleTechLevel.STANDARD);
         }
-        if (SimpleTechLevel.ADVANCED.ordinal() >= baseTA.getStaticTechLevel().ordinal()) {
+        if (SimpleTechLevel.ADVANCED.ordinal() >= baseLevel.ordinal()) {
             cbTechLevel.addItem(SimpleTechLevel.ADVANCED);
         }
         cbTechLevel.addItem(SimpleTechLevel.EXPERIMENTAL);


### PR DESCRIPTION
Applies the era-based tech progression system from IO in a few places it was missing.
1. The tech level combo box. It treats mixed tech and superheavies as always advanced, but using the IO system mixed tech is standard after 3115 and superheavies are experimental before 3076.
2. The record sheet always shows the basic (static) tech level.