### PR TITLE
Remove capital fighter weapon groups on load.

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2567,6 +2567,10 @@ public class UnitUtil {
                 unit.setArmorType(EquipmentType.T_ARMOR_PRIMITIVE_FIGHTER);
             }
         }
+        List<Mounted> weaponGroups = new ArrayList<>(unit.getWeaponGroupList());
+        for (Mounted group : weaponGroups) {
+            UnitUtil.removeMounted(unit, group);
+        }
     }
 
     public static boolean isUnitWeapon(EquipmentType eq, Entity unit) {


### PR DESCRIPTION
Capital weapon groups are created when an aerospace fighter is loaded but serve no purpose in MML. They're ignored in most places, but ammo will still show up on the equipment tab after the weapon has been removed because it matches the weapon group. When the unit is loaded into MM the weapon groups will be built normally.

Fixes #642.