### PR TITLE
Reset equipment links

### DIFF
--- a/src/megameklab/com/util/CriticalTransferHandler.java
+++ b/src/megameklab/com/util/CriticalTransferHandler.java
@@ -194,16 +194,6 @@ public class CriticalTransferHandler extends TransferHandler {
 
         UnitUtil.changeMountStatus(getUnit(), eq, location, secondaryLocation, rear);
 
-        // Check linkings after you remove everything.
-        try {
-            MechFileParser.postLoadInit(getUnit());
-        } catch (EntityLoadingException ele) {
-            // do nothing.
-        } catch (Exception ex) {
-
-            ex.printStackTrace();
-        }
-
         if (refresh != null) {
             refresh.refreshAll();
         }

--- a/src/megameklab/com/util/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/DropTargetCriticalList.java
@@ -280,17 +280,6 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
         }
 
         UnitUtil.compactCriticals(getUnit());
-
-        // Check linkings after you remove everything.
-        try {
-            MechFileParser.postLoadInit(getUnit());
-        } catch (EntityLoadingException ele) {
-            // do nothing.
-        } catch (Exception ex) {
-
-            ex.printStackTrace();
-        }
-
     }
 
     private void changeWeaponFacing(boolean rear) {
@@ -339,22 +328,13 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
         if (cs != null) {
             if (cs.getType() == CriticalSlot.TYPE_EQUIPMENT) {
                 Mounted mount = getMounted();
+                assert mount != null;
                 mount.setArmored(!cs.isArmored());
                 UnitUtil.updateCritsArmoredStatus(getUnit(), mount);
             } else {
                 cs.setArmored(!cs.isArmored());
                 UnitUtil.updateCritsArmoredStatus(getUnit(), cs, getCritLocation());
             }
-        }
-
-        // Check linkings after you remove everything.
-        try {
-            MechFileParser.postLoadInit(getUnit());
-        } catch (EntityLoadingException ele) {
-            // do nothing.
-        } catch (Exception ex) {
-
-            ex.printStackTrace();
         }
 
         if (refresh != null) {

--- a/src/megameklab/com/util/Mech/CriticalTransferHandler.java
+++ b/src/megameklab/com/util/Mech/CriticalTransferHandler.java
@@ -565,16 +565,6 @@ public class CriticalTransferHandler extends TransferHandler {
 
         UnitUtil.changeMountStatus(getUnit(), eq, location, secondaryLocation, rear);
 
-        // Check linkings after you remove everything.
-        try {
-            MechFileParser.postLoadInit(getUnit());
-        } catch (EntityLoadingException ele) {
-            // do nothing.
-        } catch (Exception ex) {
-
-            ex.printStackTrace();
-        }
-
         if (refresh != null) {
             refresh.refreshAll();
         }

--- a/src/megameklab/com/util/Mech/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/Mech/DropTargetCriticalList.java
@@ -688,16 +688,6 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
             }
         }
 
-        // Check linkings after you remove everything.
-        try {
-            MechFileParser.postLoadInit(getUnit());
-        } catch (EntityLoadingException ele) {
-            // do nothing.
-        } catch (Exception ex) {
-
-            ex.printStackTrace();
-        }
-
         if (refresh != null) {
             refresh.refreshAll();
         }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1228,6 +1228,14 @@ public class UnitUtil {
         eq.setLocation(location, rear);
         eq.setSecondLocation(secondaryLocation, rear);
         eq.setSplit(secondaryLocation > -1);
+        // If we're adding it to a location on the unit, check equipment linkages
+        if (location > Entity.LOC_NONE) {
+            try {
+                MechFileParser.postLoadInit(unit);
+            } catch (EntityLoadingException ignored) {
+                // Exception thrown for not having equipment to link to yet, which is acceptable here
+            }
+        }
     }
 
     public static void resizeMount(Mounted mount, double newSize) {
@@ -1250,11 +1258,6 @@ public class UnitUtil {
         compactCriticals(entity, loc);
         if ((start < 0) || (entity.getEmptyCriticals(loc) < mount.getCriticals())) {
             changeMountStatus(entity, mount, Entity.LOC_NONE, Entity.LOC_NONE, false);
-            try {
-                MechFileParser.postLoadInit(entity);
-            } catch (EntityLoadingException ignored) {
-                // We're not actually loading an Entity; we're fixing linked equipment
-            }
         } else {
             // If the number of criticals increases, we may need to shift existing criticals
             // to make room. Since we checked for sufficient space and compacted the existing

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1207,14 +1207,24 @@ public class UnitUtil {
      * it's located (ie, BAMountLocation isn't affected).  BattleArmor should
      * change this outside of this method.
      *
-     * @param unit
-     * @param eq
-     * @param location
-     * @param secondaryLocation
-     * @param rear
+     * @param unit               The unit being modified
+     * @param eq                 The equipment mount to move
+     * @param location           The location to move the mount to
+     * @param secondaryLocation  The secondary location for split equipment, otherwise {@link Entity#LOC_NONE Entity.LOC_NONE}
+     * @param rear               Whether to mount with a rear facing
      */
     public static void changeMountStatus(Entity unit, Mounted eq, int location,
             int secondaryLocation, boolean rear) {
+        if (location != eq.getLocation()) {
+            if (eq.getLinked() != null) {
+                eq.getLinked().setLinkedBy(null);
+                eq.setLinked(null);
+            }
+            if (eq.getLinkedBy() != null) {
+                eq.getLinkedBy().setLinked(null);
+                eq.setLinkedBy(null);
+            }
+        }
         eq.setLocation(location, rear);
         eq.setSecondLocation(secondaryLocation, rear);
         eq.setSplit(secondaryLocation > -1);


### PR DESCRIPTION
Linked equipment such as missile launchers and Artemis or PPCs and capacitors have little direct effect on construction but can affect BV calculations. Currently the links are rechecked by calling MechFileParser::postLoadInit whenever equipment location changes via drag and drop, but not when placed by popup menu. Links are also not removed once set unless the equipment is removed, so links can span locations. In the issue that prompted this change, adding a PPC to a mech resulted in linking an unallocated PPC to an unallocated capacitor (they are considered to be in the same location, because both are in LOC_NONE). Then depending on the order they are placed you can end up with one of the capacitors linked to a PPC in another location and the other not linked at all. This affects the explosion potential, so CASE II in one location gives a higher BV than the other.

I changed it to clear the links on any equipment moved to another location, consolidating some duplicated code into UnitUtil::changeMountStatus, and check for any new links that need to be created when equipment is placed anywhere on the unit. I also removed some unnecessary calls to postLoadInit() after changed the armored component status, since this has no effect on equipment linking.

Fixes #645