### PR TITLE
Fix for tripod and superheavy mech tech base

### DIFF
--- a/src/megameklab/com/ui/view/BasicInfoView.java
+++ b/src/megameklab/com/ui/view/BasicInfoView.java
@@ -65,10 +65,10 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     private static final int IS_MIXED_START = TA_MIXED_TECH.getIntroductionDate(false);
     private static final int CLAN_MIXED_START = TA_MIXED_TECH.getIntroductionDate(true);
     
-    private static final int TECH_BASE_IS           = 0;
-    private static final int TECH_BASE_CLAN         = 1;
-    private static final int TECH_BASE_IS_MIXED     = 2;
-    private static final int TECH_BASE_CLAN_MIXED   = 3;
+    private static final int BASE_IS = 0;
+    private static final int BASE_CLAN = 1;
+    private static final int BASE_IS_MIXED = 2;
+    private static final int BASE_CLAN_MIXED = 3;
     
     private String[] techBaseNames;
     private TechAdvancement baseTA;
@@ -301,7 +301,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         } else {
             Integer selected = (Integer) cbTechBase.getSelectedItem();
             return ((null != selected)
-                    && ((selected == TECH_BASE_CLAN) || (selected == TECH_BASE_CLAN_MIXED)));
+                    && ((selected == BASE_CLAN) || (selected == BASE_CLAN_MIXED)));
         }
     }
     
@@ -312,7 +312,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         }
         Integer selected = (Integer) cbTechBase.getSelectedItem();
         return ((null != selected)
-                && ((selected == TECH_BASE_IS_MIXED) || (selected == TECH_BASE_CLAN_MIXED)));
+                && ((selected == BASE_IS_MIXED) || (selected == BASE_CLAN_MIXED)));
     }
     
     public void setTechBase(boolean clan, boolean mixed) {
@@ -354,16 +354,16 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         final boolean mixedTechAvailable = (getTechIntroYear() >= IS_MIXED_START)
                 || ((getTechIntroYear() >= CLAN_MIXED_START) && clanFaction);
         if (sphereAvailable) {
-            cbTechBase.addItem(TECH_BASE_IS);
+            cbTechBase.addItem(BASE_IS);
         }
         if (clanAvailable) {
-            cbTechBase.addItem(TECH_BASE_CLAN);
+            cbTechBase.addItem(BASE_CLAN);
         }
         if (sphereAvailable && mixedTechAvailable) {
-            cbTechBase.addItem(TECH_BASE_IS_MIXED);
+            cbTechBase.addItem(BASE_IS_MIXED);
         }
         if (clanAvailable && mixedTechAvailable) {
-            cbTechBase.addItem(TECH_BASE_CLAN_MIXED);
+            cbTechBase.addItem(BASE_CLAN_MIXED);
         }
         if (null != prev) {
             cbTechBase.setSelectedItem(prev);

--- a/src/megameklab/com/ui/view/BasicInfoView.java
+++ b/src/megameklab/com/ui/view/BasicInfoView.java
@@ -347,7 +347,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         // Clan is available to anything that doesn't require an IS tech base, is built after the Clans
         // are formed, and not built by an IS faction before the Clan invasion.
         final boolean clanFaction = (getTechFaction() >= ITechnology.F_CLAN) || (getTechFaction() < 0);
-        final boolean sphereAvailable = baseTA.getTechBase() != TECH_BASE_CLAN;
+        final boolean sphereAvailable = baseTA.getTechBase() != ITechnology.TECH_BASE_CLAN;
         final boolean clanAvailable = (getTechIntroYear() >= CLAN_START)
                 && (baseTA.getTechBase() != ITechnology.TECH_BASE_IS)
                 && (clanFaction || (getTechIntroYear() >= IS_MIXED_START));


### PR DESCRIPTION
The source of this issue is the use of a named constant without the correct class reference. The local constants are used to distinguish unit tech base (IS, Clan, IS mixed, Clan mixed) and what was intended was the constant from ITechnology, which is used for equipment tech base (IS, Clan, all). I fixed the reference and renamed the local constants to make confusion less likely.

Fixes #657