### PR TITLE
Allow Torso-Mounted (Industrial) Cockpit for IndustrialMech

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -314,6 +314,33 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
                 clearCritsForCockpit(true, true);
                 getMech().addSmallCommandConsole();
                 break;
+            case Mech.COCKPIT_TORSO_MOUNTED_INDUSTRIAL:
+                if (lastEngine + 2 < getMech().getNumberOfCriticals(Mech.LOC_CT)) {
+                    clearCrit(Mech.LOC_CT, lastEngine + 1);
+                    clearCrit(Mech.LOC_CT, lastEngine + 2);
+                }
+                clearCrit(Mech.LOC_HEAD, 0);
+                clearCrit(Mech.LOC_HEAD, 1);
+                if (getMech().getEmptyCriticals(Mech.LOC_LT) < 1) {
+                    for (int i = 0; i < getMech().getNumberOfCriticals(Mech.LOC_LT); i++) {
+                        if (getMech().getCritical(Mech.LOC_LT, i) != null
+                                && getMech().getCritical(Mech.LOC_LT, i).getType() == CriticalSlot.TYPE_EQUIPMENT) {
+                            clearCrit(Mech.LOC_LT, i);
+                            break;
+                        }
+                    }
+                }
+                if (getMech().getEmptyCriticals(Mech.LOC_RT) < 1) {
+                    for (int i = 0; i < getMech().getNumberOfCriticals(Mech.LOC_RT); i++) {
+                        if (getMech().getCritical(Mech.LOC_RT, i) != null
+                                && getMech().getCritical(Mech.LOC_RT, i).getType() == CriticalSlot.TYPE_EQUIPMENT) {
+                            clearCrit(Mech.LOC_RT, i);
+                            break;
+                        }
+                    }
+                }
+                getMech().addTorsoMountedIndustrialCockpit();
+                break;
             default:
                 clearCritsForCockpit(false, false);
                 getMech().addCockpit();

--- a/src/megameklab/com/ui/view/MekChassisView.java
+++ b/src/megameklab/com/ui/view/MekChassisView.java
@@ -529,9 +529,11 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
             cbCockpit.addItem(isIndustrial()? Mech.COCKPIT_PRIMITIVE_INDUSTRIAL : Mech.COCKPIT_PRIMITIVE);
         } else if (isIndustrial()) {
             cbCockpit.addItem(Mech.COCKPIT_INDUSTRIAL);
+            cbCockpit.addItem(Mech.COCKPIT_TORSO_MOUNTED_INDUSTRIAL);
             if (techManager.isLegal(Mech.getIndustrialAdvFireConTA())) {
                 cbCockpit.addItem(Mech.COCKPIT_STANDARD);
                 cbCockpit.addItem(Mech.COCKPIT_COMMAND_CONSOLE);
+                cbCockpit.addItem(Mech.COCKPIT_TORSO_MOUNTED);
             }
         } else {
             for (int cockpitType : GENERAL_COCKPITS) {


### PR DESCRIPTION
It is the part of MegaMek/MegaMek#2062, that allows to pick Torso-Mounted Cockpit for IndustrialMech, as well as also allows to pick Torso-Mounted Industrial Cockpit.