### PR TITLE
Fixes for build tab issues with stealth armor

### DIFF
--- a/src/megameklab/com/ui/Aero/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/StructureTab.java
@@ -400,6 +400,7 @@ public class StructureTab extends ITab implements AeroBuildListener, ArmorAlloca
     public void armorTypeChanged(int at, int aTechLevel) {
         if (at != EquipmentType.T_ARMOR_PATCHWORK) {
             UnitUtil.removeISorArmorMounts(getAero(), false);
+            UnitUtil.compactCriticals(getAero());
             getAero().setArmorTechLevel(aTechLevel);
             getAero().setArmorType(at);
             panArmorAllocation.showPatchwork(false);

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -419,6 +419,7 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
     public void armorTypeChanged(int at, int aTechLevel) {
         if (at != EquipmentType.T_ARMOR_PATCHWORK) {
             UnitUtil.removeISorArmorMounts(getTank(), false);
+            UnitUtil.compactCriticals(getTank());
             getTank().setArmorTechLevel(aTechLevel);
             getTank().setArmorType(at);
             panArmorAllocation.showPatchwork(false);

--- a/src/megameklab/com/ui/Vehicle/views/CriticalView.java
+++ b/src/megameklab/com/ui/Vehicle/views/CriticalView.java
@@ -225,10 +225,7 @@ public class CriticalView extends IView {
                 if (critNames.size() == 0) {
                     critNames.add(MtfFile.EMPTY);
                 }
-                DropTargetCriticalList<String> criticalSlotList = null;
-
-                DropTargetCriticalList<String> dropTargetCriticalList = new DropTargetCriticalList<String>(critNames, eSource, refresh, showEmpty);
-                criticalSlotList = dropTargetCriticalList;
+                DropTargetCriticalList<String> criticalSlotList = new DropTargetCriticalList<>(critNames, eSource, refresh, showEmpty);
                 criticalSlotList.setVisibleRowCount(critNames.size());
                 criticalSlotList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
                 criticalSlotList.setFont(new Font("Arial", Font.PLAIN, 10));

--- a/src/megameklab/com/util/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/DropTargetCriticalList.java
@@ -109,37 +109,30 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
                 CriticalSlot cs = getCrit();
 
                 Mounted mount = getMounted();
-                if ((e.getModifiersEx() & InputEvent.ALT_DOWN_MASK) != 0) {
-                    changeWeaponFacing(!mount.isRearMounted());
-                    return;
-                }
-
-                if ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0) {
-                    changeOmniMounting(!mount.isOmniPodMounted());
-                    return;
-                }                
-                
                 if (mount != null) {
+                    if ((e.getModifiersEx() & InputEvent.ALT_DOWN_MASK) != 0) {
+                        changeWeaponFacing(!mount.isRearMounted());
+                        return;
+                    }
+
+                    if ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0) {
+                        changeOmniMounting(!mount.isOmniPodMounted());
+                        return;
+                    }
+
                     popup.setAutoscrolls(true);
                     JMenuItem info;
-                    if (!UnitUtil.isFixedLocationSpreadEquipment(mount
-                            .getType())) {
+                    if (!UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
                         info = new JMenuItem("Remove " + mount.getName());
-                        info.addActionListener(new ActionListener() {
-                            public void actionPerformed(ActionEvent e) {
-                                removeCrit();
-                            }
-                        });
+                        info.addActionListener(ev -> removeCrit());
                         popup.add(info);
                     }
 
-                    info = new JMenuItem("Delete " + mount.getName());
-                    info.addActionListener(new ActionListener() {
-                        public void actionPerformed(ActionEvent e) {
-                            removeMount();
-                        }
-                    });
-                    popup.add(info);
+                    if (!UnitUtil.isArmorOrStructure(mount.getType())) {
+                        info = new JMenuItem("Delete " + mount.getName());
+                        info.addActionListener(ev -> removeMount());
+                        popup.add(info);
+                    }
                     if (getUnit().hasWorkingMisc(MiscType.F_SPONSON_TURRET)
                             && ((mount.getLocation() == Tank.LOC_LEFT) || (mount
                                     .getLocation() == Tank.LOC_RIGHT))) {

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -127,8 +127,9 @@ public class UnitUtil {
                         || eq.hasFlag(MiscType.F_ENVIRONMENTAL_SEALING)
                         || eq.hasFlag(MiscType.F_TRACKS)
                         || eq.hasFlag(MiscType.F_TALON)
-                        || (eq.hasFlag(MiscType.F_STEALTH) && eq
-                                .hasFlag(MiscType.F_MECH_EQUIPMENT))
+                        || (eq.hasFlag(MiscType.F_STEALTH)
+                            && (eq.hasFlag(MiscType.F_MECH_EQUIPMENT)
+                                || eq.hasFlag(MiscType.F_TANK_EQUIPMENT)))
                         || eq.hasFlag(MiscType.F_CHAMELEON_SHIELD)
                         || eq.hasFlag(MiscType.F_BLUE_SHIELD)
                         || eq.hasFlag(MiscType.F_MAST_MOUNT)


### PR DESCRIPTION
This fixes a couple problems I noticed while working on MegaMek/megamek#2069. The first is that when stealth armor is removed from a vehicle due to changing armor type, the critical slots on the unit don't match up to the critical slot names in the JList model for the location on the build tab. I resolved this by compressing the criticals after removing armor mounts on vehicles and fighters. The second issue is that you can remove or delete the stealth armor critical on the build tab. This doesn't have any practical effect but it's sloppy.