### PR TITLE
Don't change secondary weapon count when setting primary weapon

### DIFF
--- a/src/megameklab/com/ui/Infantry/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Infantry/tabs/StructureTab.java
@@ -431,6 +431,7 @@ public class StructureTab extends ITab implements InfantryBuildListener {
         updateSpecializations();
         panPlatoonType.setFromEntity(getInfantry());
         panWeapons.setFromEntity(getInfantry());
+        weaponView.refresh();
         refresh.refreshStatus();
         refresh.refreshPreview();
     }

--- a/src/megameklab/com/ui/Infantry/views/SpecializationView.java
+++ b/src/megameklab/com/ui/Infantry/views/SpecializationView.java
@@ -248,6 +248,11 @@ public class SpecializationView extends IView implements TableModelListener {
                 UnitUtil.replaceMainWeapon(getInfantry(), null, true);
                 getInfantry().setSecondaryN(0);
                 getInfantry().setSpecializations(getInfantry().getSpecializations() & ~Infantry.TAG_TROOPS);
+            } else if (TestInfantry.maxSecondaryWeapons(getInfantry()) > getInfantry().getSecondaryN()) {
+                getInfantry().setSecondaryN(TestInfantry.maxSecondaryWeapons(getInfantry()));
+                if (getInfantry().getSecondaryN() == 0) {
+                    UnitUtil.replaceMainWeapon(getInfantry(), null, true);
+                }
             }
             fireTableCellUpdated(row, col);
         }

--- a/src/megameklab/com/ui/Infantry/views/WeaponView.java
+++ b/src/megameklab/com/ui/Infantry/views/WeaponView.java
@@ -244,11 +244,7 @@ public class WeaponView extends IView implements ActionListener {
     public void refresh() {
         removeAllListeners();
         filterEquipment();
-        if(TestInfantry.maxSecondaryWeapons(getInfantry()) > 0) {
-            addSecondaryButton.setEnabled(true);
-        } else {
-            addSecondaryButton.setEnabled(false);
-        }
+        addSecondaryButton.setEnabled(TestInfantry.maxSecondaryWeapons(getInfantry()) > 0);
         addAllListeners();
     }
 
@@ -281,7 +277,7 @@ public class WeaponView extends IView implements ActionListener {
                 if (equip.hasFlag(WeaponType.F_TAG)) {
                     getInfantry().setSpecializations(getInfantry().getSpecializations() | Infantry.TAG_TROOPS);
                     getInfantry().setSecondaryN(2);
-                } else if (getInfantry().getSecondaryN() == 0) {
+                } else if (isSecondary && (getInfantry().getSecondaryN() == 0)) {
                     getInfantry().setSecondaryN(1);
                 }
             }
@@ -392,7 +388,9 @@ public class WeaponView extends IView implements ActionListener {
             addPrimaryButton.setEnabled((null != etype)
                     && eSource.getTechManager().isLegal(etype)
                     && !etype.hasFlag(WeaponType.F_INF_SUPPORT));
-            addSecondaryButton.setEnabled((null != etype) && eSource.getTechManager().isLegal(etype));
+            addSecondaryButton.setEnabled((null != etype)
+                    && eSource.getTechManager().isLegal(etype)
+                    && (TestInfantry.maxSecondaryWeapons(getInfantry()) > 0));
         }
         
     };


### PR DESCRIPTION
When adding or changing an infantry unit's secondary weapon, MML makes sure it the secondary weapon count is at least one. But it also does that when changing the primary weapon. This causes validation problems with specializations that don't allow any secondary weapons, such as combat engineers. I also added some code to handle removing the secondary weapon when such a specialization is chosen and disabling the button to add a secondary weapon.

Fixes #695