### PR TITLE
Record sheet inventory weapon fixes

### DIFF
--- a/src/megameklab/com/printing/StandardInventoryEntry.java
+++ b/src/megameklab/com/printing/StandardInventoryEntry.java
@@ -109,14 +109,22 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
                     r[RangeType.RANGE_MINIMUM] = String.valueOf(wtype.getMinimumRange());
                 }
                 if ((wtype.getAmmoType() == AmmoType.T_LRM_TORPEDO)
-                    || (wtype.getAmmoType() == AmmoType.T_SRM_TORPEDO)) {
+                        || (wtype.getAmmoType() == AmmoType.T_SRM_TORPEDO)) {
                     r[RangeType.RANGE_SHORT] = String.valueOf(wtype.getWShortRange());
-                    r[RangeType.RANGE_MEDIUM] = String.valueOf(wtype.getWMediumRange());
-                    r[RangeType.RANGE_LONG] = String.valueOf(wtype.getWLongRange());
+                    if (wtype.getWMediumRange() > wtype.getWShortRange()) {
+                        r[RangeType.RANGE_MEDIUM] = String.valueOf(wtype.getWMediumRange());
+                    }
+                    if (wtype.getWLongRange() > wtype.getWMediumRange()) {
+                        r[RangeType.RANGE_LONG] = String.valueOf(wtype.getWLongRange());
+                    }
                 } else {
                     r[RangeType.RANGE_SHORT] = String.valueOf(wtype.getShortRange());
-                    r[RangeType.RANGE_MEDIUM] = String.valueOf(wtype.getMediumRange());
-                    r[RangeType.RANGE_LONG] = String.valueOf(wtype.getLongRange());
+                    if (wtype.getMediumRange() > wtype.getShortRange()) {
+                        r[RangeType.RANGE_MEDIUM] = String.valueOf(wtype.getMediumRange());
+                    }
+                    if (wtype.getLongRange() > wtype.getMediumRange()) {
+                        r[RangeType.RANGE_LONG] = String.valueOf(wtype.getLongRange());
+                    }
                 }
             } else if ((mount.getType() instanceof MiscType)
                     && (mount.getType().hasFlag(MiscType.F_ECM) || mount.getType().hasFlag(MiscType.F_BAP))) {

--- a/src/megameklab/com/printing/StandardInventoryEntry.java
+++ b/src/megameklab/com/printing/StandardInventoryEntry.java
@@ -21,6 +21,7 @@ package megameklab.com.printing;
 
 import megamek.common.*;
 import megamek.common.weapons.CLIATMWeapon;
+import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.common.weapons.missiles.ATMWeapon;
 import megamek.common.weapons.missiles.MMLWeapon;
 import megamek.common.weapons.other.ISCenturionWeaponSystem;
@@ -103,7 +104,14 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
         } else {
             String[] r = new String[4];
             Arrays.fill(r, DASH);
-            if (mount.getType() instanceof WeaponType) {
+            if (mount.getType() instanceof InfantryWeapon) {
+                final InfantryWeapon weapon = (InfantryWeapon) mount.getType();
+                r[RangeType.RANGE_SHORT] = String.valueOf(weapon.getInfantryRange());
+                if (weapon.getInfantryRange() > 0) {
+                    r[RangeType.RANGE_MEDIUM] = String.valueOf(weapon.getInfantryRange() * 2);
+                    r[RangeType.RANGE_LONG] = String.valueOf(weapon.getInfantryRange() * 3);
+                }
+            } else if (mount.getType() instanceof WeaponType) {
                 final WeaponType wtype = (WeaponType) mount.getType();
                 if (wtype.getMinimumRange() > 0) {
                     r[RangeType.RANGE_MINIMUM] = String.valueOf(wtype.getMinimumRange());

--- a/src/megameklab/com/util/StringUtils.java
+++ b/src/megameklab/com/util/StringUtils.java
@@ -18,12 +18,7 @@ package megameklab.com.util;
 
 import java.util.Comparator;
 
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.Mech;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.actions.ClubAttackAction;
 import megamek.common.actions.KickAttackAction;
 import megamek.common.weapons.artillery.ArtilleryCannonWeapon;
@@ -45,15 +40,7 @@ import megamek.common.weapons.gaussrifles.HAGWeapon;
 import megamek.common.weapons.gaussrifles.ISHGaussRifle;
 import megamek.common.weapons.gaussrifles.ISSilverBulletGauss;
 import megamek.common.weapons.infantry.InfantryWeapon;
-import megamek.common.weapons.lasers.CLERPulseLaserSmall;
-import megamek.common.weapons.lasers.CLPulseLaserMicro;
-import megamek.common.weapons.lasers.CLPulseLaserSmall;
-import megamek.common.weapons.lasers.ISBombastLaser;
-import megamek.common.weapons.lasers.ISPulseLaserSmall;
-import megamek.common.weapons.lasers.ISVariableSpeedPulseLaserLarge;
-import megamek.common.weapons.lasers.ISVariableSpeedPulseLaserMedium;
-import megamek.common.weapons.lasers.ISVariableSpeedPulseLaserSmall;
-import megamek.common.weapons.lasers.ISXPulseLaserSmall;
+import megamek.common.weapons.lasers.*;
 import megamek.common.weapons.lrms.LRMWeapon;
 import megamek.common.weapons.lrms.StreakLRMWeapon;
 import megamek.common.weapons.mgs.MGWeapon;
@@ -137,12 +124,11 @@ public class StringUtils {
                     info = "1/Msl [M,C]";
                 } else if (weapon instanceof ISSnubNosePPC) {
                     info = "10/8/5 [DE,V]";
-                } else if (weapon instanceof ISBALaserVSPSmall) {
-                    info = "5/4/3 [P,V]";
-                } else if (weapon instanceof ISBALaserVSPMedium) {
-                    info = "9/7/5 [P,V]";
-                } else if (weapon instanceof ISVariableSpeedPulseLaserLarge) {
-                    info = "11/9/7 [P,V]";
+                } else if (weapon instanceof VariableSpeedPulseLaserWeapon) {
+                    info = String.format("%d/%d/%d [P,V]",
+                            weapon.getDamage(weapon.getShortRange()),
+                            weapon.getDamage(weapon.getMediumRange()),
+                            weapon.getDamage(weapon.getLongRange()));
                 } else if (weapon instanceof ISHGaussRifle) {
                     info = "25/20/10 [DB,X]";
                 } else if (weapon instanceof ISPlasmaRifle) {

--- a/src/megameklab/com/util/StringUtils.java
+++ b/src/megameklab/com/util/StringUtils.java
@@ -83,7 +83,7 @@ public class StringUtils {
         if (mount.getType() instanceof WeaponType) {
             WeaponType weapon = (WeaponType) mount.getType();
             if (weapon instanceof InfantryWeapon) {
-                info = Integer.toString(weapon.getDamage());
+                info = Integer.toString((int) Math.round(((InfantryWeapon) weapon).getInfantryDamage()));
                 if (weapon.hasFlag(WeaponType.F_BALLISTIC)) {
                     info += " (B)";
                 } else if (weapon.hasFlag(WeaponType.F_ENERGY)) {


### PR DESCRIPTION
Fixes three issues with the weapon stats in the record sheet inventory section.
1. Heavy machine guns have no long range, and the ranges should be shown as 1/2/- instead of 1/2/2.
2. Small and medium VSP lasers show 0 for damage instead of the values for short, medium, and long range. Large and BA versions were correct.
3. Small support vehicle weapons need special handling to show their damage based on infantry weapon stats.

Fixes #703