### PR TITLE
Show correct slot count on unallocated variable-sized equipment

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/BuildTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/BuildTab.java
@@ -122,7 +122,7 @@ public class BuildTab extends ITab implements ActionListener {
                 }
 
                 int continuousNumberOfCrits = UnitUtil.getHighestContinuousNumberOfCrits(getMech(), location);
-                int critsUsed = UnitUtil.getCritsUsed(getMech(), mount.getType());
+                int critsUsed = UnitUtil.getCritsUsed(mount);
                 if (continuousNumberOfCrits < critsUsed) {
                     continue;
                 }

--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -280,9 +280,9 @@ public class BuildView extends IView implements ActionListener, MouseListener {
             JMenuItem item;
 
             final int selectedRow = equipmentTable.rowAtPoint(e.getPoint());
-            Mounted eq = (Mounted)equipmentTable.getModel().getValueAt(selectedRow, CriticalTableModel.EQUIPMENT);
+            Mounted eq = (Mounted) equipmentTable.getModel().getValueAt(selectedRow, CriticalTableModel.EQUIPMENT);
 
-            final int totalCrits = UnitUtil.getCritsUsed(getMech(), eq.getType());
+            final int totalCrits = UnitUtil.getCritsUsed(eq);
             String[] locations = getMech().getLocationNames();
             String[] abbrLocations = getMech().getLocationAbbrs();
 
@@ -400,8 +400,8 @@ public class BuildView extends IView implements ActionListener, MouseListener {
     }
 
     private void jMenuLoadSplitComponent_actionPerformed(int location, int secondaryLocation, int primarySlots, int selectedRow) {
-        Mounted eq = (Mounted)equipmentTable.getModel().getValueAt(selectedRow, CriticalTableModel.EQUIPMENT);
-        int crits = UnitUtil.getCritsUsed(getMech(), eq.getType());
+        Mounted eq = (Mounted) equipmentTable.getModel().getValueAt(selectedRow, CriticalTableModel.EQUIPMENT);
+        int crits = UnitUtil.getCritsUsed(eq);
         int openSlots = Math.min(primarySlots, UnitUtil.getHighestContinuousNumberOfCrits(getMech(), location));
         eq.setSecondLocation(secondaryLocation);
 

--- a/src/megameklab/com/ui/Mek/views/SummaryView.java
+++ b/src/megameklab/com/ui/Mek/views/SummaryView.java
@@ -338,7 +338,7 @@ public class SummaryView extends IView{
                     || mt.hasFlag(MiscType.F_INDUSTRIAL_TSM)
                     || mt.hasFlag(MiscType.F_MASC)) {
                 weightEnhance += m.getTonnage();
-                critEnhance += UnitUtil.getCritsUsed(getMech(), mt);
+                critEnhance += UnitUtil.getCritsUsed(m);
             }
             else if (mt.hasFlag(MiscType.F_JUMP_JET)
                     || mt.hasFlag(MiscType.F_JUMP_BOOSTER)) {

--- a/src/megameklab/com/util/CriticalTableModel.java
+++ b/src/megameklab/com/util/CriticalTableModel.java
@@ -185,7 +185,7 @@ public class CriticalTableModel extends AbstractTableModel {
                 return crit.getUsableShotsLeft() / ((AmmoType)crit.getType()).getShots();
             }
             if (tableType == BUILDTABLE) {
-                return UnitUtil.getCritsUsed(unit, crit.getType());
+                return UnitUtil.getCritsUsed(crit);
             }
             return crit.getCriticals();
         case EQUIPMENT:

--- a/src/megameklab/com/util/Mech/CriticalTransferHandler.java
+++ b/src/megameklab/com/util/Mech/CriticalTransferHandler.java
@@ -111,7 +111,7 @@ public class CriticalTransferHandler extends TransferHandler {
                 }
             }
             if (!(getUnit() instanceof BattleArmor)){
-                for (int i = startSlot; i < (startSlot+UnitUtil.getCritsUsed(getUnit(), mounted.getType())); i++) {
+                for (int i = startSlot; i < (startSlot+UnitUtil.getCritsUsed(mounted)); i++) {
                     getUnit().setCritical(loc, i, null);
                 }
             }
@@ -139,7 +139,7 @@ public class CriticalTransferHandler extends TransferHandler {
      */
     private boolean addEquipmentMech(Mech mech, Mounted eq, int slotNumber)
             throws LocationFullException{
-        int totalCrits = UnitUtil.getCritsUsed(getUnit(), eq.getType());
+        int totalCrits = UnitUtil.getCritsUsed(eq);
         // How much space we have in the selected location
         int primaryLocSpace = 
                 UnitUtil.getContiguousNumberOfCrits(getUnit(), location, slotNumber);


### PR DESCRIPTION
I changed the signature of the method that calculates the number of slots taken up by each separate allocation of equipment so that it can take the size of variable-sized mounts into account.

Fixes #699