### PR TITLE
Reset heat sinks after engine change

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -822,6 +822,7 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
                 UnitUtil.addHeatSinkMounts(getMech(), newHS, panHeat.getHeatSinkType());
             }
             UnitUtil.updateAutoSinks(getMech(), getMech().hasCompactHeatSinks());
+            getMech().resetSinks();
             panMovement.setFromEntity(getMech());
             panHeat.setFromMech(getMech());
             refreshSummary();


### PR DESCRIPTION
The number of active heat sinks gets reset when the heat sink count is changed directly, but not when changed indirectly by selecting an engine with more weight-free sinks.

Fixes #700