### PR TITLE
Swap BA secondary motive mount when type changes

### DIFF
--- a/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
@@ -507,14 +507,16 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
 
     @Override
     public void jumpTypeChanged(EquipmentType jumpJet) {
-        UnitUtil.removeAllMiscMounteds(getBattleArmor(), MiscType.F_JUMP_JET);
-        UnitUtil.removeAllMiscMounteds(getBattleArmor(), MiscType.F_BA_VTOL);
-        UnitUtil.removeAllMiscMounteds(getBattleArmor(), MiscType.F_UMU);
-        if (jumpJet != null) {
-            try {
-                getBattleArmor().addEquipment(jumpJet, BattleArmor.LOC_NONE);
-            } catch (LocationFullException ignored) {
-                // not when we're adding to LOC_NONE
+        if (getEntity().getMisc().stream().noneMatch(m -> m.getType().equals(jumpJet))) {
+            UnitUtil.removeAllMiscMounteds(getBattleArmor(), MiscType.F_JUMP_JET);
+            UnitUtil.removeAllMiscMounteds(getBattleArmor(), MiscType.F_BA_VTOL);
+            UnitUtil.removeAllMiscMounteds(getBattleArmor(), MiscType.F_UMU);
+            if (getBattleArmor().getOriginalJumpMP() > 0) {
+                try {
+                    getBattleArmor().addEquipment(jumpJet, BattleArmor.LOC_NONE);
+                } catch (LocationFullException ignored) {
+                    // not when we're adding to LOC_NONE
+                }
             }
         }
         if ((null == jumpJet) || (getBattleArmor().getOriginalJumpMP() == 0)) {

--- a/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
@@ -507,6 +507,16 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
 
     @Override
     public void jumpTypeChanged(EquipmentType jumpJet) {
+        UnitUtil.removeAllMiscMounteds(getBattleArmor(), MiscType.F_JUMP_JET);
+        UnitUtil.removeAllMiscMounteds(getBattleArmor(), MiscType.F_BA_VTOL);
+        UnitUtil.removeAllMiscMounteds(getBattleArmor(), MiscType.F_UMU);
+        if (jumpJet != null) {
+            try {
+                getBattleArmor().addEquipment(jumpJet, BattleArmor.LOC_NONE);
+            } catch (LocationFullException ignored) {
+                // not when we're adding to LOC_NONE
+            }
+        }
         if ((null == jumpJet) || (getBattleArmor().getOriginalJumpMP() == 0)) {
             getBattleArmor().setMovementMode(EntityMovementMode.INF_LEG);
         } else if (jumpJet.hasFlag(MiscType.F_JUMP_JET)) {

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -380,6 +380,7 @@ public class UnitUtil {
                 }
             }
         }
+        unit.recalculateTechAdvancement();
     }
 
     /**


### PR DESCRIPTION
When the secondary motive type changes among jump, vtol, and underwater, remove the old MiscType and install the new one (if any).

Partial fix for #710