### PR TITLE
Keep link with one shot ammo when weapon is moved.

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1207,7 +1207,7 @@ public class UnitUtil {
      */
     public static void changeMountStatus(Entity unit, Mounted eq, int location,
             int secondaryLocation, boolean rear) {
-        if (location != eq.getLocation()) {
+        if ((location != eq.getLocation() && !eq.isOneShot())) {
             if (eq.getLinked() != null) {
                 eq.getLinked().setLinkedBy(null);
                 eq.setLinked(null);


### PR DESCRIPTION
Fixes a bug introduced by #671. When a weapon changes locations, the link should not be broken between a one-shot weapon and its ammo.

Fixes #719