### PR TITLE
Fix run MP String on record sheet

### DIFF
--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -570,8 +570,8 @@ public abstract class PrintEntity extends PrintRecordSheet {
      */
     protected String formatMovement(double baseMP, double fullMP) {
         if (fullMP > baseMP) {
-            return NumberFormat.getInstance().format(baseMP) + " ["
-                    + NumberFormat.getInstance().format(fullMP) + "] "
+            return CConfig.formatScale(baseMP, false) + " ["
+                    + CConfig.formatScale(fullMP, false) + "] "
                     + CConfig.scaleUnits().abbreviation;
         } else {
             return CConfig.formatScale(baseMP, true);


### PR DESCRIPTION
I missed applying the scale factor to the MP when there are two values (such as when there is MASC or a supercharger). This also fails to round up.

Fixes #720