### PR TITLE
Show SRCS on mech record sheet

### DIFF
--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -20,6 +20,7 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import megameklab.com.printing.reference.*;
 import org.apache.batik.anim.dom.SVGDOMImplementation;
@@ -686,9 +687,10 @@ public class PrintMech extends PrintEntity {
                         || ((cs.getIndex() >= Mech.ACTUATOR_UPPER_LEG) && (cs.getIndex() <= Mech.ACTUATOR_FOOT))) {
                     name += " Actuator";
                 } else if (cs.getIndex() == Mech.SYSTEM_COCKPIT) {
-                    if (mech.hasWorkingMisc(MiscType.F_SRCS)) {
-                        name = mech.getMisc().stream().filter(m -> m.getType().hasFlag(MiscType.F_SRCS))
-                                .map(m -> m.getType().getShortName()).findAny().orElse("SRCS");
+                    Optional<Mounted> robotics = mech.getMisc().stream()
+                            .filter(m -> m.getType().hasFlag(MiscType.F_SRCS)).findAny();
+                    if (robotics.isPresent()) {
+                        name = robotics.get().getType().getShortName();
                     } else if (mech.getCockpitType() == Mech.COCKPIT_COMMAND_CONSOLE) {
                         if (mech.getCrewForCockpitSlot(Mech.LOC_HEAD, cs) == 0) {
                             name = EquipmentMessages.getString("SystemType.Cockpit.COCKPIT_STANDARD");

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -686,7 +686,10 @@ public class PrintMech extends PrintEntity {
                         || ((cs.getIndex() >= Mech.ACTUATOR_UPPER_LEG) && (cs.getIndex() <= Mech.ACTUATOR_FOOT))) {
                     name += " Actuator";
                 } else if (cs.getIndex() == Mech.SYSTEM_COCKPIT) {
-                    if (mech.getCockpitType() == Mech.COCKPIT_COMMAND_CONSOLE) {
+                    if (mech.hasWorkingMisc(MiscType.F_SRCS)) {
+                        name = mech.getMisc().stream().filter(m -> m.getType().hasFlag(MiscType.F_SRCS))
+                                .map(m -> m.getType().getShortName()).findAny().orElse("SRCS");
+                    } else if (mech.getCockpitType() == Mech.COCKPIT_COMMAND_CONSOLE) {
                         if (mech.getCrewForCockpitSlot(Mech.LOC_HEAD, cs) == 0) {
                             name = EquipmentMessages.getString("SystemType.Cockpit.COCKPIT_STANDARD");
                         }


### PR DESCRIPTION
Mechs with a smart robotic control system will show "SRCS" or "Improved SRCS" in the cockpit slot. This follows the cannon example of the Revenant UMB-1A from Jihad: Final Reckoning, p. 161, where it is shown as "Robotic Cockpit." In those earlier rules the system was simply referred to as a "robotic drone control system." The system received a formal name in IO and the rules were expanded to include an improved system.

Fixes #721 