### PR TITLE
Show VSTOL equipment on conventional fighter record sheet.

### DIFF
--- a/src/megameklab/com/printing/PrintAero.java
+++ b/src/megameklab/com/printing/PrintAero.java
@@ -179,6 +179,8 @@ public class PrintAero extends PrintEntity {
                 sj.add(String.join(", ", chassisMods)
                         + (chassisMods.size() == 1 ? " Chassis Mod" : " Chassis Mods"));
             }
+        } else if ((aero instanceof ConvFighter) && aero.isVSTOL()) {
+            sj.add("VSTOL Equipment");
         }
         if (aero.hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL)) {
             sj.add("Advanced Fire Control");


### PR DESCRIPTION
Fixed wing support vehicles indicate VSTOL (or STOL) capabilities by the chassis mod that's already printed. ASFs are always VSTOL and don't need to specify.

Fixes #722