### PR TITLE
Suggest filename when exporting to MUL

### DIFF
--- a/src/megameklab/com/util/UnitPrintManager.java
+++ b/src/megameklab/com/util/UnitPrintManager.java
@@ -59,6 +59,7 @@ import megameklab.com.ui.MegaMekLabMainUI;
 import megameklab.com.ui.dialog.UnitPrintQueueDialog;
 import org.apache.avalon.framework.configuration.ConfigurationException;
 import org.apache.batik.transcoder.TranscoderException;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.pdfbox.io.MemoryUsageSetting;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.xml.sax.SAXException;
@@ -123,16 +124,17 @@ public class UnitPrintManager {
             // I want a file, y'know!
             return;
         }
+        File mulFile = f.getSelectedFile();
         Vector<Entity> loadedUnits;
         try {
-            loadedUnits = EntityListFile.loadFrom(f.getSelectedFile());
+            loadedUnits = EntityListFile.loadFrom(mulFile);
             loadedUnits.trimToSize();
         } catch (Exception ex) {
             ex.printStackTrace();
             return;
         }
 
-        File exportFile = getExportFile(parent);
+        File exportFile = getExportFile(parent, FilenameUtils.removeExtension(mulFile.getPath()) + ".pdf");
         if (exportFile != null) {
             exportUnits(loadedUnits, exportFile, singlePrint);
         }


### PR DESCRIPTION
Replaces the extension on the MUL file with .pdf and uses that as the suggested file for the export. I've gathered there's some issue with the way Windows handles file extensions, but setting the name with a pdf extension doesn't seem to be a problem when exporting a single unit so I presume this will be more familiar behavior.

Fixes #724