### PR TITLE
Include supercharger in flanking speed on tank record sheet

### DIFF
--- a/data/images/recordsheets/templates_iso/naval_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_iso/naval_dualturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/naval_dualturret_superheavy.svg
+++ b/data/images/recordsheets/templates_iso/naval_dualturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/naval_noturret_standard.svg
+++ b/data/images/recordsheets/templates_iso/naval_noturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/naval_noturret_superheavy.svg
+++ b/data/images/recordsheets/templates_iso/naval_noturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/naval_turret_standard.svg
+++ b/data/images/recordsheets/templates_iso/naval_turret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/naval_turret_superheavy.svg
+++ b/data/images/recordsheets/templates_iso/naval_turret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/submarine_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_iso/submarine_dualturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/submarine_dualturret_superheavy.svg
+++ b/data/images/recordsheets/templates_iso/submarine_dualturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/submarine_noturret_standard.svg
+++ b/data/images/recordsheets/templates_iso/submarine_noturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/submarine_noturret_superheavy.svg
+++ b/data/images/recordsheets/templates_iso/submarine_noturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/submarine_turret_standard.svg
+++ b/data/images/recordsheets/templates_iso/submarine_turret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/submarine_turret_superheavy.svg
+++ b/data/images/recordsheets/templates_iso/submarine_turret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/vehicle_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_iso/vehicle_dualturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/vehicle_dualturret_superheavy.svg
+++ b/data/images/recordsheets/templates_iso/vehicle_dualturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/vehicle_noturret_standard.svg
+++ b/data/images/recordsheets/templates_iso/vehicle_noturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/vehicle_noturret_superheavy.svg
+++ b/data/images/recordsheets/templates_iso/vehicle_noturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/vehicle_turret_standard.svg
+++ b/data/images/recordsheets/templates_iso/vehicle_turret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/vehicle_turret_superheavy.svg
+++ b/data/images/recordsheets/templates_iso/vehicle_turret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/vtol_noturret_standard.svg
+++ b/data/images/recordsheets/templates_iso/vtol_noturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/vtol_turret_standard.svg
+++ b/data/images/recordsheets/templates_iso/vtol_turret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/wige_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_iso/wige_dualturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/wige_noturret_standard.svg
+++ b/data/images/recordsheets/templates_iso/wige_noturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_iso/wige_turret_standard.svg
+++ b/data/images/recordsheets/templates_iso/wige_turret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="56.150" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/naval_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_us/naval_dualturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/naval_dualturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/naval_dualturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/naval_noturret_standard.svg
+++ b/data/images/recordsheets/templates_us/naval_noturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/naval_noturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/naval_noturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/naval_turret_standard.svg
+++ b/data/images/recordsheets/templates_us/naval_turret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/naval_turret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/naval_turret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/submarine_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_us/submarine_dualturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/submarine_dualturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/submarine_dualturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/submarine_noturret_standard.svg
+++ b/data/images/recordsheets/templates_us/submarine_noturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/submarine_noturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/submarine_noturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/submarine_turret_standard.svg
+++ b/data/images/recordsheets/templates_us/submarine_turret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/submarine_turret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/submarine_turret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/vehicle_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_us/vehicle_dualturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/vehicle_dualturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/vehicle_dualturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/vehicle_noturret_standard.svg
+++ b/data/images/recordsheets/templates_us/vehicle_noturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/vehicle_noturret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/vehicle_noturret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/vehicle_turret_standard.svg
+++ b/data/images/recordsheets/templates_us/vehicle_turret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/vehicle_turret_superheavy.svg
+++ b/data/images/recordsheets/templates_us/vehicle_turret_superheavy.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/vtol_noturret_standard.svg
+++ b/data/images/recordsheets/templates_us/vtol_noturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/vtol_turret_standard.svg
+++ b/data/images/recordsheets/templates_us/vtol_turret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/wige_dualturret_standard.svg
+++ b/data/images/recordsheets/templates_us/wige_dualturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/wige_noturret_standard.svg
+++ b/data/images/recordsheets/templates_us/wige_noturret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/data/images/recordsheets/templates_us/wige_turret_standard.svg
+++ b/data/images/recordsheets/templates_us/wige_turret_standard.svg
@@ -615,11 +615,11 @@
                                                                       >Movement Points:</text
                                                                       ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.020" lengthAdjust="spacingAndGlyphs"
                                                                       >Cruising:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.937" lengthAdjust="spacingAndGlyphs"
                                                                       >Flanking:</text
-                                                                      ><text fill="#231f20" x="46.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
+                                                                      ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
                                                                       ><text x="57.850" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text

--- a/src/megameklab/com/printing/PrintTank.java
+++ b/src/megameklab/com/printing/PrintTank.java
@@ -153,6 +153,15 @@ public class PrintTank extends PrintEntity {
     }
 
     @Override
+    protected String formatRun() {
+        if (tank.hasWorkingMisc(MiscType.F_MASC)) {
+            return formatMovement(tank.getWalkMP() * 1.5, tank.getWalkMP() * 2);
+        } else {
+            return formatMovement(tank.getWalkMP() * 1.5);
+        }
+    }
+
+    @Override
     public String formatFeatures() {
         StringJoiner sj = new StringJoiner(", ");
         List<String> chassisMods = tank.getMisc().stream().filter(m -> m.getType().hasFlag(MiscType.F_CHASSIS_MODIFICATION))


### PR DESCRIPTION
This includes a change to the tank templates to move the cruising and flanking MP to the right. When the tank has a supercharger the text was crowding the label.

Fixes #737