### PR TITLE
Treat infantry flamers as flame-based weapons on equipment table and record sheets

### DIFF
--- a/src/megameklab/com/printing/PrintInfantry.java
+++ b/src/megameklab/com/printing/PrintInfantry.java
@@ -204,24 +204,10 @@ public class PrintInfantry extends PrintEntity {
         if (rangeWeapon.hasFlag(WeaponType.F_INF_NONPENETRATING)) {
             sj.add("Can only damage conventional infantry units.");
         }
-        if (infantry.getPrimaryWeapon().hasFlag(WeaponType.F_INFERNO)
-                || (infantry.getSecondaryWeapon() != null
-                && infantry.getSecondaryWeapon().hasFlag(WeaponType.F_INFERNO))) {
+        if (isFlameBased(infantry.getPrimaryWeapon())
+                || ((infantry.getSecondaryWeapon() != null)
+                    && isFlameBased(infantry.getSecondaryWeapon()))) {
             sj.add("Flame-based weapon.");
-        } else {
-            for (int i = 0; i < infantry.getPrimaryWeapon().getModesCount(); i++) {
-                if (infantry.getPrimaryWeapon().getMode(i).equals("Heat")) {
-                    sj.add("Flame-based weapon.");
-                    break;
-                }
-            }
-            if (infantry.getSecondaryWeapon() != null) {
-                for (int i = 0; i < infantry.getSecondaryWeapon().getModesCount(); i++) {
-                    if (infantry.getSecondaryWeapon().getMode(i).equals("Heat")) {
-                        sj.add("Flame-based weapon.");
-                    }
-                }
-            }
         }
         if (infantry.getPrimaryWeapon().hasFlag(WeaponType.F_INF_AA)
                 || (infantry.getSecondaryWeapon() != null
@@ -284,6 +270,13 @@ public class PrintInfantry extends PrintEntity {
         } else {
             return "None";
         }
+    }
+
+    private boolean isFlameBased(WeaponType type) {
+        return (type.hasFlag(WeaponType.F_PLASMA)
+                || type.hasFlag(WeaponType.F_INCENDIARY_NEEDLES)
+                || type.hasFlag(WeaponType.F_INFERNO)
+                || type.hasFlag(WeaponType.F_FLAMER));
     }
 
     private void writeFieldGuns() {

--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -287,7 +287,8 @@ public class EquipmentTableModel extends AbstractTableModel {
                 }
                 if (type.hasFlag(WeaponType.F_PLASMA)
                         || type.hasFlag(WeaponType.F_INCENDIARY_NEEDLES)
-                        || type.hasFlag(WeaponType.F_INFERNO)) {
+                        || type.hasFlag(WeaponType.F_INFERNO)
+                        || type.hasFlag(WeaponType.F_FLAMER)) {
                     special += "F";
                 }
             }


### PR DESCRIPTION
Show the F indicator in the special column for flamers on the equipment table. The check for a heat mode on the record sheet was not catching all flame-based weapons.

Fixes #738 