### PR TITLE
Fix Windows encoding issue on infantry record sheets

### DIFF
--- a/data/images/recordsheets/templates_iso/conventional_infantry_platoon.svg
+++ b/data/images/recordsheets/templates_iso/conventional_infantry_platoon.svg
@@ -282,234 +282,236 @@
       >—</text
       ><image x="424.207" y="9.400" width="12.593" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" visibility="hidden" xlink:actuate="onLoad" id="no_soldier_1" height="33.080" preserveAspectRatio="xMidYMid meet" xlink:show="embed" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAgCAYAAAD0S5PyAAAABHNCSVQICAgIfAhkiAAAAqtJREFUSImNldtT2kAUxr/dLFcNQR2lQJyxtcqU1hc7dsb+/2NfyiM+1GCkEKNyEySES9jtA3UlZkHP05mzZ37z7Z7LEiGEgMJqVg2+P8K3kxPVcdiEwhzHkb5t26qUkFEVeNDvS//g4AD29fVaIeT1dZxmE41GE0IIEEIAAIaRwZdyeSUkomQ8noQAQvC1ACUk9yGHj58+SkC+UEAQBLi7u3sfxLqy0Ol0cGPfAADM/X14Qw++74NSilvHUULkm1QqFcyms7WyAeDsxxk0TYsqmU6nCGZvAwBEABJSr9ehbrmwcT5XxikAtFvtd6n4fHSkhnieJ8v5lqVSKekHQSB9lk6nQ4mMadA0hvF4jHQ6hdHIB2MaiqaJRCKBbreLmmWBUop8Po+np6dFdX5dXIAQ5QTANE1sbW/B8zw4TQeELBoSAIQQOP1+uoC4rov6TV0JSSYT8P0xCCEQgi+dEJz/PF94QgjBOYdlWeh2uhHI8wjEYgy6ruO4VIrkUACglMIfjZSAnZ1tAMDGxgbu7++VauVDzFY0W///WkimUsjlcushnPPIISEE8zkHpQS3jqO8Sgjy2spL48+5AKXRdo9AlneTEAIZIxOKrWr5lUp2d3cBALq+KWOr+igEWd7qlJJI7F1Klqvjum4kUdMYhsPhegiwWIecz0NvEYvHpH9ZraqlPP8drYcHMZlMhG3bovG3If+UQb//4g8Gyn+HPcNYLIbK74qcEXPflFerVi9xeHgIjanLLK+TzWblgBlGViYcl0rgfI6rqz9ot1rrIb1eTzZU+Wv4nykUi6BUQzweXw8ZeZ4MLm8tABj7PoDFQlcZc5pN1Ov1UFszxkJJhUIRj499dLs9XNdq2NR17O3tvShpt9tgjCGZTGA+D5SS9YwuS++6LgzDCJ3/Ay78rWnfpXz1AAAAAElFTkSuQmCC"
       /><image x="424.207" y="9.400" width="12.593" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:actuate="onLoad" id="soldier_1" height="33.080" preserveAspectRatio="xMidYMid meet" xlink:show="embed" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAgCAYAAAD0S5PyAAAABHNCSVQICAgIfAhkiAAAAvJJREFUSImdlV1IU2EYx/9nJ0ebF8JGCX5tfpAmmThKI0HMtAvBuhDKjEzLVldpfiBhZk0hvBWzpSYROjVUmh+oC1LU0ITEhdqFOlteqPOr5lXngKeL5Ztneze1Bw487//5n995zjnPeQ8EN1FUUCikpaa6K4sCNLFOryd5pU73f5Dsm1midfnjMo+QI3CKmupqjAwPI0wdTLTz8fHONlFInAWr9YeL6W1z0+EgWbeyUFb+hKxztVps2+1oaW6GIAj7Q4oeFqC3uwcVz3QAgAf5eTBPTcFisUDCsmior6dCGOEvPj7uHFZXVz22DQBfZ2cgl8tdO1lfW8PWz619AQAgk8not1Oh04H7zR0IwjAMHdLb3XMgwPOqKqou+TY7eyAAAISGhZHc/sv+DxIeESEyyuVyBAUFAQCCQ0IAAN7e3nhUWorAwEB8MJkQdTISyUlJ0Ne+xJ2cHMfb2TudzlFYXIzEC4kwm82orXkBViLB0tISqX/6PO6AvGlsRKWuggpRqVSwWq0uOsMwmFu0OHJBEASO41CQl4/+vj63HSkUCpyJPYtavd6lJgEAqVSK+bk56skpl1IAADEaDUz9A1QPGfuVlRWqYXRkFADgHxCAi8nJVA8Z+8gT4eA4+sB5eXmB53nMf1/03IlzGNpaSc7zPHVSXSA8z4sKsXFxorW7bUAEYVmWiGlXLgMATkVFuT2RCuk0GokoO+r4Ut93dx0OsrGxTsR3bW1U8/T0tGeIu1AolSS/mp5O9ZDdfnNzE2MTE6h7pYePjw8x1L9uwOnoaDAMg8kvk/Qr7f47hj4OCqEqNTl2417uXSFUpRY6OzoE08CA55/Xzs4OAdzIuC4y7er3tVoqhDyTocFB0l1Ti0HUbfbtHACA73Ff6t0QyMyeJ79tt4tMC/MLAIDl5WUqhD2mVD7NvJaB8bFxIhaXlIhMfn5+6Ghvx6LFApttDTabTTSIki6jEVKpFOpgx+7mH+DvcqUYjYbkrQYDEhISRPU/YkUFJc1xbRsAAAAASUVORK5CYII="
-      /><text fill="#231f20" x="3.000" y="70.988" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" text-anchor="start"
+      /><text fill="#231f20" x="3.000" y="69.879" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" text-anchor="start"
       >*Damage is always applied in 2-point Damage Value groupings</text
-      ><text fill="#231f20" x="218.900" id="rangeInHexes" y="70.988" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+      ><text fill="#231f20" x="218.900" id="rangeInHexes" y="69.879" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
       >RANGE IN HEXES (TO-HIT MODIFIER)</text
-      ><text fill="#231f20" x="3.000" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+      ><text fill="#231f20" x="3.000" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
       >Range:</text
-      ><text fill="#231f20" x="63.452" id="range_0" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="63.452" id="range_0" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >0</text
-      ><text fill="#231f20" x="63.452" id="range_mod_0" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="63.452" id="range_mod_0" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="63.452" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_0"
+      ><text x="63.452" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_0"
       >–</text
-      ><text fill="#231f20" x="80.724" id="range_1" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="80.724" id="range_1" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >1</text
-      ><text fill="#231f20" x="80.724" id="range_mod_1" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="80.724" id="range_mod_1" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="80.724" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_1"
+      ><text x="80.724" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_1"
       >–</text
-      ><text fill="#231f20" x="97.996" id="range_2" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="97.996" id="range_2" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >2</text
-      ><text fill="#231f20" x="97.996" id="range_mod_2" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="97.996" id="range_mod_2" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="97.996" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_2"
+      ><text x="97.996" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_2"
       >–</text
-      ><text fill="#231f20" x="115.268" id="range_3" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="115.268" id="range_3" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >3</text
-      ><text fill="#231f20" x="115.268" id="range_mod_3" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="115.268" id="range_mod_3" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="115.268" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_3"
+      ><text x="115.268" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_3"
       >–</text
-      ><text fill="#231f20" x="132.540" id="range_4" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="132.540" id="range_4" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >4</text
-      ><text fill="#231f20" x="132.540" id="range_mod_4" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="132.540" id="range_mod_4" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="132.540" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_4"
+      ><text x="132.540" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_4"
       >–</text
-      ><text fill="#231f20" x="149.812" id="range_5" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="149.812" id="range_5" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >5</text
-      ><text fill="#231f20" x="149.812" id="range_mod_5" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="149.812" id="range_mod_5" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="149.812" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_5"
+      ><text x="149.812" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_5"
       >–</text
-      ><text fill="#231f20" x="167.084" id="range_6" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="167.084" id="range_6" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >6</text
-      ><text fill="#231f20" x="167.084" id="range_mod_6" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="167.084" id="range_mod_6" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="167.084" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_6"
+      ><text x="167.084" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_6"
       >–</text
-      ><text fill="#231f20" x="184.356" id="range_7" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="184.356" id="range_7" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >7</text
-      ><text fill="#231f20" x="184.356" id="range_mod_7" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="184.356" id="range_mod_7" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="184.356" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_7"
+      ><text x="184.356" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_7"
       >–</text
-      ><text fill="#231f20" x="201.628" id="range_8" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="201.628" id="range_8" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >8</text
-      ><text fill="#231f20" x="201.628" id="range_mod_8" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="201.628" id="range_mod_8" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="201.628" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_8"
+      ><text x="201.628" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_8"
       >–</text
-      ><text fill="#231f20" x="218.900" id="range_9" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="218.900" id="range_9" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >9</text
-      ><text fill="#231f20" x="218.900" id="range_mod_9" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="218.900" id="range_mod_9" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="218.900" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_9"
+      ><text x="218.900" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_9"
       >–</text
-      ><text fill="#231f20" x="236.172" id="range_10" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="236.172" id="range_10" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >10</text
-      ><text fill="#231f20" x="236.172" id="range_mod_10" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="236.172" id="range_mod_10" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="236.172" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_10"
+      ><text x="236.172" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_10"
       >–</text
-      ><text fill="#231f20" x="253.444" id="range_11" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="253.444" id="range_11" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >11</text
-      ><text fill="#231f20" x="253.444" id="range_mod_11" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="253.444" id="range_mod_11" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="253.444" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_11"
+      ><text x="253.444" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_11"
       >–</text
-      ><text fill="#231f20" x="270.716" id="range_12" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="270.716" id="range_12" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >12</text
-      ><text fill="#231f20" x="270.716" id="range_mod_12" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="270.716" id="range_mod_12" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="270.716" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_12"
+      ><text x="270.716" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_12"
       >–</text
-      ><text fill="#231f20" x="287.988" id="range_13" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="287.988" id="range_13" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >13</text
-      ><text fill="#231f20" x="287.988" id="range_mod_13" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="287.988" id="range_mod_13" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="287.988" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_13"
+      ><text x="287.988" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_13"
       >–</text
-      ><text fill="#231f20" x="305.260" id="range_14" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="305.260" id="range_14" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >14</text
-      ><text fill="#231f20" x="305.260" id="range_mod_14" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="305.260" id="range_mod_14" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="305.260" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_14"
+      ><text x="305.260" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_14"
       >–</text
-      ><text fill="#231f20" x="322.532" id="range_15" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="322.532" id="range_15" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >15</text
-      ><text fill="#231f20" x="322.532" id="range_mod_15" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="322.532" id="range_mod_15" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="322.532" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_15"
+      ><text x="322.532" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_15"
       >–</text
-      ><text fill="#231f20" x="339.804" id="range_16" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="339.804" id="range_16" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >16</text
-      ><text fill="#231f20" x="339.804" id="range_mod_16" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="339.804" id="range_mod_16" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="339.804" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_16"
+      ><text x="339.804" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_16"
       >–</text
-      ><text fill="#231f20" x="357.076" id="range_17" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="357.076" id="range_17" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >17</text
-      ><text fill="#231f20" x="357.076" id="range_mod_17" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="357.076" id="range_mod_17" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="357.076" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_17"
+      ><text x="357.076" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_17"
       >–</text
-      ><text fill="#231f20" x="374.348" id="range_18" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="374.348" id="range_18" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >18</text
-      ><text fill="#231f20" x="374.348" id="range_mod_18" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="374.348" id="range_mod_18" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="374.348" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_18"
+      ><text x="374.348" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_18"
       >–</text
-      ><text fill="#231f20" x="391.620" id="range_19" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="391.620" id="range_19" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >19</text
-      ><text fill="#231f20" x="391.620" id="range_mod_19" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="391.620" id="range_mod_19" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="391.620" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_19"
+      ><text x="391.620" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_19"
       >–</text
-      ><text fill="#231f20" x="408.892" id="range_20" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="408.892" id="range_20" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >20</text
-      ><text fill="#231f20" x="408.892" id="range_mod_20" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="408.892" id="range_mod_20" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="408.892" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_20"
+      ><text x="408.892" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_20"
       >–</text
-      ><text fill="#231f20" x="426.164" id="range_21" y="79.861" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="426.164" id="range_21" y="77.643" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >21</text
-      ><text fill="#231f20" x="426.164" id="range_mod_21" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="426.164" id="range_mod_21" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="426.164" y="97.608" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_21"
+      ><text x="426.164" y="93.172" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_21"
       >–</text
-      ><text fill="#231f20" x="3.000" y="88.735" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+      ><text fill="#231f20" x="3.000" y="85.407" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
       >Range Modifier:</text
-      ><text x="3.000" y="97.608" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" visibility="hidden" id="uw_range_modifier"
+      ><text x="3.000" y="93.172" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" visibility="hidden" id="uw_range_modifier"
       >Underwater:</text
       ><g visibility="hidden" id="field_gun_columns"
-      ><text fill="#231f20" x="6.000" y="106.482" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="6.000" y="100.936" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >Qty</text
-        ><text fill="#231f20" x="20.272" y="106.482" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+        ><text fill="#231f20" x="20.272" y="100.936" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
         >Field Gun Type</text
-        ><text fill="#231f20" x="85.042" y="106.482" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+        ><text fill="#231f20" x="85.042" y="100.936" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
         >Dmg</text
-        ><text fill="#231f20" x="119.586" y="106.482" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="119.586" y="100.936" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >Min</text
-        ><text fill="#231f20" x="132.540" y="106.482" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="132.540" y="100.936" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >S</text
-        ><text fill="#231f20" x="145.494" y="106.482" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="145.494" y="100.936" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >M</text
-        ><text fill="#231f20" x="158.448" y="106.482" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="158.448" y="100.936" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >L</text
-        ><text fill="#231f20" x="175.720" y="106.482" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="175.720" y="100.936" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >Ammo</text
-        ><text fill="#231f20" x="197.310" y="106.482" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="197.310" y="100.936" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >Crew</text
-        ><text fill="#231f20" x="6.000" id="field_gun_qty" y="115.355" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="6.000" id="field_gun_qty" y="108.700" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
-        ><text fill="#231f20" x="20.272" id="field_gun_type" y="115.355" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+        ><text fill="#231f20" x="20.272" id="field_gun_type" y="108.700" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
         ></text
-        ><text fill="#231f20" x="85.042" id="field_gun_dmg" y="115.355" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+        ><text fill="#231f20" x="85.042" id="field_gun_dmg" y="108.700" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
         ></text
-        ><text fill="#231f20" x="119.586" id="field_gun_min_range" y="115.355" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="85.042" id="field_gun_dmg_2" y="116.465" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
         ></text
-        ><text fill="#231f20" x="132.540" id="field_gun_short" y="115.355" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="119.586" id="field_gun_min_range" y="108.700" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
-        ><text fill="#231f20" x="145.494" id="field_gun_med" y="115.355" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="132.540" id="field_gun_short" y="108.700" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
-        ><text fill="#231f20" x="158.448" id="field_gun_long" y="115.355" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="145.494" id="field_gun_med" y="108.700" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
-        ><text fill="#231f20" x="175.720" id="field_gun_ammo" y="115.355" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="158.448" id="field_gun_long" y="108.700" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
-        ><text fill="#231f20" x="197.310" id="field_gun_crew" y="115.355" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="175.720" id="field_gun_ammo" y="108.700" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ></text
+        ><text fill="#231f20" x="197.310" id="field_gun_crew" y="108.700" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
       ></g
       ><text x="0.000" y="0.000" fill="#000000" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="dest_mods"
-      ><tspan x="218.900" y="106.482"
+      ><tspan x="218.900" y="100.936"
         >+1 to-hit modifier to attackers</tspan
-        ><tspan x="218.900" y="113.581"
+        ><tspan x="218.900" y="107.147"
         >if unit does not move.</tspan
       ></text
       ><text x="0.000" y="0.000" fill="#000000" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="sneak_camo_mods"
-      ><tspan x="218.900" y="106.482"
+      ><tspan x="218.900" y="100.936"
         >MPs Used:</tspan
-        ><tspan x="218.900" y="113.581"
+        ><tspan x="218.900" y="107.147"
         >To-Hit Modifier:</tspan
-        ><tspan x="218.900" y="120.679"
+        ><tspan x="218.900" y="113.359"
         >(All Attackers)</tspan
-        ><tspan x="264.501" y="106.482"
+        ><tspan x="264.501" y="100.936"
         >0</tspan
-        ><tspan x="277.453" y="106.482"
+        ><tspan x="277.453" y="100.936"
         >1</tspan
-        ><tspan x="290.409" y="106.482"
+        ><tspan x="290.409" y="100.936"
         >2</tspan
-        ><tspan x="301.465" y="106.482"
+        ><tspan x="301.465" y="100.936"
         >3+</tspan
-        ><tspan x="262.603" y="113.581"
+        ><tspan x="262.603" y="107.147"
         >+3</tspan
-        ><tspan x="275.557" y="113.581"
+        ><tspan x="275.557" y="107.147"
         >+2</tspan
-        ><tspan x="288.510" y="113.581"
+        ><tspan x="288.510" y="107.147"
         >+1</tspan
-        ><tspan x="303.363" y="113.581"
+        ><tspan x="303.363" y="107.147"
         >0</tspan
       ></text
-      ><text x="326.850" y="106.482" fill="#000000" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="sneak_camo_mods"
-      ><tspan x="326.850" y="106.482"
+      ><text x="326.850" y="100.936" fill="#000000" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="sneak_camo_mods"
+      ><tspan x="326.850" y="100.936"
         >Range Category:</tspan
-        ><tspan x="326.850" y="113.581"
+        ><tspan x="326.850" y="107.147"
         >To-Hit Modifier:</tspan
-        ><tspan x="326.850" y="120.679"
+        ><tspan x="326.850" y="113.359"
         >(Non-Infantry Attackers)</tspan
-        ><tspan x="382.548" y="106.482"
+        ><tspan x="382.548" y="100.936"
         >S</tspan
-        ><tspan x="395.875" y="106.482"
+        ><tspan x="395.875" y="100.936"
         >M</tspan
-        ><tspan x="411.710" y="106.482"
+        ><tspan x="411.710" y="100.936"
         >L</tspan
-        ><tspan x="380.483" y="113.581"
+        ><tspan x="380.483" y="107.147"
         >+1</tspan
-        ><tspan x="394.733" y="113.581"
+        ><tspan x="394.733" y="107.147"
         >+1</tspan
-        ><tspan x="409.415" y="113.581"
+        ><tspan x="409.415" y="107.147"
         >+2</tspan
       ></text
     ></g

--- a/data/images/recordsheets/templates_us/conventional_infantry_platoon.svg
+++ b/data/images/recordsheets/templates_us/conventional_infantry_platoon.svg
@@ -282,234 +282,236 @@
       >—</text
       ><image x="437.353" y="9.400" width="13.047" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" visibility="hidden" xlink:actuate="onLoad" id="no_soldier_1" height="29.580" preserveAspectRatio="xMidYMid meet" xlink:show="embed" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAgCAYAAAD0S5PyAAAABHNCSVQICAgIfAhkiAAAAqtJREFUSImNldtT2kAUxr/dLFcNQR2lQJyxtcqU1hc7dsb+/2NfyiM+1GCkEKNyEySES9jtA3UlZkHP05mzZ37z7Z7LEiGEgMJqVg2+P8K3kxPVcdiEwhzHkb5t26qUkFEVeNDvS//g4AD29fVaIeT1dZxmE41GE0IIEEIAAIaRwZdyeSUkomQ8noQAQvC1ACUk9yGHj58+SkC+UEAQBLi7u3sfxLqy0Ol0cGPfAADM/X14Qw++74NSilvHUULkm1QqFcyms7WyAeDsxxk0TYsqmU6nCGZvAwBEABJSr9ehbrmwcT5XxikAtFvtd6n4fHSkhnieJ8v5lqVSKekHQSB9lk6nQ4mMadA0hvF4jHQ6hdHIB2MaiqaJRCKBbreLmmWBUop8Po+np6dFdX5dXIAQ5QTANE1sbW/B8zw4TQeELBoSAIQQOP1+uoC4rov6TV0JSSYT8P0xCCEQgi+dEJz/PF94QgjBOYdlWeh2uhHI8wjEYgy6ruO4VIrkUACglMIfjZSAnZ1tAMDGxgbu7++VauVDzFY0W///WkimUsjlcushnPPIISEE8zkHpQS3jqO8Sgjy2spL48+5AKXRdo9AlneTEAIZIxOKrWr5lUp2d3cBALq+KWOr+igEWd7qlJJI7F1Klqvjum4kUdMYhsPhegiwWIecz0NvEYvHpH9ZraqlPP8drYcHMZlMhG3bovG3If+UQb//4g8Gyn+HPcNYLIbK74qcEXPflFerVi9xeHgIjanLLK+TzWblgBlGViYcl0rgfI6rqz9ot1rrIb1eTzZU+Wv4nykUi6BUQzweXw8ZeZ4MLm8tABj7PoDFQlcZc5pN1Ov1UFszxkJJhUIRj499dLs9XNdq2NR17O3tvShpt9tgjCGZTGA+D5SS9YwuS++6LgzDCJ3/Ay78rWnfpXz1AAAAAElFTkSuQmCC"
       /><image x="437.353" y="9.400" width="13.047" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:actuate="onLoad" id="soldier_1" height="29.580" preserveAspectRatio="xMidYMid meet" xlink:show="embed" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAAgCAYAAAD0S5PyAAAABHNCSVQICAgIfAhkiAAAAvJJREFUSImdlV1IU2EYx/9nJ0ebF8JGCX5tfpAmmThKI0HMtAvBuhDKjEzLVldpfiBhZk0hvBWzpSYROjVUmh+oC1LU0ITEhdqFOlteqPOr5lXngKeL5Ztneze1Bw487//5n995zjnPeQ8EN1FUUCikpaa6K4sCNLFOryd5pU73f5Dsm1midfnjMo+QI3CKmupqjAwPI0wdTLTz8fHONlFInAWr9YeL6W1z0+EgWbeyUFb+hKxztVps2+1oaW6GIAj7Q4oeFqC3uwcVz3QAgAf5eTBPTcFisUDCsmior6dCGOEvPj7uHFZXVz22DQBfZ2cgl8tdO1lfW8PWz619AQAgk8not1Oh04H7zR0IwjAMHdLb3XMgwPOqKqou+TY7eyAAAISGhZHc/sv+DxIeESEyyuVyBAUFAQCCQ0IAAN7e3nhUWorAwEB8MJkQdTISyUlJ0Ne+xJ2cHMfb2TudzlFYXIzEC4kwm82orXkBViLB0tISqX/6PO6AvGlsRKWuggpRqVSwWq0uOsMwmFu0OHJBEASO41CQl4/+vj63HSkUCpyJPYtavd6lJgEAqVSK+bk56skpl1IAADEaDUz9A1QPGfuVlRWqYXRkFADgHxCAi8nJVA8Z+8gT4eA4+sB5eXmB53nMf1/03IlzGNpaSc7zPHVSXSA8z4sKsXFxorW7bUAEYVmWiGlXLgMATkVFuT2RCuk0GokoO+r4Ut93dx0OsrGxTsR3bW1U8/T0tGeIu1AolSS/mp5O9ZDdfnNzE2MTE6h7pYePjw8x1L9uwOnoaDAMg8kvk/Qr7f47hj4OCqEqNTl2417uXSFUpRY6OzoE08CA55/Xzs4OAdzIuC4y7er3tVoqhDyTocFB0l1Ti0HUbfbtHACA73Ff6t0QyMyeJ79tt4tMC/MLAIDl5WUqhD2mVD7NvJaB8bFxIhaXlIhMfn5+6Ghvx6LFApttDTabTTSIki6jEVKpFOpgx+7mH+DvcqUYjYbkrQYDEhISRPU/YkUFJc1xbRsAAAAASUVORK5CYII="
-      /><text fill="#231f20" x="3.000" y="65.274" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" text-anchor="start"
+      /><text fill="#231f20" x="3.000" y="64.254" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" text-anchor="start"
       >*Damage is always applied in 2-point Damage Value groupings</text
-      ><text fill="#231f20" x="225.700" id="rangeInHexes" y="65.274" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+      ><text fill="#231f20" x="225.700" id="rangeInHexes" y="64.254" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
       >RANGE IN HEXES (TO-HIT MODIFIER)</text
-      ><text fill="#231f20" x="3.000" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+      ><text fill="#231f20" x="3.000" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
       >Range:</text
-      ><text fill="#231f20" x="65.356" id="range_0" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="65.356" id="range_0" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >0</text
-      ><text fill="#231f20" x="65.356" id="range_mod_0" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="65.356" id="range_mod_0" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="65.356" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_0"
+      ><text x="65.356" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_0"
       >–</text
-      ><text fill="#231f20" x="83.172" id="range_1" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="83.172" id="range_1" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >1</text
-      ><text fill="#231f20" x="83.172" id="range_mod_1" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="83.172" id="range_mod_1" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="83.172" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_1"
+      ><text x="83.172" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_1"
       >–</text
-      ><text fill="#231f20" x="100.988" id="range_2" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="100.988" id="range_2" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >2</text
-      ><text fill="#231f20" x="100.988" id="range_mod_2" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="100.988" id="range_mod_2" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="100.988" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_2"
+      ><text x="100.988" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_2"
       >–</text
-      ><text fill="#231f20" x="118.804" id="range_3" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="118.804" id="range_3" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >3</text
-      ><text fill="#231f20" x="118.804" id="range_mod_3" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="118.804" id="range_mod_3" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="118.804" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_3"
+      ><text x="118.804" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_3"
       >–</text
-      ><text fill="#231f20" x="136.620" id="range_4" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="136.620" id="range_4" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >4</text
-      ><text fill="#231f20" x="136.620" id="range_mod_4" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="136.620" id="range_mod_4" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="136.620" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_4"
+      ><text x="136.620" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_4"
       >–</text
-      ><text fill="#231f20" x="154.436" id="range_5" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="154.436" id="range_5" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >5</text
-      ><text fill="#231f20" x="154.436" id="range_mod_5" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="154.436" id="range_mod_5" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="154.436" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_5"
+      ><text x="154.436" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_5"
       >–</text
-      ><text fill="#231f20" x="172.252" id="range_6" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="172.252" id="range_6" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >6</text
-      ><text fill="#231f20" x="172.252" id="range_mod_6" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="172.252" id="range_mod_6" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="172.252" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_6"
+      ><text x="172.252" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_6"
       >–</text
-      ><text fill="#231f20" x="190.068" id="range_7" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="190.068" id="range_7" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >7</text
-      ><text fill="#231f20" x="190.068" id="range_mod_7" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="190.068" id="range_mod_7" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="190.068" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_7"
+      ><text x="190.068" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_7"
       >–</text
-      ><text fill="#231f20" x="207.884" id="range_8" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="207.884" id="range_8" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >8</text
-      ><text fill="#231f20" x="207.884" id="range_mod_8" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="207.884" id="range_mod_8" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="207.884" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_8"
+      ><text x="207.884" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_8"
       >–</text
-      ><text fill="#231f20" x="225.700" id="range_9" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="225.700" id="range_9" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >9</text
-      ><text fill="#231f20" x="225.700" id="range_mod_9" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="225.700" id="range_mod_9" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="225.700" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_9"
+      ><text x="225.700" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_9"
       >–</text
-      ><text fill="#231f20" x="243.516" id="range_10" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="243.516" id="range_10" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >10</text
-      ><text fill="#231f20" x="243.516" id="range_mod_10" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="243.516" id="range_mod_10" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="243.516" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_10"
+      ><text x="243.516" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_10"
       >–</text
-      ><text fill="#231f20" x="261.332" id="range_11" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="261.332" id="range_11" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >11</text
-      ><text fill="#231f20" x="261.332" id="range_mod_11" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="261.332" id="range_mod_11" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="261.332" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_11"
+      ><text x="261.332" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_11"
       >–</text
-      ><text fill="#231f20" x="279.148" id="range_12" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="279.148" id="range_12" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >12</text
-      ><text fill="#231f20" x="279.148" id="range_mod_12" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="279.148" id="range_mod_12" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="279.148" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_12"
+      ><text x="279.148" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_12"
       >–</text
-      ><text fill="#231f20" x="296.964" id="range_13" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="296.964" id="range_13" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >13</text
-      ><text fill="#231f20" x="296.964" id="range_mod_13" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="296.964" id="range_mod_13" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="296.964" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_13"
+      ><text x="296.964" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_13"
       >–</text
-      ><text fill="#231f20" x="314.780" id="range_14" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="314.780" id="range_14" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >14</text
-      ><text fill="#231f20" x="314.780" id="range_mod_14" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="314.780" id="range_mod_14" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="314.780" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_14"
+      ><text x="314.780" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_14"
       >–</text
-      ><text fill="#231f20" x="332.596" id="range_15" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="332.596" id="range_15" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >15</text
-      ><text fill="#231f20" x="332.596" id="range_mod_15" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="332.596" id="range_mod_15" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="332.596" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_15"
+      ><text x="332.596" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_15"
       >–</text
-      ><text fill="#231f20" x="350.412" id="range_16" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="350.412" id="range_16" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >16</text
-      ><text fill="#231f20" x="350.412" id="range_mod_16" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="350.412" id="range_mod_16" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="350.412" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_16"
+      ><text x="350.412" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_16"
       >–</text
-      ><text fill="#231f20" x="368.228" id="range_17" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="368.228" id="range_17" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >17</text
-      ><text fill="#231f20" x="368.228" id="range_mod_17" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="368.228" id="range_mod_17" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="368.228" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_17"
+      ><text x="368.228" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_17"
       >–</text
-      ><text fill="#231f20" x="386.044" id="range_18" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="386.044" id="range_18" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >18</text
-      ><text fill="#231f20" x="386.044" id="range_mod_18" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="386.044" id="range_mod_18" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="386.044" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_18"
+      ><text x="386.044" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_18"
       >–</text
-      ><text fill="#231f20" x="403.860" id="range_19" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="403.860" id="range_19" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >19</text
-      ><text fill="#231f20" x="403.860" id="range_mod_19" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="403.860" id="range_mod_19" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="403.860" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_19"
+      ><text x="403.860" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_19"
       >–</text
-      ><text fill="#231f20" x="421.676" id="range_20" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="421.676" id="range_20" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >20</text
-      ><text fill="#231f20" x="421.676" id="range_mod_20" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="421.676" id="range_mod_20" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="421.676" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_20"
+      ><text x="421.676" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_20"
       >–</text
-      ><text fill="#231f20" x="439.492" id="range_21" y="73.433" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="439.492" id="range_21" y="71.393" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
       >21</text
-      ><text fill="#231f20" x="439.492" id="range_mod_21" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="439.492" id="range_mod_21" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" text-anchor="middle"
       >–</text
-      ><text x="439.492" y="89.751" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_21"
+      ><text x="439.492" y="85.672" fill="#231f20" text-anchor="middle" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="uw_range_mod_21"
       >–</text
-      ><text fill="#231f20" x="3.000" y="81.592" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+      ><text fill="#231f20" x="3.000" y="78.532" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
       >Range Modifier:</text
-      ><text x="3.000" y="89.751" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" visibility="hidden" id="uw_range_modifier"
+      ><text x="3.000" y="85.672" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" visibility="hidden" id="uw_range_modifier"
       >Underwater:</text
       ><g visibility="hidden" id="field_gun_columns"
-      ><text fill="#231f20" x="6.000" y="97.910" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+      ><text fill="#231f20" x="6.000" y="92.811" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >Qty</text
-        ><text fill="#231f20" x="20.816" y="97.910" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+        ><text fill="#231f20" x="20.816" y="92.811" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
         >Field Gun Type</text
-        ><text fill="#231f20" x="87.626" y="97.910" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+        ><text fill="#231f20" x="87.626" y="92.811" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
         >Dmg</text
-        ><text fill="#231f20" x="123.258" y="97.910" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="123.258" y="92.811" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >Min</text
-        ><text fill="#231f20" x="136.620" y="97.910" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="136.620" y="92.811" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >S</text
-        ><text fill="#231f20" x="149.982" y="97.910" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="149.982" y="92.811" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >M</text
-        ><text fill="#231f20" x="163.344" y="97.910" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="163.344" y="92.811" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >L</text
-        ><text fill="#231f20" x="181.160" y="97.910" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="181.160" y="92.811" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >Ammo</text
-        ><text fill="#231f20" x="203.430" y="97.910" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="203.430" y="92.811" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         >Crew</text
-        ><text fill="#231f20" x="6.000" id="field_gun_qty" y="106.070" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="6.000" id="field_gun_qty" y="99.950" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
-        ><text fill="#231f20" x="20.816" id="field_gun_type" y="106.070" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+        ><text fill="#231f20" x="20.816" id="field_gun_type" y="99.950" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
         ></text
-        ><text fill="#231f20" x="87.626" id="field_gun_dmg" y="106.070" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
+        ><text fill="#231f20" x="87.626" id="field_gun_dmg" y="99.950" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
         ></text
-        ><text fill="#231f20" x="123.258" id="field_gun_min_range" y="106.070" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="87.626" id="field_gun_dmg_2" y="107.090" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="start"
         ></text
-        ><text fill="#231f20" x="136.620" id="field_gun_short" y="106.070" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="123.258" id="field_gun_min_range" y="99.950" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
-        ><text fill="#231f20" x="149.982" id="field_gun_med" y="106.070" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="136.620" id="field_gun_short" y="99.950" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
-        ><text fill="#231f20" x="163.344" id="field_gun_long" y="106.070" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="149.982" id="field_gun_med" y="99.950" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
-        ><text fill="#231f20" x="181.160" id="field_gun_ammo" y="106.070" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="163.344" id="field_gun_long" y="99.950" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
-        ><text fill="#231f20" x="203.430" id="field_gun_crew" y="106.070" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ><text fill="#231f20" x="181.160" id="field_gun_ammo" y="99.950" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
+        ></text
+        ><text fill="#231f20" x="203.430" id="field_gun_crew" y="99.950" style="font-family:Eurostile;font-size:6.200px;font-weight:bold;font-style:normal" text-anchor="middle"
         ></text
       ></g
       ><text x="0.000" y="0.000" fill="#000000" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="dest_mods"
-      ><tspan x="225.700" y="97.910"
+      ><tspan x="225.700" y="92.811"
         >+1 to-hit modifier to attackers</tspan
-        ><tspan x="225.700" y="104.438"
+        ><tspan x="225.700" y="98.522"
         >if unit does not move.</tspan
       ></text
       ><text x="0.000" y="0.000" fill="#000000" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="sneak_camo_mods"
-      ><tspan x="225.700" y="97.910"
+      ><tspan x="225.700" y="92.811"
         >MPs Used:</tspan
-        ><tspan x="225.700" y="104.438"
+        ><tspan x="225.700" y="98.522"
         >To-Hit Modifier:</tspan
-        ><tspan x="225.700" y="110.965"
+        ><tspan x="225.700" y="104.234"
         >(All Attackers)</tspan
-        ><tspan x="272.797" y="97.910"
+        ><tspan x="272.797" y="92.811"
         >0</tspan
-        ><tspan x="286.157" y="97.910"
+        ><tspan x="286.157" y="92.811"
         >1</tspan
-        ><tspan x="299.521" y="97.910"
+        ><tspan x="299.521" y="92.811"
         >2</tspan
-        ><tspan x="310.985" y="97.910"
+        ><tspan x="310.985" y="92.811"
         >3+</tspan
-        ><tspan x="270.899" y="104.438"
+        ><tspan x="270.899" y="98.522"
         >+3</tspan
-        ><tspan x="284.261" y="104.438"
+        ><tspan x="284.261" y="98.522"
         >+2</tspan
-        ><tspan x="297.622" y="104.438"
+        ><tspan x="297.622" y="98.522"
         >+1</tspan
-        ><tspan x="312.883" y="104.438"
+        ><tspan x="312.883" y="98.522"
         >0</tspan
       ></text
-      ><text x="337.050" y="97.910" fill="#000000" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="sneak_camo_mods"
-      ><tspan x="337.050" y="97.910"
+      ><text x="337.050" y="92.811" fill="#000000" text-anchor="start" style="font-family:Eurostile;font-size:6.200px;font-weight:normal;font-style:normal" visibility="hidden" id="sneak_camo_mods"
+      ><tspan x="337.050" y="92.811"
         >Range Category:</tspan
-        ><tspan x="337.050" y="104.438"
+        ><tspan x="337.050" y="98.522"
         >To-Hit Modifier:</tspan
-        ><tspan x="337.050" y="110.965"
+        ><tspan x="337.050" y="104.234"
         >(Non-Infantry Attackers)</tspan
-        ><tspan x="394.557" y="97.910"
+        ><tspan x="394.557" y="92.811"
         >S</tspan
-        ><tspan x="408.332" y="97.910"
+        ><tspan x="408.332" y="92.811"
         >M</tspan
-        ><tspan x="424.630" y="97.910"
+        ><tspan x="424.630" y="92.811"
         >L</tspan
-        ><tspan x="392.492" y="104.438"
+        ><tspan x="392.492" y="98.522"
         >+1</tspan
-        ><tspan x="407.190" y="104.438"
+        ><tspan x="407.190" y="98.522"
         >+1</tspan
-        ><tspan x="422.335" y="104.438"
+        ><tspan x="422.335" y="98.522"
         >+2</tspan
       ></text
     ></g

--- a/src/megameklab/com/printing/IdConstants.java
+++ b/src/megameklab/com/printing/IdConstants.java
@@ -147,6 +147,7 @@ public interface IdConstants {
     String FIELD_GUN_QTY = "field_gun_qty";
     String FIELD_GUN_TYPE = "field_gun_type";
     String FIELD_GUN_DMG = "field_gun_dmg";
+    String FIELD_GUN_DMG_2 = "field_gun_dmg_2";
     String FIELD_GUN_MIN_RANGE = "field_gun_min_range";
     String FIELD_GUN_SHORT = "field_gun_short";
     String FIELD_GUN_MED = "field_gun_med";

--- a/src/megameklab/com/printing/PrintInfantry.java
+++ b/src/megameklab/com/printing/PrintInfantry.java
@@ -27,6 +27,8 @@ import org.w3c.dom.svg.SVGRectElement;
 import java.util.Enumeration;
 import java.util.StringJoiner;
 
+import static megameklab.com.printing.InventoryEntry.DASH;
+
 /**
  * Lays out a record sheet block for a single infantry unit
  */
@@ -335,7 +337,7 @@ public class PrintInfantry extends PrintEntity {
         if (gun.getMinimumRange() > 0) {
             setTextField(FIELD_GUN_MIN_RANGE, gun.getMinimumRange());
         } else {
-            setTextField(FIELD_GUN_MIN_RANGE, "—");
+            setTextField(FIELD_GUN_MIN_RANGE, DASH);
         }
         setTextField(FIELD_GUN_SHORT, gun.getShortRange());
         setTextField(FIELD_GUN_MED, gun.getMediumRange());
@@ -409,7 +411,7 @@ public class PrintInfantry extends PrintEntity {
         }
 
         if (range >= mods.length) {
-            return "—";
+            return DASH;
         }
         int mod = mods[range];
         if (range == 0) {

--- a/src/megameklab/com/printing/PrintInfantry.java
+++ b/src/megameklab/com/printing/PrintInfantry.java
@@ -315,19 +315,21 @@ public class PrintInfantry extends PrintEntity {
             switch (gun.getAmmoType()) {
                 case AmmoType.T_AC_ULTRA:
                 case AmmoType.T_AC_ULTRA_THB:
-                    sb.append("/Sht, R2 [DB,R/S/C]");
+                    sb.append("/Sht, R2");
+                    setTextField(FIELD_GUN_DMG_2, "[DB,R/S/C]");
                     break;
                 case AmmoType.T_AC_ROTARY:
-                    sb.append("/Sht, R6 [DB,R/S/C]");
+                    sb.append("/Sht, R6");
+                    setTextField(FIELD_GUN_DMG_2, "[DB,R/S/C]");
                     break;
                 case AmmoType.T_AC:
                 case AmmoType.T_AC_PRIMITIVE:
                 case AmmoType.T_LAC:
-                    sb.append(" [DB,C/S/F]");
+                    setTextField(FIELD_GUN_DMG_2, "[DB,C/S/F]");
                     break;
                 case AmmoType.T_AC_LBX:
                 case AmmoType.T_AC_LBX_THB:
-                    sb.append(" [DB,C/F]");
+                    setTextField(FIELD_GUN_DMG_2, "[DB,C/F]");
                     break;
                 default:
                     sb.append(" [DB]");


### PR DESCRIPTION
When generated on Windows, the dash is printed as â€”, using Windows 1252 instead of Unicode. The escape sequence \u2014 is known to work on other sheets, so I replaced the literal with that.

I also noticed in the provided sample that the damage string for field guns can overrun the minimum range field, so I added a second field below it and split the text when it's longer.

Fixes #740.