### PR TITLE
Add jitpack repo for mm serialkiller dep

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ repositories {
         url 'https://github.com/MegaMek/mavenrepo/raw/master'
     }
     jcenter()
+    maven {
+        url 'https://jitpack.io'
+    }
 }
 
 configurations {


### PR DESCRIPTION
Same as [#1919](https://github.com/MegaMek/mekhq/pull/1919). Adding the jitpack maven repo to build the SerialKiller object deserialization library added to MegaMek.