### PR TITLE
Show mech structure type on RS when it has an in-game effect

### DIFF
--- a/data/images/recordsheets/templates_iso/mech_biped_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_biped_default.svg
@@ -2012,7 +2012,7 @@
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
                                                                               >
-    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="473.3" font-size="6.76" y="549.3" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                               >Standard</text
                                                                             ></g
                                                                             ><g id="structurePips"

--- a/data/images/recordsheets/templates_iso/mech_biped_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_biped_default.svg
@@ -1991,7 +1991,7 @@
                                                                             >
 <g style="font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.7954998px;font-family:Eurostile;writing-mode:lr-tb;fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="translate(-397.43863,-386.6357)"
                                                                             >
-             <text x="468" y="506.86" id="textIS_CT" font-weight="bold"
+             <text x="473.3" y="506.86" id="textIS_CT" font-weight="bold" text-anchor="middle"
                                                                               >( 0 )</text
                                                                               >
     <text x="532.30" y="400.84" id="textIS_RT" font-weight="bold"
@@ -2011,32 +2011,35 @@
                                                                               >
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
-                                                                              ><g id="structurePips"
-                                                                              ><g id="isPipsHD"
-                                                                                ><g id="g1680" transform="translate(476.465,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
-                                                                                  /></g
-                                                                                  ><g id="g1684" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
-                                                                                  /></g
-                                                                                  ><g id="g1688" transform="translate(468.3491,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
-                                                                                  /></g
-                                                                                ></g
-                                                                                ><g visibility="hidden" id="isPipsHD_SH"
-                                                                                ><g id="g1693" transform="translate(476.465,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
-                                                                                  /></g
-                                                                                  ><g id="g1697" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
-                                                                                  /></g
-                                                                                  ><g id="g1701" transform="translate(468.3491,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
-                                                                                  /></g
-                                                                                  ><g id="g1705" transform="translate(472.3109,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
-                                                                                  /></g
-                                                                                ></g
+                                                                              >
+    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                              >Standard</text
+                                                                            ></g
+                                                                            ><g id="structurePips"
+                                                                            ><g id="isPipsHD"
+                                                                              ><g id="g1680" transform="translate(476.465,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
+                                                                                /></g
+                                                                                ><g id="g1684" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
+                                                                                /></g
+                                                                                ><g id="g1688" transform="translate(468.3491,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
+                                                                                /></g
+                                                                              ></g
+                                                                              ><g visibility="hidden" id="isPipsHD_SH"
+                                                                              ><g id="g1693" transform="translate(476.465,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
+                                                                                /></g
+                                                                                ><g id="g1697" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
+                                                                                /></g
+                                                                                ><g id="g1701" transform="translate(468.3491,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
+                                                                                /></g
+                                                                                ><g id="g1705" transform="translate(472.3109,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
+                                                                                /></g
                                                                                 ><g fill="none" id="isPipsCT" transform="translate(461.54,418.4)"
                                                                                 ><rect x="0" width="22.28" y="0" height="5.4313" id="isCTRow00"
                                                                                   /><rect x="0" width="22.28" y="4.7035" height="5.4313" id="isCTRow01"
@@ -2153,7 +2156,7 @@
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (1.041 0 0 1.041 -415.054,-405.211)"
+                                                                            ><g id="canonStructurePips" transform="matrix (1.041 0 0 1.041 -415.053,-405.211)"
                                                                           /></g
                                                                           ><g transform="translate (372.667 591.000)"
                                                                           ><g

--- a/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
@@ -2012,7 +2012,7 @@
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
                                                                               >
-    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="473.3" font-size="6.76" y="549.3" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                               >Standard</text
                                                                             ></g
                                                                             ><g id="structurePips"

--- a/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
@@ -1991,7 +1991,7 @@
                                                                             >
 <g style="font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.7954998px;font-family:Eurostile;writing-mode:lr-tb;fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="translate(-397.43863,-386.6357)"
                                                                             >
-             <text x="468" y="506.86" id="textIS_CT" font-weight="bold"
+             <text x="473.3" y="506.86" id="textIS_CT" font-weight="bold" text-anchor="middle"
                                                                               >( 0 )</text
                                                                               >
     <text x="532.30" y="400.84" id="textIS_RT" font-weight="bold"
@@ -2011,32 +2011,35 @@
                                                                               >
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
-                                                                              ><g id="structurePips"
-                                                                              ><g id="isPipsHD"
-                                                                                ><g id="g1680" transform="translate(476.465,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
-                                                                                  /></g
-                                                                                  ><g id="g1684" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
-                                                                                  /></g
-                                                                                  ><g id="g1688" transform="translate(468.3491,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
-                                                                                  /></g
-                                                                                ></g
-                                                                                ><g visibility="hidden" id="isPipsHD_SH"
-                                                                                ><g id="g1693" transform="translate(476.465,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
-                                                                                  /></g
-                                                                                  ><g id="g1697" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
-                                                                                  /></g
-                                                                                  ><g id="g1701" transform="translate(468.3491,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
-                                                                                  /></g
-                                                                                  ><g id="g1705" transform="translate(472.3109,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
-                                                                                  /></g
-                                                                                ></g
+                                                                              >
+    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                              >Standard</text
+                                                                            ></g
+                                                                            ><g id="structurePips"
+                                                                            ><g id="isPipsHD"
+                                                                              ><g id="g1680" transform="translate(476.465,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
+                                                                                /></g
+                                                                                ><g id="g1684" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
+                                                                                /></g
+                                                                                ><g id="g1688" transform="translate(468.3491,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
+                                                                                /></g
+                                                                              ></g
+                                                                              ><g visibility="hidden" id="isPipsHD_SH"
+                                                                              ><g id="g1693" transform="translate(476.465,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
+                                                                                /></g
+                                                                                ><g id="g1697" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
+                                                                                /></g
+                                                                                ><g id="g1701" transform="translate(468.3491,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
+                                                                                /></g
+                                                                                ><g id="g1705" transform="translate(472.3109,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
+                                                                                /></g
                                                                                 ><g fill="none" id="isPipsCT" transform="translate(461.54,418.4)"
                                                                                 ><rect x="0" width="22.28" y="0" height="5.4313" id="isCTRow00"
                                                                                   /><rect x="0" width="22.28" y="4.7035" height="5.4313" id="isCTRow01"
@@ -2153,7 +2156,7 @@
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (1.041 0 0 1.041 -415.054,-405.211)"
+                                                                            ><g id="canonStructurePips" transform="matrix (1.041 0 0 1.041 -415.053,-405.211)"
                                                                           /></g
                                                                           ><g transform="translate (372.667 591.000)"
                                                                           ><g

--- a/data/images/recordsheets/templates_iso/mech_lam_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_lam_default.svg
@@ -2030,7 +2030,7 @@
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
                                                                               >
-    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="473.3" font-size="6.76" y="549.3" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                               >Standard</text
                                                                             ></g
                                                                             ><g id="structurePips"

--- a/data/images/recordsheets/templates_iso/mech_lam_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_lam_default.svg
@@ -2009,7 +2009,7 @@
                                                                             >
 <g style="font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.7954998px;font-family:Eurostile;writing-mode:lr-tb;fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="translate(-397.43863,-386.6357)"
                                                                             >
-             <text x="468" y="506.86" id="textIS_CT" font-weight="bold"
+             <text x="473.3" y="506.86" id="textIS_CT" font-weight="bold" text-anchor="middle"
                                                                               >( 0 )</text
                                                                               >
     <text x="532.30" y="400.84" id="textIS_RT" font-weight="bold"
@@ -2029,32 +2029,35 @@
                                                                               >
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
-                                                                              ><g id="structurePips"
-                                                                              ><g id="isPipsHD"
-                                                                                ><g id="g1680" transform="translate(476.465,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
-                                                                                  /></g
-                                                                                  ><g id="g1684" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
-                                                                                  /></g
-                                                                                  ><g id="g1688" transform="translate(468.3491,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
-                                                                                  /></g
-                                                                                ></g
-                                                                                ><g visibility="hidden" id="isPipsHD_SH"
-                                                                                ><g id="g1693" transform="translate(476.465,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
-                                                                                  /></g
-                                                                                  ><g id="g1697" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
-                                                                                  /></g
-                                                                                  ><g id="g1701" transform="translate(468.3491,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
-                                                                                  /></g
-                                                                                  ><g id="g1705" transform="translate(472.3109,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
-                                                                                  /></g
-                                                                                ></g
+                                                                              >
+    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                              >Standard</text
+                                                                            ></g
+                                                                            ><g id="structurePips"
+                                                                            ><g id="isPipsHD"
+                                                                              ><g id="g1680" transform="translate(476.465,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
+                                                                                /></g
+                                                                                ><g id="g1684" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
+                                                                                /></g
+                                                                                ><g id="g1688" transform="translate(468.3491,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
+                                                                                /></g
+                                                                              ></g
+                                                                              ><g visibility="hidden" id="isPipsHD_SH"
+                                                                              ><g id="g1693" transform="translate(476.465,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
+                                                                                /></g
+                                                                                ><g id="g1697" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
+                                                                                /></g
+                                                                                ><g id="g1701" transform="translate(468.3491,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
+                                                                                /></g
+                                                                                ><g id="g1705" transform="translate(472.3109,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
+                                                                                /></g
                                                                                 ><g fill="none" id="isPipsCT" transform="translate(461.54,418.4)"
                                                                                 ><rect x="0" width="22.28" y="0" height="5.4313" id="isCTRow00"
                                                                                   /><rect x="0" width="22.28" y="4.7035" height="5.4313" id="isCTRow01"
@@ -2171,7 +2174,7 @@
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (1.041 0 0 1.041 -415.054,-405.211)"
+                                                                            ><g id="canonStructurePips" transform="matrix (1.041 0 0 1.041 -415.053,-405.211)"
                                                                           /></g
                                                                           ><g transform="translate (372.667 591.000)"
                                                                           ><g

--- a/data/images/recordsheets/templates_iso/mech_lam_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_lam_toheat.svg
@@ -2030,7 +2030,7 @@
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
                                                                               >
-    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="473.3" font-size="6.76" y="549.3" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                               >Standard</text
                                                                             ></g
                                                                             ><g id="structurePips"

--- a/data/images/recordsheets/templates_iso/mech_lam_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_lam_toheat.svg
@@ -2009,7 +2009,7 @@
                                                                             >
 <g style="font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.7954998px;font-family:Eurostile;writing-mode:lr-tb;fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="translate(-397.43863,-386.6357)"
                                                                             >
-             <text x="468" y="506.86" id="textIS_CT" font-weight="bold"
+             <text x="473.3" y="506.86" id="textIS_CT" font-weight="bold" text-anchor="middle"
                                                                               >( 0 )</text
                                                                               >
     <text x="532.30" y="400.84" id="textIS_RT" font-weight="bold"
@@ -2029,32 +2029,35 @@
                                                                               >
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
-                                                                              ><g id="structurePips"
-                                                                              ><g id="isPipsHD"
-                                                                                ><g id="g1680" transform="translate(476.465,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
-                                                                                  /></g
-                                                                                  ><g id="g1684" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
-                                                                                  /></g
-                                                                                  ><g id="g1688" transform="translate(468.3491,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
-                                                                                  /></g
-                                                                                ></g
-                                                                                ><g visibility="hidden" id="isPipsHD_SH"
-                                                                                ><g id="g1693" transform="translate(476.465,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
-                                                                                  /></g
-                                                                                  ><g id="g1697" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
-                                                                                  /></g
-                                                                                  ><g id="g1701" transform="translate(468.3491,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
-                                                                                  /></g
-                                                                                  ><g id="g1705" transform="translate(472.3109,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
-                                                                                  /></g
-                                                                                ></g
+                                                                              >
+    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                              >Standard</text
+                                                                            ></g
+                                                                            ><g id="structurePips"
+                                                                            ><g id="isPipsHD"
+                                                                              ><g id="g1680" transform="translate(476.465,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
+                                                                                /></g
+                                                                                ><g id="g1684" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
+                                                                                /></g
+                                                                                ><g id="g1688" transform="translate(468.3491,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
+                                                                                /></g
+                                                                              ></g
+                                                                              ><g visibility="hidden" id="isPipsHD_SH"
+                                                                              ><g id="g1693" transform="translate(476.465,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
+                                                                                /></g
+                                                                                ><g id="g1697" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
+                                                                                /></g
+                                                                                ><g id="g1701" transform="translate(468.3491,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
+                                                                                /></g
+                                                                                ><g id="g1705" transform="translate(472.3109,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
+                                                                                /></g
                                                                                 ><g fill="none" id="isPipsCT" transform="translate(461.54,418.4)"
                                                                                 ><rect x="0" width="22.28" y="0" height="5.4313" id="isCTRow00"
                                                                                   /><rect x="0" width="22.28" y="4.7035" height="5.4313" id="isCTRow01"
@@ -2171,7 +2174,7 @@
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (1.041 0 0 1.041 -415.054,-405.211)"
+                                                                            ><g id="canonStructurePips" transform="matrix (1.041 0 0 1.041 -415.053,-405.211)"
                                                                           /></g
                                                                           ><g transform="translate (372.667 591.000)"
                                                                           ><g

--- a/data/images/recordsheets/templates_iso/mech_quad_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_quad_default.svg
@@ -1781,6 +1781,8 @@
                                                                                     >
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
+                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle" font-weight="bold"
+                                                                                    >Standard</text
                                                                                     >
 </g
                                                                                     >         </g

--- a/data/images/recordsheets/templates_iso/mech_quad_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_quad_default.svg
@@ -1781,7 +1781,7 @@
                                                                                     >
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
-                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle" font-weight="bold"
+                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle;font-size:6.76" font-weight="bold"
                                                                                     >Standard</text
                                                                                     >
 </g

--- a/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
@@ -1781,6 +1781,8 @@
                                                                                     >
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
+                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle" font-weight="bold"
+                                                                                    >Standard</text
                                                                                     >
 </g
                                                                                     >         </g

--- a/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
@@ -1781,7 +1781,7 @@
                                                                                     >
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
-                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle" font-weight="bold"
+                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle;font-size:6.76" font-weight="bold"
                                                                                     >Standard</text
                                                                                     >
 </g

--- a/data/images/recordsheets/templates_iso/mech_quadvee_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_quadvee_default.svg
@@ -1899,6 +1899,9 @@
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
                                                                                     >
+    <text x="471.5" y="550" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                                    >Standard</text
+                                                                                    >
 </g
                                                                                   ></g
                                                                                 ></g

--- a/data/images/recordsheets/templates_iso/mech_quadvee_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_quadvee_toheat.svg
@@ -1899,6 +1899,9 @@
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
                                                                                     >
+    <text x="471.5" y="550" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                                    >Standard</text
+                                                                                    >
 </g
                                                                                   ></g
                                                                                 ></g

--- a/data/images/recordsheets/templates_iso/mech_tripod_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_tripod_default.svg
@@ -2064,7 +2064,7 @@
                                                                           /><text x="74.117" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="127.941" lengthAdjust="spacingAndGlyphs"
                                                                           >INTERNAL STRUCTURE DIAGRAM</text
                                                                         ></g
-                                                                        ><g transform="matrix(1.099 0 0 1.099 0.277 12.250)"
+                                                                        ><g transform="matrix(1.052 0 0 1.052 3.809 12.250)"
                                                                         >
 <g id="internal_diagram_tripod" transform="matrix(1,0,0,-1,-390.22409,379.2819)"
                                                                           ><g id="g3654" transform="translate(477.6598,215.3208)"
@@ -2371,12 +2371,15 @@
 <text x="446.22" y="535.60" id="textIS_CL" font-weight="bold" text-anchor="middle"
                                                                                 >( 0 )</text
                                                                                 >
+    <text x="496.04" y="564.26" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                                >Standard</text
+                                                                                >
 </g
                                                                               ></g
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (1.061 0 0 1.061 -424.611,-414.991)"
+                                                                            ><g id="canonStructurePips" transform="matrix (1.016 0 0 1.016 -402.972,-392.848)"
                                                                           /></g
                                                                           ><g transform="translate (372.667 591.000)"
                                                                           ><g

--- a/data/images/recordsheets/templates_iso/mech_tripod_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_tripod_default.svg
@@ -2064,7 +2064,7 @@
                                                                           /><text x="74.117" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="127.941" lengthAdjust="spacingAndGlyphs"
                                                                           >INTERNAL STRUCTURE DIAGRAM</text
                                                                         ></g
-                                                                        ><g transform="matrix(1.052 0 0 1.052 3.809 12.250)"
+                                                                        ><g transform="matrix(1.052 0 0 1.052 3.815 12.250)"
                                                                         >
 <g id="internal_diagram_tripod" transform="matrix(1,0,0,-1,-390.22409,379.2819)"
                                                                           ><g id="g3654" transform="translate(477.6598,215.3208)"
@@ -2371,7 +2371,7 @@
 <text x="446.22" y="535.60" id="textIS_CL" font-weight="bold" text-anchor="middle"
                                                                                 >( 0 )</text
                                                                                 >
-    <text x="496.04" y="564.26" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="496.04" font-size="6.76" y="564.26" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                                 >Standard</text
                                                                                 >
 </g
@@ -2379,7 +2379,7 @@
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (1.016 0 0 1.016 -402.972,-392.848)"
+                                                                            ><g id="canonStructurePips" transform="matrix (1.016 0 0 1.016 -402.938,-392.813)"
                                                                           /></g
                                                                           ><g transform="translate (372.667 591.000)"
                                                                           ><g

--- a/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
@@ -2064,7 +2064,7 @@
                                                                           /><text x="74.117" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="127.941" lengthAdjust="spacingAndGlyphs"
                                                                           >INTERNAL STRUCTURE DIAGRAM</text
                                                                         ></g
-                                                                        ><g transform="matrix(1.099 0 0 1.099 0.277 12.250)"
+                                                                        ><g transform="matrix(1.052 0 0 1.052 3.809 12.250)"
                                                                         >
 <g id="internal_diagram_tripod" transform="matrix(1,0,0,-1,-390.22409,379.2819)"
                                                                           ><g id="g3654" transform="translate(477.6598,215.3208)"
@@ -2371,12 +2371,15 @@
 <text x="446.22" y="535.60" id="textIS_CL" font-weight="bold" text-anchor="middle"
                                                                                 >( 0 )</text
                                                                                 >
+    <text x="496.04" y="564.26" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                                >Standard</text
+                                                                                >
 </g
                                                                               ></g
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (1.061 0 0 1.061 -424.611,-414.991)"
+                                                                            ><g id="canonStructurePips" transform="matrix (1.016 0 0 1.016 -402.972,-392.848)"
                                                                           /></g
                                                                           ><g transform="translate (372.667 591.000)"
                                                                           ><g

--- a/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
@@ -2064,7 +2064,7 @@
                                                                           /><text x="74.117" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="127.941" lengthAdjust="spacingAndGlyphs"
                                                                           >INTERNAL STRUCTURE DIAGRAM</text
                                                                         ></g
-                                                                        ><g transform="matrix(1.052 0 0 1.052 3.809 12.250)"
+                                                                        ><g transform="matrix(1.052 0 0 1.052 3.815 12.250)"
                                                                         >
 <g id="internal_diagram_tripod" transform="matrix(1,0,0,-1,-390.22409,379.2819)"
                                                                           ><g id="g3654" transform="translate(477.6598,215.3208)"
@@ -2371,7 +2371,7 @@
 <text x="446.22" y="535.60" id="textIS_CL" font-weight="bold" text-anchor="middle"
                                                                                 >( 0 )</text
                                                                                 >
-    <text x="496.04" y="564.26" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="496.04" font-size="6.76" y="564.26" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                                 >Standard</text
                                                                                 >
 </g
@@ -2379,7 +2379,7 @@
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (1.016 0 0 1.016 -402.972,-392.848)"
+                                                                            ><g id="canonStructurePips" transform="matrix (1.016 0 0 1.016 -402.938,-392.813)"
                                                                           /></g
                                                                           ><g transform="translate (372.667 591.000)"
                                                                           ><g

--- a/data/images/recordsheets/templates_us/mech_biped_default.svg
+++ b/data/images/recordsheets/templates_us/mech_biped_default.svg
@@ -2012,7 +2012,7 @@
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
                                                                               >
-    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="473.3" font-size="6.76" y="549.3" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                               >Standard</text
                                                                             ></g
                                                                             ><g id="structurePips"

--- a/data/images/recordsheets/templates_us/mech_biped_default.svg
+++ b/data/images/recordsheets/templates_us/mech_biped_default.svg
@@ -1991,7 +1991,7 @@
                                                                             >
 <g style="font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.7954998px;font-family:Eurostile;writing-mode:lr-tb;fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="translate(-397.43863,-386.6357)"
                                                                             >
-             <text x="468" y="506.86" id="textIS_CT" font-weight="bold"
+             <text x="473.3" y="506.86" id="textIS_CT" font-weight="bold" text-anchor="middle"
                                                                               >( 0 )</text
                                                                               >
     <text x="532.30" y="400.84" id="textIS_RT" font-weight="bold"
@@ -2011,32 +2011,35 @@
                                                                               >
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
-                                                                              ><g id="structurePips"
-                                                                              ><g id="isPipsHD"
-                                                                                ><g id="g1680" transform="translate(476.465,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
-                                                                                  /></g
-                                                                                  ><g id="g1684" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
-                                                                                  /></g
-                                                                                  ><g id="g1688" transform="translate(468.3491,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
-                                                                                  /></g
-                                                                                ></g
-                                                                                ><g visibility="hidden" id="isPipsHD_SH"
-                                                                                ><g id="g1693" transform="translate(476.465,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
-                                                                                  /></g
-                                                                                  ><g id="g1697" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
-                                                                                  /></g
-                                                                                  ><g id="g1701" transform="translate(468.3491,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
-                                                                                  /></g
-                                                                                  ><g id="g1705" transform="translate(472.3109,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
-                                                                                  /></g
-                                                                                ></g
+                                                                              >
+    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                              >Standard</text
+                                                                            ></g
+                                                                            ><g id="structurePips"
+                                                                            ><g id="isPipsHD"
+                                                                              ><g id="g1680" transform="translate(476.465,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
+                                                                                /></g
+                                                                                ><g id="g1684" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
+                                                                                /></g
+                                                                                ><g id="g1688" transform="translate(468.3491,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
+                                                                                /></g
+                                                                              ></g
+                                                                              ><g visibility="hidden" id="isPipsHD_SH"
+                                                                              ><g id="g1693" transform="translate(476.465,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
+                                                                                /></g
+                                                                                ><g id="g1697" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
+                                                                                /></g
+                                                                                ><g id="g1701" transform="translate(468.3491,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
+                                                                                /></g
+                                                                                ><g id="g1705" transform="translate(472.3109,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
+                                                                                /></g
                                                                                 ><g fill="none" id="isPipsCT" transform="translate(461.54,418.4)"
                                                                                 ><rect x="0" width="22.28" y="0" height="5.4313" id="isCTRow00"
                                                                                   /><rect x="0" width="22.28" y="4.7035" height="5.4313" id="isCTRow01"

--- a/data/images/recordsheets/templates_us/mech_biped_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_biped_toheat.svg
@@ -2012,7 +2012,7 @@
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
                                                                               >
-    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="473.3" font-size="6.76" y="549.3" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                               >Standard</text
                                                                             ></g
                                                                             ><g id="structurePips"

--- a/data/images/recordsheets/templates_us/mech_biped_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_biped_toheat.svg
@@ -1991,7 +1991,7 @@
                                                                             >
 <g style="font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.7954998px;font-family:Eurostile;writing-mode:lr-tb;fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="translate(-397.43863,-386.6357)"
                                                                             >
-             <text x="468" y="506.86" id="textIS_CT" font-weight="bold"
+             <text x="473.3" y="506.86" id="textIS_CT" font-weight="bold" text-anchor="middle"
                                                                               >( 0 )</text
                                                                               >
     <text x="532.30" y="400.84" id="textIS_RT" font-weight="bold"
@@ -2011,32 +2011,35 @@
                                                                               >
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
-                                                                              ><g id="structurePips"
-                                                                              ><g id="isPipsHD"
-                                                                                ><g id="g1680" transform="translate(476.465,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
-                                                                                  /></g
-                                                                                  ><g id="g1684" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
-                                                                                  /></g
-                                                                                  ><g id="g1688" transform="translate(468.3491,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
-                                                                                  /></g
-                                                                                ></g
-                                                                                ><g visibility="hidden" id="isPipsHD_SH"
-                                                                                ><g id="g1693" transform="translate(476.465,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
-                                                                                  /></g
-                                                                                  ><g id="g1697" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
-                                                                                  /></g
-                                                                                  ><g id="g1701" transform="translate(468.3491,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
-                                                                                  /></g
-                                                                                  ><g id="g1705" transform="translate(472.3109,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
-                                                                                  /></g
-                                                                                ></g
+                                                                              >
+    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                              >Standard</text
+                                                                            ></g
+                                                                            ><g id="structurePips"
+                                                                            ><g id="isPipsHD"
+                                                                              ><g id="g1680" transform="translate(476.465,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
+                                                                                /></g
+                                                                                ><g id="g1684" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
+                                                                                /></g
+                                                                                ><g id="g1688" transform="translate(468.3491,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
+                                                                                /></g
+                                                                              ></g
+                                                                              ><g visibility="hidden" id="isPipsHD_SH"
+                                                                              ><g id="g1693" transform="translate(476.465,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
+                                                                                /></g
+                                                                                ><g id="g1697" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
+                                                                                /></g
+                                                                                ><g id="g1701" transform="translate(468.3491,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
+                                                                                /></g
+                                                                                ><g id="g1705" transform="translate(472.3109,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
+                                                                                /></g
                                                                                 ><g fill="none" id="isPipsCT" transform="translate(461.54,418.4)"
                                                                                 ><rect x="0" width="22.28" y="0" height="5.4313" id="isCTRow00"
                                                                                   /><rect x="0" width="22.28" y="4.7035" height="5.4313" id="isCTRow01"

--- a/data/images/recordsheets/templates_us/mech_lam_default.svg
+++ b/data/images/recordsheets/templates_us/mech_lam_default.svg
@@ -2030,7 +2030,7 @@
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
                                                                               >
-    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="473.3" font-size="6.76" y="549.3" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                               >Standard</text
                                                                             ></g
                                                                             ><g id="structurePips"

--- a/data/images/recordsheets/templates_us/mech_lam_default.svg
+++ b/data/images/recordsheets/templates_us/mech_lam_default.svg
@@ -2009,7 +2009,7 @@
                                                                             >
 <g style="font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.7954998px;font-family:Eurostile;writing-mode:lr-tb;fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="translate(-397.43863,-386.6357)"
                                                                             >
-             <text x="468" y="506.86" id="textIS_CT" font-weight="bold"
+             <text x="473.3" y="506.86" id="textIS_CT" font-weight="bold" text-anchor="middle"
                                                                               >( 0 )</text
                                                                               >
     <text x="532.30" y="400.84" id="textIS_RT" font-weight="bold"
@@ -2029,32 +2029,35 @@
                                                                               >
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
-                                                                              ><g id="structurePips"
-                                                                              ><g id="isPipsHD"
-                                                                                ><g id="g1680" transform="translate(476.465,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
-                                                                                  /></g
-                                                                                  ><g id="g1684" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
-                                                                                  /></g
-                                                                                  ><g id="g1688" transform="translate(468.3491,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
-                                                                                  /></g
-                                                                                ></g
-                                                                                ><g visibility="hidden" id="isPipsHD_SH"
-                                                                                ><g id="g1693" transform="translate(476.465,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
-                                                                                  /></g
-                                                                                  ><g id="g1697" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
-                                                                                  /></g
-                                                                                  ><g id="g1701" transform="translate(468.3491,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
-                                                                                  /></g
-                                                                                  ><g id="g1705" transform="translate(472.3109,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
-                                                                                  /></g
-                                                                                ></g
+                                                                              >
+    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                              >Standard</text
+                                                                            ></g
+                                                                            ><g id="structurePips"
+                                                                            ><g id="isPipsHD"
+                                                                              ><g id="g1680" transform="translate(476.465,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
+                                                                                /></g
+                                                                                ><g id="g1684" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
+                                                                                /></g
+                                                                                ><g id="g1688" transform="translate(468.3491,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
+                                                                                /></g
+                                                                              ></g
+                                                                              ><g visibility="hidden" id="isPipsHD_SH"
+                                                                              ><g id="g1693" transform="translate(476.465,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
+                                                                                /></g
+                                                                                ><g id="g1697" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
+                                                                                /></g
+                                                                                ><g id="g1701" transform="translate(468.3491,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
+                                                                                /></g
+                                                                                ><g id="g1705" transform="translate(472.3109,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
+                                                                                /></g
                                                                                 ><g fill="none" id="isPipsCT" transform="translate(461.54,418.4)"
                                                                                 ><rect x="0" width="22.28" y="0" height="5.4313" id="isCTRow00"
                                                                                   /><rect x="0" width="22.28" y="4.7035" height="5.4313" id="isCTRow01"

--- a/data/images/recordsheets/templates_us/mech_lam_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_lam_toheat.svg
@@ -2030,7 +2030,7 @@
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
                                                                               >
-    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="473.3" font-size="6.76" y="549.3" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                               >Standard</text
                                                                             ></g
                                                                             ><g id="structurePips"

--- a/data/images/recordsheets/templates_us/mech_lam_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_lam_toheat.svg
@@ -2009,7 +2009,7 @@
                                                                             >
 <g style="font-variant:normal;font-weight:bold;font-stretch:normal;font-size:5.7954998px;font-family:Eurostile;writing-mode:lr-tb;fill:#231f20;fill-opacity:1;fill-rule:nonzero;stroke:none" transform="translate(-397.43863,-386.6357)"
                                                                             >
-             <text x="468" y="506.86" id="textIS_CT" font-weight="bold"
+             <text x="473.3" y="506.86" id="textIS_CT" font-weight="bold" text-anchor="middle"
                                                                               >( 0 )</text
                                                                               >
     <text x="532.30" y="400.84" id="textIS_RT" font-weight="bold"
@@ -2029,32 +2029,35 @@
                                                                               >
     <text x="412.84" y="535.60" id="textIS_LL" font-weight="bold"
                                                                               >( 0 )</text
-                                                                              ><g id="structurePips"
-                                                                              ><g id="isPipsHD"
-                                                                                ><g id="g1680" transform="translate(476.465,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
-                                                                                  /></g
-                                                                                  ><g id="g1684" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
-                                                                                  /></g
-                                                                                  ><g id="g1688" transform="translate(468.3491,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
-                                                                                  /></g
-                                                                                ></g
-                                                                                ><g visibility="hidden" id="isPipsHD_SH"
-                                                                                ><g id="g1693" transform="translate(476.465,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
-                                                                                  /></g
-                                                                                  ><g id="g1697" transform="translate(472.3109,401.1173)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
-                                                                                  /></g
-                                                                                  ><g id="g1701" transform="translate(468.3491,404.8215)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
-                                                                                  /></g
-                                                                                  ><g id="g1705" transform="translate(472.3109,408.5257)"
-                                                                                  ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
-                                                                                  /></g
-                                                                                ></g
+                                                                              >
+    <text x="473.3" y="549.3" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                              >Standard</text
+                                                                            ></g
+                                                                            ><g id="structurePips"
+                                                                            ><g id="isPipsHD"
+                                                                              ><g id="g1680" transform="translate(476.465,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1682"
+                                                                                /></g
+                                                                                ><g id="g1684" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1686"
+                                                                                /></g
+                                                                                ><g id="g1688" transform="translate(468.3491,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1690"
+                                                                                /></g
+                                                                              ></g
+                                                                              ><g visibility="hidden" id="isPipsHD_SH"
+                                                                              ><g id="g1693" transform="translate(476.465,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1695"
+                                                                                /></g
+                                                                                ><g id="g1697" transform="translate(472.3109,401.1173)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1699"
+                                                                                /></g
+                                                                                ><g id="g1701" transform="translate(468.3491,404.8215)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.96,0 -1.76,0.8 -1.76,1.759 0,0.959 0.8,1.759 1.76,1.759 0.959,0 1.758,-0.8 1.758,-1.759 C 1.758,0.8 0.959,0 0,0 Z" id="path1703"
+                                                                                /></g
+                                                                                ><g id="g1705" transform="translate(472.3109,408.5257)"
+                                                                                ><path style="fill:none;stroke:#231f20;stroke-width:0.48699999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:2.41400003;stroke-dasharray:none;stroke-opacity:1" d="m 0,0 c -0.961,0 -1.761,0.8 -1.761,1.758 0,0.96 0.8,1.761 1.761,1.761 0.959,0 1.758,-0.801 1.758,-1.761 C 1.758,0.8 0.959,0 0,0 Z" id="path1707"
+                                                                                /></g
                                                                                 ><g fill="none" id="isPipsCT" transform="translate(461.54,418.4)"
                                                                                 ><rect x="0" width="22.28" y="0" height="5.4313" id="isCTRow00"
                                                                                   /><rect x="0" width="22.28" y="4.7035" height="5.4313" id="isCTRow01"

--- a/data/images/recordsheets/templates_us/mech_quad_default.svg
+++ b/data/images/recordsheets/templates_us/mech_quad_default.svg
@@ -1781,6 +1781,8 @@
                                                                                     >
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
+                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle" font-weight="bold"
+                                                                                    >Standard</text
                                                                                     >
 </g
                                                                                     >         </g

--- a/data/images/recordsheets/templates_us/mech_quad_default.svg
+++ b/data/images/recordsheets/templates_us/mech_quad_default.svg
@@ -1781,7 +1781,7 @@
                                                                                     >
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
-                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle" font-weight="bold"
+                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle;font-size:6.76" font-weight="bold"
                                                                                     >Standard</text
                                                                                     >
 </g

--- a/data/images/recordsheets/templates_us/mech_quad_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_quad_toheat.svg
@@ -1781,6 +1781,8 @@
                                                                                     >
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
+                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle" font-weight="bold"
+                                                                                    >Standard</text
                                                                                     >
 </g
                                                                                     >         </g

--- a/data/images/recordsheets/templates_us/mech_quad_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_quad_toheat.svg
@@ -1781,7 +1781,7 @@
                                                                                     >
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
-                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle" font-weight="bold"
+                                                                                    ><text x="471.60025" y="552.09985" id="structureType" style="font-weight:bold;text-anchor:middle;font-size:6.76" font-weight="bold"
                                                                                     >Standard</text
                                                                                     >
 </g

--- a/data/images/recordsheets/templates_us/mech_quadvee_default.svg
+++ b/data/images/recordsheets/templates_us/mech_quadvee_default.svg
@@ -1899,6 +1899,9 @@
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
                                                                                     >
+    <text x="471.5" y="550" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                                    >Standard</text
+                                                                                    >
 </g
                                                                                   ></g
                                                                                 ></g

--- a/data/images/recordsheets/templates_us/mech_quadvee_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_quadvee_toheat.svg
@@ -1899,6 +1899,9 @@
 <text x="408.81" y="526.15" id="textIS_RLL" font-weight="bold" text-anchor="middle"
                                                                                     >( 0 )</text
                                                                                     >
+    <text x="471.5" y="550" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                                    >Standard</text
+                                                                                    >
 </g
                                                                                   ></g
                                                                                 ></g

--- a/data/images/recordsheets/templates_us/mech_tripod_default.svg
+++ b/data/images/recordsheets/templates_us/mech_tripod_default.svg
@@ -2064,7 +2064,7 @@
                                                                           /><text x="74.117" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="127.941" lengthAdjust="spacingAndGlyphs"
                                                                           >INTERNAL STRUCTURE DIAGRAM</text
                                                                         ></g
-                                                                        ><g transform="matrix(1.024 0 0 1.024 8.718 12.250)"
+                                                                        ><g transform="matrix(0.981 0 0 0.981 12.012 12.250)"
                                                                         >
 <g id="internal_diagram_tripod" transform="matrix(1,0,0,-1,-390.22409,379.2819)"
                                                                           ><g id="g3654" transform="translate(477.6598,215.3208)"
@@ -2371,12 +2371,15 @@
 <text x="446.22" y="535.60" id="textIS_CL" font-weight="bold" text-anchor="middle"
                                                                                 >( 0 )</text
                                                                                 >
+    <text x="496.04" y="564.26" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                                >Standard</text
+                                                                                >
 </g
                                                                               ></g
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (0.990 0 0 0.990 -387.422,-386.085)"
+                                                                            ><g id="canonStructurePips" transform="matrix (0.947 0 0 0.947 -367.247,-365.439)"
                                                                           /></g
                                                                           ><g transform="translate (384.000 553.500)"
                                                                           ><g

--- a/data/images/recordsheets/templates_us/mech_tripod_default.svg
+++ b/data/images/recordsheets/templates_us/mech_tripod_default.svg
@@ -2064,7 +2064,7 @@
                                                                           /><text x="74.117" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="127.941" lengthAdjust="spacingAndGlyphs"
                                                                           >INTERNAL STRUCTURE DIAGRAM</text
                                                                         ></g
-                                                                        ><g transform="matrix(0.981 0 0 0.981 12.012 12.250)"
+                                                                        ><g transform="matrix(0.981 0 0 0.981 12.017 12.250)"
                                                                         >
 <g id="internal_diagram_tripod" transform="matrix(1,0,0,-1,-390.22409,379.2819)"
                                                                           ><g id="g3654" transform="translate(477.6598,215.3208)"
@@ -2371,7 +2371,7 @@
 <text x="446.22" y="535.60" id="textIS_CL" font-weight="bold" text-anchor="middle"
                                                                                 >( 0 )</text
                                                                                 >
-    <text x="496.04" y="564.26" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="496.04" font-size="6.76" y="564.26" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                                 >Standard</text
                                                                                 >
 </g
@@ -2379,7 +2379,7 @@
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (0.947 0 0 0.947 -367.247,-365.439)"
+                                                                            ><g id="canonStructurePips" transform="matrix (0.947 0 0 0.947 -367.215,-365.407)"
                                                                           /></g
                                                                           ><g transform="translate (384.000 553.500)"
                                                                           ><g

--- a/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
@@ -2064,7 +2064,7 @@
                                                                           /><text x="74.117" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="127.941" lengthAdjust="spacingAndGlyphs"
                                                                           >INTERNAL STRUCTURE DIAGRAM</text
                                                                         ></g
-                                                                        ><g transform="matrix(1.024 0 0 1.024 8.718 12.250)"
+                                                                        ><g transform="matrix(0.981 0 0 0.981 12.012 12.250)"
                                                                         >
 <g id="internal_diagram_tripod" transform="matrix(1,0,0,-1,-390.22409,379.2819)"
                                                                           ><g id="g3654" transform="translate(477.6598,215.3208)"
@@ -2371,12 +2371,15 @@
 <text x="446.22" y="535.60" id="textIS_CL" font-weight="bold" text-anchor="middle"
                                                                                 >( 0 )</text
                                                                                 >
+    <text x="496.04" y="564.26" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+                                                                                >Standard</text
+                                                                                >
 </g
                                                                               ></g
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (0.990 0 0 0.990 -387.422,-386.085)"
+                                                                            ><g id="canonStructurePips" transform="matrix (0.947 0 0 0.947 -367.247,-365.439)"
                                                                           /></g
                                                                           ><g transform="translate (384.000 553.500)"
                                                                           ><g

--- a/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
@@ -2064,7 +2064,7 @@
                                                                           /><text x="74.117" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="127.941" lengthAdjust="spacingAndGlyphs"
                                                                           >INTERNAL STRUCTURE DIAGRAM</text
                                                                         ></g
-                                                                        ><g transform="matrix(0.981 0 0 0.981 12.012 12.250)"
+                                                                        ><g transform="matrix(0.981 0 0 0.981 12.017 12.250)"
                                                                         >
 <g id="internal_diagram_tripod" transform="matrix(1,0,0,-1,-390.22409,379.2819)"
                                                                           ><g id="g3654" transform="translate(477.6598,215.3208)"
@@ -2371,7 +2371,7 @@
 <text x="446.22" y="535.60" id="textIS_CL" font-weight="bold" text-anchor="middle"
                                                                                 >( 0 )</text
                                                                                 >
-    <text x="496.04" y="564.26" id="structureType" style="mml-field-width=45" font-weight="bold" text-anchor="middle"
+    <text x="496.04" font-size="6.76" y="564.26" text-anchor="middle" style="mml-field-width=45" id="structureType" font-weight="bold"
                                                                                 >Standard</text
                                                                                 >
 </g
@@ -2379,7 +2379,7 @@
                                                                             ></g
                                                                             >
 </g
-                                                                            ><g id="canonStructurePips" transform="matrix (0.947 0 0 0.947 -367.247,-365.439)"
+                                                                            ><g id="canonStructurePips" transform="matrix (0.947 0 0 0.947 -367.215,-365.407)"
                                                                           /></g
                                                                           ><g transform="translate (384.000 553.500)"
                                                                           ><g

--- a/src/megameklab/com/printing/IdConstants.java
+++ b/src/megameklab/com/printing/IdConstants.java
@@ -94,6 +94,7 @@ public interface IdConstants {
 
     String ARMOR_TYPE = "armorType";
     String ARMOR_TYPE_2 = "armorType2";
+    String STRUCTURE_TYPE = "structureType";
     String PATCHWORK = "patchwork";
     String TEXT_ARMOR = "textArmor_";
     String TEXT_IS = "textIS_";

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import megamek.common.*;
 import megameklab.com.printing.reference.*;
 import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.dom.util.SAXDocumentFactory;
@@ -34,19 +35,6 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.svg.SVGRectElement;
 
-import megamek.common.AmmoType;
-import megamek.common.BipedMech;
-import megamek.common.CriticalSlot;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EquipmentMessages;
-import megamek.common.ITechnology;
-import megamek.common.LAMPilot;
-import megamek.common.LandAirMech;
-import megamek.common.Mech;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.QuadVee;
 import megamek.common.annotations.Nullable;
 import megameklab.com.MegaMekLab;
 import megameklab.com.util.ImageHelper;
@@ -59,7 +47,7 @@ import megameklab.com.util.UnitUtil;
  *
  */
 public class PrintMech extends PrintEntity {
-    
+
     /**
      * The current mech being printed.
      */
@@ -177,7 +165,7 @@ public class PrintMech extends PrintEntity {
             if (si instanceof SVGRectElement) {
                 drawSIPips((SVGRectElement) si);
             } else {
-                MegaMekLab.getLogger().error(getClass(), "PrintImage(Graphics2D, PageFormat, int)",
+                MegaMekLab.getLogger().error(getClass(),
                         "Region siPips does not exist in template or is not a <rect>");
             }
         }
@@ -264,6 +252,16 @@ public class PrintMech extends PrintEntity {
         hideElement(WARRIOR_DATA_TRIPLE, getEntity().getCrew().getSlotCount() != 3);
     }
 
+    @Override
+    protected void drawStructure() {
+        if (mech.hasCompositeStructure() || mech.hasReinforcedStructure()) {
+            String isName = EquipmentType.getStructureTypeName(mech.getStructureType());
+            setTextField(STRUCTURE_TYPE, isName);
+        } else {
+            hideElement(STRUCTURE_TYPE, true);
+        }
+    }
+
     private boolean loadArmorPips(int loc, boolean rear) {
         String locAbbr;
         switch(loc) {
@@ -323,7 +321,6 @@ public class PrintMech extends PrintEntity {
     }
 
     private @Nullable NodeList loadPipSVG(String filename) {
-        final String METHOD_NAME = "loadPipsSVG(int, int)"; //$NON-NLS-1$
         File f = new File(filename);
         if (!f.exists()) {
             return null;
@@ -336,12 +333,12 @@ public class PrintMech extends PrintEntity {
             SAXDocumentFactory df = new SAXDocumentFactory(impl, parser);
             doc = df.createDocument(f.toURI().toASCIIString(), is);
         } catch (Exception e) {
-            MegaMekLab.getLogger().error(PrintRecordSheet.class, METHOD_NAME,
+            MegaMekLab.getLogger().error(PrintRecordSheet.class,
                     "Failed to open pip SVG file! Path: " + f.getName());
             return null;
         }
         if (null == doc) {
-            MegaMekLab.getLogger().error(PrintRecordSheet.class, METHOD_NAME,
+            MegaMekLab.getLogger().error(PrintRecordSheet.class,
                     "Failed to open pip SVG file! Path: " + f.getName());
             return null;
         }

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -165,7 +165,7 @@ public class PrintMech extends PrintEntity {
             if (si instanceof SVGRectElement) {
                 drawSIPips((SVGRectElement) si);
             } else {
-                MegaMekLab.getLogger().error(getClass(),
+                MegaMekLab.getLogger().error(this,
                         "Region siPips does not exist in template or is not a <rect>");
             }
         }


### PR DESCRIPTION
Reinforced and composite structure affect how damage is applied and should appear on the record sheet.

Biped:
![Screenshot from 2020-09-23 18-25-01](https://user-images.githubusercontent.com/16927464/94084526-5e452680-fdcb-11ea-833f-9dffb1735ac4.png)

Quad:
![Screenshot from 2020-09-23 18-30-16](https://user-images.githubusercontent.com/16927464/94084549-6735f800-fdcb-11ea-98d3-3224955e1997.png)

Tripod:
![Screenshot from 2020-09-23 18-29-44](https://user-images.githubusercontent.com/16927464/94084561-6bfaac00-fdcb-11ea-900d-671e744ed569.png)

Closes #749 
