### PR TITLE
Use kilogram standard on small SV record sheets

### DIFF
--- a/src/megameklab/com/printing/PrintAero.java
+++ b/src/megameklab/com/printing/PrintAero.java
@@ -188,17 +188,23 @@ public class PrintAero extends PrintEntity {
             sj.add("Basic Fire Control");
         }
         Map<String, Double> transport = new HashMap<>();
+        Map<String, Integer> seating = new HashMap<>();
         for (Transporter t : aero.getTransports()) {
             if (t instanceof TroopSpace) {
                 transport.merge("Infantry Bay", t.getUnused(), Double::sum);
+            } else if (t instanceof StandardSeatCargoBay) {
+                seating.merge(((Bay) t).getType(), (int) ((Bay) t).getCapacity(), Integer::sum);
             // include cargo bays for fighters and fixed wing, but small craft get a block for transport bays
             } else if (t instanceof Bay && !((Bay) t).isQuarters() && !(aero instanceof SmallCraft)) {
                 transport.merge(((Bay) t).getType(), ((Bay) t).getCapacity(), Double::sum);
             }
         }
+        for (Map.Entry<String, Integer> e : seating.entrySet()) {
+            sj.add(e.getValue() + " " + ((e.getValue() == 1) ?
+                    e.getKey().replace("Seats", "Seat") : e.getKey()));
+        }
         for (Map.Entry<String, Double> e : transport.entrySet()) {
-            sj.add(e.getKey() + " (" + DecimalFormat.getInstance().format(e.getValue())
-                    + ((e.getValue() == 1)? " ton)" : " tons)"));
+            sj.add(e.getKey() + " (" + formatWeight(e.getValue()) + ")");
         }
         return sj.toString();
     }

--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -198,7 +198,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
         setTextField(MP_JUMP, formatJump());
         if (getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
             setTextField(TONNAGE, NumberFormat.getInstance()
-                    .format((int) getEntity().getWeight() * 1000) + " kg");
+                    .format((int) (getEntity().getWeight() * 1000)) + " kg");
         } else {
             setTextField(TONNAGE, NumberFormat.getInstance().format((int) getEntity().getWeight()));
         }

--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -178,7 +178,12 @@ public abstract class PrintEntity extends PrintRecordSheet {
         setTextField(MP_WALK, formatWalk());
         setTextField(MP_RUN, formatRun());
         setTextField(MP_JUMP, formatJump());
-        setTextField(TONNAGE, NumberFormat.getInstance().format((int) getEntity().getWeight()));
+        if (getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+            setTextField(TONNAGE, NumberFormat.getInstance()
+                    .format((int) getEntity().getWeight() * 1000) + " kg");
+        } else {
+            setTextField(TONNAGE, NumberFormat.getInstance().format((int) getEntity().getWeight()));
+        }
         setTextField(TECH_BASE, formatTechBase());
         setTextField(RULES_LEVEL, formatRulesLevel());
         setTextField(ERA, formatEra(getEntity().getYear()));

--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -167,7 +167,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
             return DecimalFormat.getInstance().format(weight * 1000) + " kg";
         } else {
             return DecimalFormat.getInstance().format(weight)
-                    + ((weight == 1)? " ton)" : " tons");
+                    + ((weight == 1) ? " ton)" : " tons");
         }
     }
     

--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -16,6 +16,7 @@ package megameklab.com.printing;
 import java.awt.geom.Rectangle2D;
 import java.awt.print.PageFormat;
 import java.io.File;
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.*;
 
@@ -151,6 +152,23 @@ public abstract class PrintEntity extends PrintRecordSheet {
      */
     public String formatTacticalFuel() {
         return "";
+    }
+
+    /**
+     * Converts a weight to a String, either in kg or tons as appropriate to the Entity,
+     * labeled with the measurement unit.
+     * @param weight The weight in tons
+     * @return       The formatted weight with units
+     */
+    String formatWeight(double weight) {
+        if ((getEntity() instanceof BattleArmor)
+                || (getEntity() instanceof Protomech)
+                || getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+            return DecimalFormat.getInstance().format(weight * 1000) + " kg";
+        } else {
+            return DecimalFormat.getInstance().format(weight)
+                    + ((weight == 1)? " ton)" : " tons");
+        }
     }
     
     @Override

--- a/src/megameklab/com/printing/PrintTank.java
+++ b/src/megameklab/com/printing/PrintTank.java
@@ -177,18 +177,32 @@ public class PrintTank extends PrintEntity {
             sj.add("Basic Fire Control");
         }
         Map<String, Double> transport = new HashMap<>();
+        Map<String, Integer> seating = new HashMap<>();
         for (Transporter t : tank.getTransports()) {
             if (t instanceof TroopSpace) {
                 transport.merge("Infantry Bay", t.getUnused(), Double::sum);
+            } else if (t instanceof StandardSeatCargoBay) {
+                seating.merge(((Bay) t).getType(), (int) ((Bay) t).getCapacity(), Integer::sum);
             } else if (t instanceof Bay) {
                 transport.merge(((Bay) t).getType(), ((Bay) t).getCapacity(), Double::sum);
             }
         }
+        for (Map.Entry<String, Integer> e : seating.entrySet()) {
+            sj.add(e.getValue() + " " + e.getKey());
+        }
         for (Map.Entry<String, Double> e : transport.entrySet()) {
-            sj.add(e.getKey() + " (" + DecimalFormat.getInstance().format(e.getValue())
-                    + ((e.getValue() == 1)? " ton)" : " tons)"));
+            sj.add(e.getKey() + " (" + formatWeight(e.getValue()) + ")");
         }
         return sj.toString();
+    }
+
+    private String formatWeight(double weight) {
+        if (getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+            return DecimalFormat.getInstance().format(weight * 1000) + " kg";
+        } else {
+            return DecimalFormat.getInstance().format(weight)
+                    + ((weight == 1)? " ton)" : " tons");
+        }
     }
 
     @Override

--- a/src/megameklab/com/printing/PrintTank.java
+++ b/src/megameklab/com/printing/PrintTank.java
@@ -188,21 +188,13 @@ public class PrintTank extends PrintEntity {
             }
         }
         for (Map.Entry<String, Integer> e : seating.entrySet()) {
-            sj.add(e.getValue() + " " + e.getKey());
+            sj.add(e.getValue() + " " + ((e.getValue() == 1) ?
+                    e.getKey().replace("Seats", "Seat") : e.getKey()));
         }
         for (Map.Entry<String, Double> e : transport.entrySet()) {
             sj.add(e.getKey() + " (" + formatWeight(e.getValue()) + ")");
         }
         return sj.toString();
-    }
-
-    private String formatWeight(double weight) {
-        if (getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
-            return DecimalFormat.getInstance().format(weight * 1000) + " kg";
-        } else {
-            return DecimalFormat.getInstance().format(weight)
-                    + ((weight == 1)? " ton)" : " tons");
-        }
     }
 
     @Override


### PR DESCRIPTION
1. Show the unit weight in kg instead of rounding tons.
2. Show transport bay capacity in kg instead of fractional tons (following examples in House Liao and House Kurita handbooks).
3. Treat the capacity of standard/pinion/ejection seating as the number of seats rather than the capacity in tons.

Fixes #726
Fixes #756