### PR TITLE
Don't adjust crit indices when removing one-shot ammo.

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2065,23 +2065,8 @@ public class UnitUtil {
         }
 
         for (Mounted mount : ammoList) {
-            int index = unit.getEquipment().indexOf(mount);
             unit.getEquipment().remove(mount);
             unit.getAmmo().remove(mount);
-
-            for (int location = 0; location <= Mech.LOC_LLEG; location++) {
-                for (int slot = 0; slot < unit.getNumberOfCriticals(location); slot++) {
-                    CriticalSlot cs = unit.getCritical(location, slot);
-                    if ((cs == null)
-                            || (cs.getType() == CriticalSlot.TYPE_SYSTEM)) {
-                        continue;
-                    }
-
-                    if (cs.getIndex() >= index) {
-                        cs.setIndex(cs.getIndex() - 1);
-                    }
-                }
-            }
         }
     }
 


### PR DESCRIPTION
I missed this in a previous change. UnitUtil#removeOneShotAmmo used to be called only for mechs, and I changed it to run on all units. The purpose is to avoid having to deal with the one-shot ammo showing up on various equipment lists. It's safe to remove because it has no effect on construction, isn't written to the unit file, and gets reinitialized on load.

The code that I removed has no effect on mechs, since the index that gets adjusted is the index for system equipment and not the index of the mount in the equipment list. For non-mech units this can throw an indexOutOfRangeException that gets swallowed by the SwingWorker that loads the unit in the background.

Fixes #767 