### PR TITLE
Remove one shot bins that are automatically added with the launcher

### DIFF
--- a/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
@@ -528,6 +528,9 @@ public class EquipmentTab extends ITab implements ActionListener {
                             getAero().addEquipment(mount, Entity.LOC_NONE, false);
                         }
                         equipmentList.addCrit(mount);
+                        if ((equip instanceof WeaponType) && equip.hasFlag(WeaponType.F_ONESHOT)) {
+                            UnitUtil.removeOneShotAmmo(eSource.getEntity());
+                        }
                     }
                 } catch (LocationFullException lfe) {
                     // Shouldn't happen when adding to LOC_NONE

--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -474,6 +474,9 @@ public class EquipmentTab extends ITab implements ActionListener {
             try {
                 mount = new Mounted(getMech(), equip);
                 getMech().addEquipment(mount, Entity.LOC_NONE, false);
+                if ((equip instanceof WeaponType) && equip.hasFlag(WeaponType.F_ONESHOT)) {
+                    UnitUtil.removeOneShotAmmo(eSource.getEntity());
+                }
                 success = true;
             } catch (LocationFullException lfe) {
                 // this can't happen, we add to Entity.LOC_NONE

--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -462,6 +462,9 @@ public class EquipmentTab extends ITab implements ActionListener {
                     loc = Tank.LOC_BODY;
                 }
                 getTank().addEquipment(mount, loc, false);
+                if ((equip instanceof WeaponType) && equip.hasFlag(WeaponType.F_ONESHOT)) {
+                    UnitUtil.removeOneShotAmmo(eSource.getEntity());
+                }
                 success = true;
             } catch (LocationFullException lfe) {
                 // this can't happen, we add to Entity.LOC_NONE

--- a/src/megameklab/com/ui/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/tabs/EquipmentTab.java
@@ -575,6 +575,10 @@ public class EquipmentTab extends ITab implements ActionListener {
                         eSource.getEntity().addEquipment(mount, Entity.LOC_NONE, false);
                     }
                     equipmentList.addCrit(mount);
+                    if ((equip instanceof WeaponType) && (equip.hasFlag(WeaponType.F_ONESHOT)
+                            || (((WeaponType) equip).getAmmoType() == AmmoType.T_INFANTRY))) {
+                        UnitUtil.removeOneShotAmmo(eSource.getEntity());
+                    }
                 }
             }
         } catch (LocationFullException ex) {


### PR DESCRIPTION
More one-shot and small SV ammo cleanup. The ammo bin is automatically added when the launcher is, and it shows up on the installed equipment list on the equipment tab when it refreshes. Following the approach that has been part of MML for some time, we remove them as irrelevant to construction.