### PR TITLE
Small fixed wing SV corrections

### DIFF
--- a/src/megameklab/com/printing/StandardInventoryEntry.java
+++ b/src/megameklab/com/printing/StandardInventoryEntry.java
@@ -425,7 +425,7 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
     public String getShortField(int row) {
         if (mount.getEntity().isAero() && !isMML && !isATM) {
             if ((row == 0) && (mount.getType() instanceof WeaponType)) {
-                return String.valueOf((int) ((WeaponType) mount.getType()).getShortAV() + aeroAVMod(mount));
+                return String.valueOf(((WeaponType) mount.getType()).getRoundShortAV() + aeroAVMod(mount));
             } else if (row == 0) {
                 return DASH;
             } else {
@@ -442,8 +442,8 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
     public String getMediumField(int row) {
         if (mount.getEntity().isAero() && !isMML && !isATM) {
             if ((row == 0) && (mount.getType() instanceof WeaponType)
-                    && ((WeaponType) mount.getType()).maxRange >= WeaponType.RANGE_MED) {
-                return String.valueOf((int) ((WeaponType) mount.getType()).getMedAV() + aeroAVMod(mount));
+                    && ((WeaponType) mount.getType()).getMaxRange(mount) >= WeaponType.RANGE_MED) {
+                return String.valueOf(((WeaponType) mount.getType()).getRoundMedAV() + aeroAVMod(mount));
             } else if (row == 0) {
                 return DASH;
             } else {
@@ -460,8 +460,8 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
     public String getLongField(int row) {
         if (mount.getEntity().isAero() && !isMML && !isATM) {
             if ((row == 0) && (mount.getType() instanceof WeaponType)
-                    && ((WeaponType) mount.getType()).maxRange >= WeaponType.RANGE_LONG) {
-                return String.valueOf((int) ((WeaponType) mount.getType()).getLongAV() + aeroAVMod(mount));
+                    && ((WeaponType) mount.getType()).getMaxRange(mount) >= WeaponType.RANGE_LONG) {
+                return String.valueOf(((WeaponType) mount.getType()).getRoundLongAV() + aeroAVMod(mount));
             } else if (row == 0) {
                 return DASH;
             } else {
@@ -478,8 +478,8 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
     public String getExtremeField(int row) {
         if (mount.getEntity().isAero() && !isMML && !isATM) {
             if ((row == 0) && (mount.getType() instanceof WeaponType)
-                    && ((WeaponType) mount.getType()).maxRange >= WeaponType.RANGE_EXT) {
-                return String.valueOf((int) ((WeaponType) mount.getType()).getExtAV() + aeroAVMod(mount));
+                    && ((WeaponType) mount.getType()).getMaxRange(mount) >= WeaponType.RANGE_EXT) {
+                return String.valueOf(((WeaponType) mount.getType()).getRoundExtAV() + aeroAVMod(mount));
             } else if (row == 0) {
                 return DASH;
             } else {

--- a/src/megameklab/com/printing/StandardInventoryEntry.java
+++ b/src/megameklab/com/printing/StandardInventoryEntry.java
@@ -268,6 +268,11 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
         if (mount.getEntity().isAero()) {
             name.append(" ").append(StringUtils.getAeroEquipmentInfo(mount));
         }
+        if (mount.getEntity().isSupportVehicle() && mount.getType() instanceof InfantryWeapon) {
+            name.append(" [")
+                    .append((int) mount.getSize() * ((InfantryWeapon) mount.getType()).getShots())
+                    .append(" shots]");
+        }
         return name.toString();
     }
 

--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -341,7 +341,7 @@ public class EquipmentTableModel extends AbstractTableModel {
         } else if (col == COL_RANGE) {
             if (null != wtype) {
                 if (entity instanceof Aero) {
-                    switch (wtype.maxRange) {
+                    switch (wtype.getMaxRange(null)) {
                         case RangeType.RANGE_SHORT:
                             return "Short";
                         case RangeType.RANGE_MEDIUM:
@@ -452,10 +452,10 @@ public class EquipmentTableModel extends AbstractTableModel {
         // Aeros should print AV instead
         if (isAero) {
             int[] attackValue = new int[RangeType.RANGE_EXTREME + 1];
-            attackValue[RangeType.RANGE_SHORT] = (int)wtype.getShortAV();
-            attackValue[RangeType.RANGE_MEDIUM] = (int)wtype.getMedAV();
-            attackValue[RangeType.RANGE_LONG] = (int)wtype.getLongAV();
-            attackValue[RangeType.RANGE_EXTREME] = (int)wtype.getExtAV();
+            attackValue[RangeType.RANGE_SHORT] = wtype.getRoundShortAV();
+            attackValue[RangeType.RANGE_MEDIUM] = wtype.getRoundMedAV();
+            attackValue[RangeType.RANGE_LONG] = wtype.getRoundLongAV();
+            attackValue[RangeType.RANGE_EXTREME] = wtype.getRoundExtAV();
             boolean allEq = true;
             for (int i = 2; i <= wtype.maxRange; i++) {
                 if (attackValue[i - 1] != attackValue[i]) {

--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -457,7 +457,7 @@ public class EquipmentTableModel extends AbstractTableModel {
             attackValue[RangeType.RANGE_LONG] = wtype.getRoundLongAV();
             attackValue[RangeType.RANGE_EXTREME] = wtype.getRoundExtAV();
             boolean allEq = true;
-            for (int i = 2; i <= wtype.maxRange; i++) {
+            for (int i = 2; i <= wtype.getMaxRange(null); i++) {
                 if (attackValue[i - 1] != attackValue[i]) {
                     allEq = false;
                     break;
@@ -466,7 +466,7 @@ public class EquipmentTableModel extends AbstractTableModel {
             StringBuilder avString = new StringBuilder();
             avString.append(attackValue[RangeType.RANGE_SHORT]);
             if (!allEq) {
-                for (int i = 2; i <= wtype.maxRange; i++) {
+                for (int i = 2; i <= wtype.getMaxRange(null); i++) {
                     avString.append('/').append(attackValue[i]);
                 }
             }

--- a/src/megameklab/com/util/StringUtils.java
+++ b/src/megameklab/com/util/StringUtils.java
@@ -31,8 +31,6 @@ import megamek.common.weapons.battlearmor.CLBALBX;
 import megamek.common.weapons.battlearmor.CLBAPulseLaserMicro;
 import megamek.common.weapons.battlearmor.CLBAPulseLaserSmall;
 import megamek.common.weapons.battlearmor.ISBALaserPulseSmall;
-import megamek.common.weapons.battlearmor.ISBALaserVSPMedium;
-import megamek.common.weapons.battlearmor.ISBALaserVSPSmall;
 import megamek.common.weapons.battlearmor.ISBAPopUpMineLauncher;
 import megamek.common.weapons.defensivepods.BPodWeapon;
 import megamek.common.weapons.flamers.FlamerWeapon;
@@ -252,7 +250,7 @@ public class StringUtils {
         if (mount.getType() instanceof WeaponType) {
             WeaponType weapon = (WeaponType) mount.getType();
             if (weapon instanceof InfantryWeapon) {
-                info = Integer.toString(weapon.getDamage());
+                info = "";
                 if (weapon.hasFlag(WeaponType.F_BALLISTIC)) {
                     info += " (B)";
                 } else if (weapon.hasFlag(WeaponType.F_ENERGY)) {


### PR DESCRIPTION
This is a companion PR to MegaMek/megamek#2293. It uses aero stats instead of ground stats for small fixed wing support vehicles on the master equipment table and on the record sheet. It also shows the number of shots of ammo for each weapon in the inventory, which is needed for all small support vehicles.