### PR TITLE
Apply primitive armor multiplier to SC/DS free armor from SI

### DIFF
--- a/src/megameklab/com/ui/view/ArmorAllocationView.java
+++ b/src/megameklab/com/ui/view/ArmorAllocationView.java
@@ -238,7 +238,7 @@ public class ArmorAllocationView extends BuildView implements
         int raw = (int) (UnitUtil.getRawArmorPoints(en, en.getLabArmorTonnage())
                 + UnitUtil.getSIBonusArmorPoints(en));
         int currentPoints = en.getTotalOArmor();
-        int armorPoints = 0;
+        int armorPoints;
         if (showPatchwork) {
             armorPoints = currentPoints;
             raw = currentPoints;

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1595,17 +1595,16 @@ public class UnitUtil {
      *               is usually divided evenly among armor facings.
      */
     public static double getSIBonusArmorPoints(Entity entity) {
+        double points = 0.0;
         if (entity.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)) {
-            return ((SmallCraft)entity).getSI() * (entity.locations() - 1);
+            points = ((SmallCraft)entity).getSI() * (entity.locations() - 1);
         } else if (entity.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
-            double points = Math.round(((Jumpship) entity).getSI() / 10.0) * 6;
-            if (((Jumpship) entity).isPrimitive()) {
-                return Math.floor(points * EquipmentType.getArmorPointMultiplier(EquipmentType.T_ARMOR_PRIMITIVE_AERO));
-            } else {
-                return points;
-            }
+            points = Math.round(((Jumpship) entity).getSI() / 10.0) * 6;
+        }
+        if (entity.isPrimitive()) {
+            return points * EquipmentType.getArmorPointMultiplier(EquipmentType.T_ARMOR_PRIMITIVE_AERO);
         } else {
-            return 0;
+            return points;
         }
     }
 


### PR DESCRIPTION
See MegaMek/megamek#2299. This corrects the method used by the armor allocation view to display total armor points available and points remaining to be allocated. In researching this I discovered in the IO errata that the points from armor tonnage and SI should be combined before applying the primitive multiplier, rather than separately and rounded before combining, so there's a more general correction here that affects primitive jumpships as well. The fractional amount is retained here and the rounding is applied after the values have been added.

Fixes #752