### PR TITLE
Early primitive dropship/small craft date fix

### DIFF
--- a/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStructureTab.java
@@ -398,6 +398,7 @@ public class DropshipStructureTab extends ITab implements DropshipBuildListener,
             } else {
                 ((Dropship) getSmallCraft()).setCollarType(Dropship.COLLAR_STANDARD);
             }
+            getEntity().recalculateTechAdvancement();
         }
         refresh.refreshSummary();
         refresh.refreshPreview();

--- a/src/megameklab/com/ui/view/DropshipChassisView.java
+++ b/src/megameklab/com/ui/view/DropshipChassisView.java
@@ -237,6 +237,8 @@ public class DropshipChassisView extends BuildView implements ActionListener, Ch
             } else {
                 chkKFBoom.setSelected(false);
                 chkKFBoom.setEnabled(false);
+                // ActionListener does not respond to setSelected.
+                listeners.forEach(l -> l.kfBoomChanged(chkKFBoom.isSelected()));
             }
         } else {
             chkKFBoom.setVisible(false);

--- a/src/megameklab/com/ui/view/MVFArmorView.java
+++ b/src/megameklab/com/ui/view/MVFArmorView.java
@@ -297,13 +297,16 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
             chkPatchwork.setVisible(false);
             chkPatchwork.setSelected(false);
         }
-        if (null == prev) {
+        if ((null == prev) && (cbArmorType.getModel().getSize() > 0)) {
             cbArmorType.setSelectedIndex(cbArmorType.getModel().getSize() - 1);
         } else {
             cbArmorType.setSelectedItem(prev);
         }
         cbArmorType.addActionListener(this);
-        if ((null != prev) && (cbArmorType.getSelectedIndex() < 0)) {
+        /* If there was a type previously set and nothing is selected, the previous choice
+         * is not in the list. Select the first in the list after the listener is restored
+         * to make sure the Entity is updated. */
+        if ((null != prev) && (cbArmorType.getSelectedIndex() < 0) && (cbArmorType.getModel().getSize() > 0)) {
             cbArmorType.setSelectedIndex(0);
         }
         cbArmorType.showTechBase(techManager.useMixedTech());

--- a/src/megameklab/com/util/MenuBarCreator.java
+++ b/src/megameklab/com/util/MenuBarCreator.java
@@ -915,19 +915,19 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         if (en instanceof Tank) {
             parentFrame.createNewUnit(Entity.ETYPE_TANK);
         } else if (en instanceof Mech) {
-            parentFrame.createNewUnit(Entity.ETYPE_BIPED_MECH, ((Mech)en).isPrimitive(), ((Mech)en).isIndustrial());
+            parentFrame.createNewUnit(Entity.ETYPE_BIPED_MECH, en.isPrimitive(), ((Mech)en).isIndustrial());
         } else if (en.hasETypeFlag(Entity.ETYPE_DROPSHIP)) {
-            parentFrame.createNewUnit(Entity.ETYPE_DROPSHIP);
+            parentFrame.createNewUnit(Entity.ETYPE_DROPSHIP, en.isPrimitive());
         } else if (en.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)) {
-            parentFrame.createNewUnit(Entity.ETYPE_SMALL_CRAFT, ((Aero)en).isPrimitive());
+            parentFrame.createNewUnit(Entity.ETYPE_SMALL_CRAFT, en.isPrimitive());
         } else if (en.hasETypeFlag(Entity.ETYPE_SPACE_STATION)) {
             parentFrame.createNewUnit(Entity.ETYPE_SPACE_STATION);
         } else if (en.hasETypeFlag(Entity.ETYPE_WARSHIP)) {
-            parentFrame.createNewUnit(Entity.ETYPE_WARSHIP, ((Aero)en).isPrimitive());
+            parentFrame.createNewUnit(Entity.ETYPE_WARSHIP, en.isPrimitive());
         } else if (en.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
             parentFrame.createNewUnit(Entity.ETYPE_JUMPSHIP);
         } else if (parentFrame.getEntity() instanceof Aero) {
-            parentFrame.createNewUnit(Entity.ETYPE_AERO, ((Aero)en).isPrimitive());
+            parentFrame.createNewUnit(Entity.ETYPE_AERO, en.isPrimitive());
         } else if (parentFrame.getEntity() instanceof BattleArmor) {
             parentFrame.createNewUnit(Entity.ETYPE_BATTLEARMOR);
         } else if (parentFrame.getEntity() instanceof Infantry) {


### PR DESCRIPTION
This fixes three issues of four issues related to early primitive dropships and small craft.
1. When setting the year before the introduction of the KF drive boom, the boom is not being removed from the unit or its tech advancement.
2. When there is no armor available at the current tech settings, the armor is left as is instead of throwing an exception. This shouldn't happen, but there is an inconsistency between the published production dates of primitive DS/SC and primitive aerospace armor that makes the armor experimental for a century after the unit becomes advanced when using variable tech dates. Besides that, it's just better to handle it more gracefully.
3. Resetting the unit is currently taking you from primitive to standard.

The other issue is resolved by MegaMek/megamek#2316.

Fixes #765