### PR TITLE
Add an outline to PDF output

### DIFF
--- a/src/megameklab/com/printing/PrintCompositeTankSheet.java
+++ b/src/megameklab/com/printing/PrintCompositeTankSheet.java
@@ -17,6 +17,7 @@
  */
 package megameklab.com.printing;
 
+import megamek.common.Entity;
 import megamek.common.Tank;
 import megamek.common.VTOL;
 import megamek.common.annotations.Nullable;
@@ -26,6 +27,7 @@ import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import java.awt.print.PageFormat;
+import java.util.stream.Collectors;
 
 /**
  * Creates a single-page record sheet for two vehicles. If only one vehicle is provided,
@@ -62,6 +64,15 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
      */
     public PrintCompositeTankSheet(Tank tank1, @Nullable Tank tank2, int startPage) {
         this(tank1, tank2, startPage, new RecordSheetOptions());
+    }
+
+    @Override
+    public String getSheetName() {
+        String name = tank1.getShortNameRaw();
+        if ((tank2 != null) && !tank2.getShortNameRaw().equals(tank1.getShortNameRaw())) {
+            name += tank2.getShortNameRaw();
+        }
+        return name;
     }
 
     @Override
@@ -128,6 +139,11 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
         protected String getRecordSheetTitle() {
             return "";
         }
+
+        @Override
+        public String getSheetName() {
+            return "";
+        }
     }
 
     private static class VTOLTables extends PrintRecordSheet {
@@ -143,6 +159,11 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
 
         @Override
         protected String getRecordSheetTitle() {
+            return "";
+        }
+
+        @Override
+        public String getSheetName() {
             return "";
         }
     }

--- a/src/megameklab/com/printing/PrintCompositeTankSheet.java
+++ b/src/megameklab/com/printing/PrintCompositeTankSheet.java
@@ -17,7 +17,6 @@
  */
 package megameklab.com.printing;
 
-import megamek.common.Entity;
 import megamek.common.Tank;
 import megamek.common.VTOL;
 import megamek.common.annotations.Nullable;
@@ -27,7 +26,9 @@ import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import java.awt.print.PageFormat;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Creates a single-page record sheet for two vehicles. If only one vehicle is provided,
@@ -67,12 +68,13 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
     }
 
     @Override
-    public String getSheetName() {
-        String name = tank1.getShortNameRaw();
+    public List<String> getBookmarkNames() {
+        List<String> retVal = new ArrayList<>();
+        retVal.add(tank1.getShortNameRaw());
         if ((tank2 != null) && !tank2.getShortNameRaw().equals(tank1.getShortNameRaw())) {
-            name += tank2.getShortNameRaw();
+            retVal.add(tank2.getShortNameRaw());
         }
-        return name;
+        return retVal;
     }
 
     @Override
@@ -141,8 +143,8 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
         }
 
         @Override
-        public String getSheetName() {
-            return "";
+        public List<String> getBookmarkNames() {
+            return Collections.emptyList();
         }
     }
 
@@ -163,8 +165,8 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
         }
 
         @Override
-        public String getSheetName() {
-            return "";
+        public List<String> getBookmarkNames() {
+            return Collections.emptyList();
         }
     }
 }

--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -71,8 +71,8 @@ public abstract class PrintEntity extends PrintRecordSheet {
     public abstract Entity getEntity();
 
     @Override
-    public String getSheetName() {
-        return getEntity().getShortNameRaw();
+    public List<String> getBookmarkNames() {
+        return Collections.singletonList(getEntity().getShortNameRaw());
     }
     
     /**

--- a/src/megameklab/com/printing/PrintEntity.java
+++ b/src/megameklab/com/printing/PrintEntity.java
@@ -69,6 +69,11 @@ public abstract class PrintEntity extends PrintRecordSheet {
     }
 
     public abstract Entity getEntity();
+
+    @Override
+    public String getSheetName() {
+        return getEntity().getShortNameRaw();
+    }
     
     /**
      * When printing from a MUL the pilot data is filled in unless the option has been disabled. This

--- a/src/megameklab/com/printing/PrintRecordSheet.java
+++ b/src/megameklab/com/printing/PrintRecordSheet.java
@@ -56,6 +56,7 @@ import java.io.*;
 import java.net.URLConnection;
 import java.time.LocalDate;
 import java.util.*;
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -407,9 +408,11 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
     protected abstract String getRecordSheetTitle();
 
     /**
-     * @return The title of the page that would be shown in a table of contents
+     * Used to build an outline of a PDF document
+     *
+     * @return Names of outline entries
      */
-    public abstract String getSheetName();
+    public abstract List<String> getBookmarkNames();
     
     protected void setTextField(String id, int i) {
         setTextField(id, String.valueOf(i));

--- a/src/megameklab/com/printing/PrintRecordSheet.java
+++ b/src/megameklab/com/printing/PrintRecordSheet.java
@@ -405,6 +405,11 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
      * @return The title to use for the record sheet
      */
     protected abstract String getRecordSheetTitle();
+
+    /**
+     * @return The title of the page that would be shown in a table of contents
+     */
+    public abstract String getSheetName();
     
     protected void setTextField(String id, int i) {
         setTextField(id, String.valueOf(i));

--- a/src/megameklab/com/printing/PrintSmallUnitSheet.java
+++ b/src/megameklab/com/printing/PrintSmallUnitSheet.java
@@ -58,8 +58,8 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
     }
 
     @Override
-    public String getSheetName() {
-        return entities.stream().map(Entity::getShortNameRaw).distinct().collect(Collectors.joining(", "));
+    public List<String> getBookmarkNames() {
+        return entities.stream().map(Entity::getShortNameRaw).distinct().collect(Collectors.toList());
     }
 
     @Override

--- a/src/megameklab/com/printing/PrintSmallUnitSheet.java
+++ b/src/megameklab/com/printing/PrintSmallUnitSheet.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Lays out a record sheet for infantry, BA, or protomechs
@@ -54,6 +55,11 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
      */
     public PrintSmallUnitSheet(Collection<? extends Entity> entities, int startPage) {
         this(entities, startPage, new RecordSheetOptions());
+    }
+
+    @Override
+    public String getSheetName() {
+        return entities.stream().map(Entity::getShortNameRaw).distinct().collect(Collectors.joining(", "));
     }
 
     @Override

--- a/src/megameklab/com/printing/RecordSheetTask.java
+++ b/src/megameklab/com/printing/RecordSheetTask.java
@@ -179,11 +179,11 @@ public abstract class RecordSheetTask extends SwingWorker<Void, Integer> {
         public Void doInBackground() throws Exception {
             PDFMergerUtility merger = new PDFMergerUtility();
             merger.setDestinationFileName(fileName);
-            Map<Integer, String> pageNames = new HashMap<>();
+            Map<Integer, List<String>> bookmarkNames = new HashMap<>();
             Iterator<PrintRecordSheet> iter = sheets.iterator();
             while (iter.hasNext()) {
                 final PrintRecordSheet rs = iter.next();
-                pageNames.put(rs.getFirstPage(), rs.getSheetName());
+                bookmarkNames.put(rs.getFirstPage(), rs.getBookmarkNames());
                 for (int i = 0; i < rs.getPageCount(); i++) {
                     merger.addSource(rs.exportPDF(i, pageFormat));
                 }
@@ -194,11 +194,13 @@ public abstract class RecordSheetTask extends SwingWorker<Void, Integer> {
             PDDocument doc = PDDocument.load(new File(fileName));
             PDDocumentOutline outline = new PDDocumentOutline();
             doc.getDocumentCatalog().setDocumentOutline(outline);
-            for (int pageNum : pageNames.keySet()) {
-                PDOutlineItem bookmark = new PDOutlineItem();
-                bookmark.setDestination(doc.getPage(pageNum));
-                bookmark.setTitle(pageNames.get(pageNum));
-                outline.addLast(bookmark);
+            for (Map.Entry<Integer, List<String>> entry : bookmarkNames.entrySet()) {
+                for (String name : entry.getValue()) {
+                    PDOutlineItem bookmark = new PDOutlineItem();
+                    bookmark.setDestination(doc.getPage(entry.getKey()));
+                    bookmark.setTitle(name);
+                    outline.addLast(bookmark);
+                }
             }
             outline.openNode();
             doc.save(new File(fileName));

--- a/src/megameklab/com/printing/RecordSheetTask.java
+++ b/src/megameklab/com/printing/RecordSheetTask.java
@@ -191,7 +191,9 @@ public abstract class RecordSheetTask extends SwingWorker<Void, Integer> {
             }
             merger.mergeDocuments(MemoryUsageSetting.setupTempFileOnly());
 
-            PDDocument doc = PDDocument.load(new File(fileName));
+            // Load newly created document, add an outline, then write back to the file.
+            File file = new File(fileName);
+            PDDocument doc = PDDocument.load(file);
             PDDocumentOutline outline = new PDDocumentOutline();
             doc.getDocumentCatalog().setDocumentOutline(outline);
             for (Map.Entry<Integer, List<String>> entry : bookmarkNames.entrySet()) {
@@ -203,7 +205,7 @@ public abstract class RecordSheetTask extends SwingWorker<Void, Integer> {
                 }
             }
             outline.openNode();
-            doc.save(new File(fileName));
+            doc.save(file);
             return null;
         }
     }


### PR DESCRIPTION
Since we can now create large record sheet pdf documents, I thought it would be nice to add an outline to the document for quick navigation. Sheets with multiple units per page have an entry for each unique unit on the sheet.

![Screenshot from 2020-10-13 18-19-26](https://user-images.githubusercontent.com/16927464/95926094-0b82dd00-0d81-11eb-8be0-7e7be14133cb.png)
