### PR TITLE
Proper scaling for PDF export

### DIFF
--- a/src/megameklab/com/printing/PaperSize.java
+++ b/src/megameklab/com/printing/PaperSize.java
@@ -71,10 +71,10 @@ public enum PaperSize {
     /**
      * Creates a {@link Paper} instance with the provided margins. Units are in 1/72 inches.
      *
-     * @param left The left margin
-     * @param left The right margin
-     * @param left The top margin
-     * @param left The bottom margin
+     * @param left   The left margin
+     * @param right  The right margin
+     * @param top    The top margin
+     * @param bottom The bottom margin
      * @return A Paper for use with a {@link java.awt.print.PageFormat PageFormat}
      */
     public Paper createPaper(int left, int top, int right, int bottom) {

--- a/src/megameklab/com/printing/PrintRecordSheet.java
+++ b/src/megameklab/com/printing/PrintRecordSheet.java
@@ -344,8 +344,8 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
         TranscoderInput input = new TranscoderInput(getSVGDocument());
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         TranscoderOutput transOutput = new TranscoderOutput(output);
-        transcoder.addTranscodingHint(PDFTranscoder.KEY_HEIGHT, (float) (pageFormat.getHeight() / 0.75));
-        transcoder.addTranscodingHint(PDFTranscoder.KEY_WIDTH, (float) (pageFormat.getWidth() / 0.75));
+        // The default for the transcoder is 96 dpi, but the source document is 72 dpi.
+        transcoder.addTranscodingHint(PDFTranscoder.KEY_PIXEL_UNIT_TO_MILLIMETER, 0.352778f);
         transcoder.transcode(input, transOutput);
 
         if (callback != null) {

--- a/src/megameklab/com/printing/PrintRecordSheet.java
+++ b/src/megameklab/com/printing/PrintRecordSheet.java
@@ -344,6 +344,8 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
         TranscoderInput input = new TranscoderInput(getSVGDocument());
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         TranscoderOutput transOutput = new TranscoderOutput(output);
+        transcoder.addTranscodingHint(PDFTranscoder.KEY_HEIGHT, (float) (pageFormat.getHeight() / 0.75));
+        transcoder.addTranscodingHint(PDFTranscoder.KEY_WIDTH, (float) (pageFormat.getWidth() / 0.75));
         transcoder.transcode(input, transOutput);
 
         if (callback != null) {

--- a/src/megameklab/com/printing/RecordSheetTask.java
+++ b/src/megameklab/com/printing/RecordSheetTask.java
@@ -206,6 +206,7 @@ public abstract class RecordSheetTask extends SwingWorker<Void, Integer> {
             }
             outline.openNode();
             doc.save(file);
+            doc.close();
             return null;
         }
     }


### PR DESCRIPTION
Since I've only dealt with the PDF export on the computer, where the documents can be scaled arbitrarily, I never noticed that the sheets are being generated at 75% scale. After digging through the library code, I eventually figured out that the transcoder assumes the SVG document is 96 dpi, while we are using the screen display standard of 72 dpi. So I changed the conversion factor, and fixed a couple other things I noticed while trying to figure out what's going on.

Fixes #802 