### PR TITLE
Use common print dialog instead of native.

### DIFF
--- a/src/megameklab/com/util/UnitPrintManager.java
+++ b/src/megameklab/com/util/UnitPrintManager.java
@@ -280,7 +280,7 @@ public class UnitPrintManager {
         HashPrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
         aset.add(options.getPaperSize().sizeName);
         aset.add(options.getPaperSize().printableArea);
-        aset.add(DialogTypeSelection.NATIVE);
+        aset.add(DialogTypeSelection.COMMON);
         PrinterJob masterPrintJob = PrinterJob.getPrinterJob();
         if (!masterPrintJob.printDialog(aset)) {
             return;


### PR DESCRIPTION
The documentation for `PrinterDialog#printDialog(PrintRequestAttributeSet)` says that it displays a cross-platform print dialog, but I had at one point set the option to use native instead. The native dialog does not necessarily include a page setup tab. If it doesn't the page prints with 1" margins instead of the default 0.25" margins, with no way to change it.

Fixes #746.