### PR TITLE
Compound sheet margins

### DIFF
--- a/src/megameklab/com/printing/PrintCompositeTankSheet.java
+++ b/src/megameklab/com/printing/PrintCompositeTankSheet.java
@@ -91,12 +91,9 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
     protected void processImage(int startPage, PageFormat pageFormat) {
         PrintRecordSheet sheet = new PrintTank(tank1, getFirstPage(), options);
         sheet.createDocument(startPage, pageFormat);
-        Element g = getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_G_TAG);
-        g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
-                String.format("%s(0 %f)", SVGConstants.SVG_TRANSLATE_VALUE, pageFormat.getImageableY()));
         sheet.hideElement(FOOTER);
-        g.appendChild(getSVGDocument().importNode(sheet.getSVGDocument().getDocumentElement(), true));
-        getSVGDocument().getDocumentElement().appendChild(g);
+        getSVGDocument().getDocumentElement().appendChild(getSVGDocument()
+                .importNode(sheet.getSVGDocument().getDocumentElement(), true));
 
         if (tank2 != null) {
             sheet = new PrintTank(tank2, getFirstPage(), options);
@@ -106,7 +103,7 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
             sheet = new TankTables(options);
         }
         sheet.createDocument(startPage, pageFormat);
-        g = getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_G_TAG);
+        Element g = getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_G_TAG);
         g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
                 String.format("%s(0 %f)", SVGConstants.SVG_TRANSLATE_VALUE,
                         pageFormat.getImageableHeight() * 0.5));

--- a/src/megameklab/com/printing/PrintCompositeTankSheet.java
+++ b/src/megameklab/com/printing/PrintCompositeTankSheet.java
@@ -90,10 +90,15 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
     @Override
     protected void processImage(int startPage, PageFormat pageFormat) {
         PrintRecordSheet sheet = new PrintTank(tank1, getFirstPage(), options);
-        sheet.createDocument(startPage, pageFormat);
+        sheet.createDocument(startPage, pageFormat, false);
+        Element g = getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_G_TAG);
+        g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
+                String.format("%s(%f %f)", SVGConstants.SVG_TRANSLATE_VALUE,
+                        pageFormat.getImageableX(),
+                        pageFormat.getImageableY()));
         sheet.hideElement(FOOTER);
-        getSVGDocument().getDocumentElement().appendChild(getSVGDocument()
-                .importNode(sheet.getSVGDocument().getDocumentElement(), true));
+        g.appendChild(getSVGDocument().importNode(sheet.getSVGDocument().getDocumentElement(), true));
+        getSVGDocument().getDocumentElement().appendChild(g);
 
         if (tank2 != null) {
             sheet = new PrintTank(tank2, getFirstPage(), options);
@@ -102,11 +107,12 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
         } else {
             sheet = new TankTables(options);
         }
-        sheet.createDocument(startPage, pageFormat);
-        Element g = getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_G_TAG);
+        sheet.createDocument(startPage, pageFormat, false);
+        g = getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_G_TAG);
         g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
-                String.format("%s(0 %f)", SVGConstants.SVG_TRANSLATE_VALUE,
-                        pageFormat.getImageableHeight() * 0.5));
+                String.format("%s(%f %f)", SVGConstants.SVG_TRANSLATE_VALUE,
+                        pageFormat.getImageableX(),
+                        pageFormat.getImageableHeight() * 0.5 + pageFormat.getImageableY()));
         g.appendChild(getSVGDocument().importNode(sheet.getSVGDocument().getDocumentElement(), true));
         getSVGDocument().getDocumentElement().appendChild(g);
     }

--- a/src/megameklab/com/printing/PrintRecordSheet.java
+++ b/src/megameklab/com/printing/PrintRecordSheet.java
@@ -283,7 +283,7 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
                 getSVGFileName(pageIndex - firstPage));
     }
 
-    void createDocument(int pageIndex, PageFormat pageFormat) {
+    void createDocument(int pageIndex, PageFormat pageFormat, boolean addMargin) {
         svgDocument = loadTemplate(pageIndex, pageFormat);
         if (null != svgDocument) {
             subFonts((SVGDocument) svgDocument);
@@ -300,9 +300,15 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
             svgRoot.setAttributeNS(null, SVGConstants.SVG_HEIGHT_ATTRIBUTE, String.valueOf(pageFormat.getHeight()));
             Element g = svgDocument.getElementById(RS_TEMPLATE);
             if (g != null) {
-                g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
-                        String.format("%s(%f 0 0 %f %f %f)", SVGConstants.SVG_MATRIX_VALUE,
-                                ratio, ratio, pageFormat.getImageableX(), pageFormat.getImageableY()));
+                if (addMargin) {
+                    g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
+                            String.format("%s(%f 0 0 %f %f %f)", SVGConstants.SVG_MATRIX_VALUE,
+                                    ratio, ratio, pageFormat.getImageableX(), pageFormat.getImageableY()));
+                } else {
+                    g.setAttributeNS(null, SVGConstants.SVG_TRANSFORM_ATTRIBUTE,
+                            String.format("%s(%f %f)", SVGConstants.SVG_SCALE_ATTRIBUTE,
+                                    ratio, ratio));
+                }
             }
             processImage(pageIndex - firstPage, pageFormat);
         }
@@ -314,7 +320,7 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
         
         Graphics2D g2d = (Graphics2D) graphics;
         if (null != g2d) {
-            createDocument(pageIndex, pageFormat);
+            createDocument(pageIndex, pageFormat, true);
             GraphicsNode node = build();
             node.paint(g2d);
             /* Testing code that outputs the generated svg
@@ -335,7 +341,7 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
     }
 
     public InputStream exportPDF(int pageNumber, PageFormat pageFormat) throws TranscoderException, SAXException, IOException, ConfigurationException {
-        createDocument(pageNumber + firstPage, pageFormat);
+        createDocument(pageNumber + firstPage, pageFormat, true);
         DefaultConfigurationBuilder cfgBuilder = new DefaultConfigurationBuilder();
         Configuration cfg = cfgBuilder.build(getClass().getResourceAsStream("fop-config.xml"));
         PDFTranscoder transcoder = new PDFTranscoder();

--- a/src/megameklab/com/printing/PrintSmallUnitSheet.java
+++ b/src/megameklab/com/printing/PrintSmallUnitSheet.java
@@ -73,9 +73,8 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
             Element g = getSVGDocument().getElementById("unit_" + count);
             if (g != null) {
                 PrintEntity sheet = getBlockFor(entity, count);
-                sheet.createDocument(startPage, pageFormat);
+                sheet.createDocument(startPage, pageFormat, false);
                 g.appendChild(getSVGDocument().importNode(sheet.getSVGDocument().getDocumentElement(), true));
-                getSVGDocument().getDocumentElement().appendChild(g);
             }
             count++;
         }


### PR DESCRIPTION
When printing record sheets that have multiple units on them (non-naval vehicles, battlearmor, infantry, protomechs), the margins are applied to each unit and the overall sheet. To solve this I added a parameter to createDocument that controls whether the margins should be added. For tanks, which are basically two complete record sheets on one page, the margin is applied to each unit. For the other types, which have a full page template that has data on where to put each unit, the page gets the margins and the units don't. I also removed a line that was incorrectly moving each group to the top level, which made any scaling applied to the overall page not work.

Fixes #665.