### PR TITLE
Show munition type on record sheet

### DIFF
--- a/src/megameklab/com/printing/InventoryWriter.java
+++ b/src/megameklab/com/printing/InventoryWriter.java
@@ -218,8 +218,6 @@ public class InventoryWriter {
                 if (m.getLocation() != Entity.LOC_NONE) {
                     String shortName = m.getType().getShortName().replace("Ammo", "");
                     shortName = shortName.replace("(Clan)", "");
-                    String munition = ((AmmoType) m.getType()).getSubMunitionName().replace("(Clan) ", "");
-                    shortName = shortName.replace(munition, "");
                     ammo.merge(shortName.trim(), m.getBaseShotsLeft(), Integer::sum);
                 } else if ((sheet.getEntity() instanceof Protomech)
                         && (((AmmoType) m.getType()).getAmmoType() == AmmoType.T_IATM)) {

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -772,14 +772,14 @@ public class PrintMech extends PrintEntity {
             buffer.setLength(buffer.length() - 5);
             buffer.trimToSize();
         }
-        
+/*
         String submunitionName = ammo.getSubMunitionName().replace("(Clan) ", "");
         int index = buffer.indexOf(submunitionName);
         if (index >= 0) {
             buffer.delete(index, index + submunitionName.length());
             buffer.trimToSize();
         }
-
+*/
         // Trim trailing spaces.
         while (buffer.charAt(buffer.length() - 1) == ' ') {
             buffer.setLength(buffer.length() - 1);

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -769,14 +769,6 @@ public class PrintMech extends PrintEntity {
             buffer.setLength(buffer.length() - 5);
             buffer.trimToSize();
         }
-/*
-        String submunitionName = ammo.getSubMunitionName().replace("(Clan) ", "");
-        int index = buffer.indexOf(submunitionName);
-        if (index >= 0) {
-            buffer.delete(index, index + submunitionName.length());
-            buffer.trimToSize();
-        }
-*/
         // Trim trailing spaces.
         while (buffer.charAt(buffer.length() - 1) == ' ') {
             buffer.setLength(buffer.length() - 1);

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -165,8 +165,7 @@ public class PrintMech extends PrintEntity {
             if (si instanceof SVGRectElement) {
                 drawSIPips((SVGRectElement) si);
             } else {
-                MegaMekLab.getLogger().error(this,
-                        "Region siPips does not exist in template or is not a <rect>");
+                MegaMekLab.getLogger().error("Region siPips does not exist in template or is not a <rect>");
             }
         }
         
@@ -333,13 +332,11 @@ public class PrintMech extends PrintEntity {
             SAXDocumentFactory df = new SAXDocumentFactory(impl, parser);
             doc = df.createDocument(f.toURI().toASCIIString(), is);
         } catch (Exception e) {
-            MegaMekLab.getLogger().error(PrintRecordSheet.class,
-                    "Failed to open pip SVG file! Path: " + f.getName());
+            MegaMekLab.getLogger().error("Failed to open pip SVG file! Path: " + f.getName());
             return null;
         }
         if (null == doc) {
-            MegaMekLab.getLogger().error(PrintRecordSheet.class,
-                    "Failed to open pip SVG file! Path: " + f.getName());
+            MegaMekLab.getLogger().error("Failed to open pip SVG file! Path: " + f.getName());
             return null;
         }
         return doc.getElementsByTagName(SVGConstants.SVG_PATH_TAG);


### PR DESCRIPTION
Though each ammo bin is configurable on a per-battle basis, and the munition type is not part of the construction, there are times when showing a specific munition type is helpful:
1. MML ammo has a different number of shots/ton for SRM and LRM ammo, and it's not otherwise clear on the record sheet which is being counted.
2. MekHQ can print sheets that have been configured for a specific battle.

It used to be done this way, but was changed because the munition type often made the text overflow the assigned area. With the work that has been done redoing the layout and improving the way text is positioned, that's no longer an issue -- though the text may be compressed for very long munition names.