### PR TITLE
Increment page count for every PrintAero

### DIFF
--- a/src/megameklab/com/util/UnitPrintManager.java
+++ b/src/megameklab/com/util/UnitPrintManager.java
@@ -196,7 +196,7 @@ public class UnitPrintManager {
                     pageCount += pds.getPageCount();
                     sheets.add(pds);
                 } else {
-                    sheets.add(new PrintAero((Aero) unit, pageCount, options));
+                    sheets.add(new PrintAero((Aero) unit, pageCount++, options));
                 }
             } else if (unit instanceof BattleArmor) {
                 baList.add((BattleArmor) unit);


### PR DESCRIPTION
When creating an instance of PrintAero, used for aerospace and conventional fighters and small craft, the page index is not incremented. This causes an off-by-one error in the PDF index. I double checked the other unit types and this is the only one that I saw that was missing.