### PR TITLE
Adjust elements that were in the right margin on aero sheets.

### DIFF
--- a/data/images/recordsheets/templates_iso/dropship_aerodyne_default.svg
+++ b/data/images/recordsheets/templates_iso/dropship_aerodyne_default.svg
@@ -666,7 +666,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="217.600" id="fluffImage" height="90.720" y="526.900"
                                                                     /><g transform="translate (226.600 0.000)"
-                                                                    ><g transform="translate (252.15791747244367,0.0)"
+                                                                    ><g transform="translate (250.15791747244367,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_iso/dropship_spheroid_default.svg
+++ b/data/images/recordsheets/templates_iso/dropship_spheroid_default.svg
@@ -666,7 +666,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="217.600" id="fluffImage" height="90.720" y="526.900"
                                                                     /><g transform="translate (226.600 0.000)"
-                                                                    ><g transform="translate (252.15791747244367,0.0)"
+                                                                    ><g transform="translate (250.15791747244367,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_iso/fighter_aerospace_default.svg
+++ b/data/images/recordsheets/templates_iso/fighter_aerospace_default.svg
@@ -1917,7 +1917,7 @@
                                                                                         >0</text
                                                                                       ></g
                                                                                     ></g
-                                                                                    ><g id="external_stores" transform="translate (440.033 0.000)"
+                                                                                    ><g id="external_stores" transform="translate (432.534 0.000)"
                                                                                     ><g transform="translate (0.0,0.0)"
                                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 118.967 l 3.749,5.625 l -3.749,5.625 h -118.967 Z"
                                                                                         /><text x="63.233" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="108.152" lengthAdjust="spacingAndGlyphs"

--- a/data/images/recordsheets/templates_iso/fighter_conventional_default.svg
+++ b/data/images/recordsheets/templates_iso/fighter_conventional_default.svg
@@ -1526,7 +1526,7 @@
                                                                                         ></text
                                                                                       ></g
                                                                                     ></g
-                                                                                    ><g id="external_stores" transform="translate (440.033 0.000)"
+                                                                                    ><g id="external_stores" transform="translate (432.534 0.000)"
                                                                                     ><g transform="translate (0.0,0.0)"
                                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 118.967 l 3.749,5.625 l -3.749,5.625 h -118.967 Z"
                                                                                         /><text x="63.233" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="108.152" lengthAdjust="spacingAndGlyphs"

--- a/data/images/recordsheets/templates_iso/jumpship_default.svg
+++ b/data/images/recordsheets/templates_iso/jumpship_default.svg
@@ -660,7 +660,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="217.600" id="fluffImage" height="90.720" y="526.900"
                                                                     /><g transform="translate (226.600 0.000)"
-                                                                    ><g transform="translate (252.15791747244367,0.0)"
+                                                                    ><g transform="translate (250.15791747244367,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_iso/smallcraft_aerodyne_default.svg
+++ b/data/images/recordsheets/templates_iso/smallcraft_aerodyne_default.svg
@@ -661,7 +661,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="217.600" id="fluffImage" height="108.900" y="409.000"
                                                                     /><g transform="translate (226.600 0.000)"
-                                                                    ><g transform="translate (252.15791747244367,0.0)"
+                                                                    ><g transform="translate (250.15791747244367,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_iso/smallcraft_spheroid_default.svg
+++ b/data/images/recordsheets/templates_iso/smallcraft_spheroid_default.svg
@@ -661,7 +661,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="217.600" id="fluffImage" height="108.900" y="409.000"
                                                                     /><g transform="translate (226.600 0.000)"
-                                                                    ><g transform="translate (252.15791747244367,0.0)"
+                                                                    ><g transform="translate (250.15791747244367,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_iso/spacestation_default.svg
+++ b/data/images/recordsheets/templates_iso/spacestation_default.svg
@@ -660,7 +660,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="217.600" id="fluffImage" height="90.720" y="526.900"
                                                                     /><g transform="translate (226.600 0.000)"
-                                                                    ><g transform="translate (252.15791747244367,0.0)"
+                                                                    ><g transform="translate (250.15791747244367,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_iso/warship_default.svg
+++ b/data/images/recordsheets/templates_iso/warship_default.svg
@@ -666,7 +666,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="217.600" id="fluffImage" height="90.720" y="526.900"
                                                                     /><g transform="translate (226.600 0.000)"
-                                                                    ><g transform="translate (252.15791747244367,0.0)"
+                                                                    ><g transform="translate (250.15791747244367,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_us/dropship_aerodyne_default.svg
+++ b/data/images/recordsheets/templates_us/dropship_aerodyne_default.svg
@@ -666,7 +666,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="224.400" id="fluffImage" height="84.720" y="494.400"
                                                                     /><g transform="translate (233.400 0.000)"
-                                                                    ><g transform="translate (262.35791747244366,0.0)"
+                                                                    ><g transform="translate (260.35791747244366,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_us/dropship_spheroid_default.svg
+++ b/data/images/recordsheets/templates_us/dropship_spheroid_default.svg
@@ -666,7 +666,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="224.400" id="fluffImage" height="84.720" y="494.400"
                                                                     /><g transform="translate (233.400 0.000)"
-                                                                    ><g transform="translate (262.35791747244366,0.0)"
+                                                                    ><g transform="translate (260.35791747244366,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_us/fighter_aerospace_default.svg
+++ b/data/images/recordsheets/templates_us/fighter_aerospace_default.svg
@@ -1909,7 +1909,7 @@
                                                                                         >0</text
                                                                                       ></g
                                                                                     ></g
-                                                                                    ><g id="external_stores" transform="translate (457.033 0.000)"
+                                                                                    ><g id="external_stores" transform="translate (449.534 0.000)"
                                                                                     ><g transform="translate (0.0,0.0)"
                                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 118.967 l 3.749,5.625 l -3.749,5.625 h -118.967 Z"
                                                                                         /><text x="63.233" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="108.152" lengthAdjust="spacingAndGlyphs"

--- a/data/images/recordsheets/templates_us/fighter_conventional_default.svg
+++ b/data/images/recordsheets/templates_us/fighter_conventional_default.svg
@@ -1526,7 +1526,7 @@
                                                                                         ></text
                                                                                       ></g
                                                                                     ></g
-                                                                                    ><g id="external_stores" transform="translate (457.033 0.000)"
+                                                                                    ><g id="external_stores" transform="translate (449.534 0.000)"
                                                                                     ><g transform="translate (0.0,0.0)"
                                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 118.967 l 3.749,5.625 l -3.749,5.625 h -118.967 Z"
                                                                                         /><text x="63.233" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="108.152" lengthAdjust="spacingAndGlyphs"

--- a/data/images/recordsheets/templates_us/jumpship_default.svg
+++ b/data/images/recordsheets/templates_us/jumpship_default.svg
@@ -660,7 +660,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="224.400" id="fluffImage" height="84.720" y="494.400"
                                                                     /><g transform="translate (233.400 0.000)"
-                                                                    ><g transform="translate (262.35791747244366,0.0)"
+                                                                    ><g transform="translate (260.35791747244366,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_us/smallcraft_aerodyne_default.svg
+++ b/data/images/recordsheets/templates_us/smallcraft_aerodyne_default.svg
@@ -661,7 +661,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="224.400" id="fluffImage" height="101.400" y="384.000"
                                                                     /><g transform="translate (233.400 0.000)"
-                                                                    ><g transform="translate (262.35791747244366,0.0)"
+                                                                    ><g transform="translate (260.35791747244366,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_us/smallcraft_spheroid_default.svg
+++ b/data/images/recordsheets/templates_us/smallcraft_spheroid_default.svg
@@ -661,7 +661,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="224.400" id="fluffImage" height="101.400" y="384.000"
                                                                     /><g transform="translate (233.400 0.000)"
-                                                                    ><g transform="translate (262.35791747244366,0.0)"
+                                                                    ><g transform="translate (260.35791747244366,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_us/spacestation_default.svg
+++ b/data/images/recordsheets/templates_us/spacestation_default.svg
@@ -660,7 +660,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="224.400" id="fluffImage" height="84.720" y="494.400"
                                                                     /><g transform="translate (233.400 0.000)"
-                                                                    ><g transform="translate (262.35791747244366,0.0)"
+                                                                    ><g transform="translate (260.35791747244366,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text

--- a/data/images/recordsheets/templates_us/warship_default.svg
+++ b/data/images/recordsheets/templates_us/warship_default.svg
@@ -666,7 +666,7 @@
                                                                     ></g
                                                                     ><rect fill="none" x="3.000" width="224.400" id="fluffImage" height="84.720" y="494.400"
                                                                     /><g transform="translate (233.400 0.000)"
-                                                                    ><g transform="translate (262.35791747244366,0.0)"
+                                                                    ><g transform="translate (260.35791747244366,0.0)"
                                                                       ><path fill="#000000" d="M 0,5.625 l 3.749,-5.625 h 76.493 l 3.749,5.625 l -3.749,5.625 h -76.493 Z"
                                                                         /><text x="41.996" y="8.438" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="69.539" lengthAdjust="spacingAndGlyphs"
                                                                         >ARMOR DIAGRAM</text


### PR DESCRIPTION
The bombs inventory on fighter record sheets and the "armor diagram" label on other aerospace sheets prints a little into the right margin. I noticed this while working on aerospace reference tables. This is a data fix that moves them to the correct position.