### PR TITLE
Switch to EquipmentType::equals for AmmoType, etc

### DIFF
--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -733,7 +733,7 @@ public class PrintMech extends PrintEntity {
                 critName.append(shots);
             } else if ((cs.getMount2() != null)
                     && (m.getType() instanceof MiscType) && (m.getType().hasFlag(MiscType.F_HEAT_SINK))
-                    && (m.getType() == cs.getMount2().getType())) {
+                    && (m.getType().equals(cs.getMount2().getType()))) {
                 critName.insert(0, "2 ").append("s");
             } else if ((cs.getMount2() != null)
                     && (m.getType() instanceof MiscType) && (m.getType().hasFlag(MiscType.F_COMPACT_HEAT_SINK))

--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -1085,7 +1085,7 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
             getMech().setOriginalJumpMP(0);
         }
         List<Mounted> jjs = getMech().getMisc().stream()
-                .filter(m -> m.getType() == jumpJet)
+                .filter(m -> jumpJet.equals(m.getType()))
                 .collect(Collectors.toList());
         if (jumpJet.hasFlag(MiscType.F_JUMP_BOOSTER)) {
             if (!getMech().hasWorkingMisc(MiscType.F_JUMP_BOOSTER)) {
@@ -1118,7 +1118,7 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
                 .filter(m -> m.getType().hasFlag(MiscType.F_JUMP_JET)
                         || m.getType().hasFlag(MiscType.F_UMU)
                         || m.getType().hasFlag(MiscType.F_JUMP_BOOSTER))
-                .filter(m -> m.getType() != jumpJet)
+                .filter(m -> !jumpJet.equals(m.getType()))
                 .collect(Collectors.toList());
         jjs.forEach(jj -> UnitUtil.removeMounted(getMech(), jj));
         jumpChanged(panMovement.getJump(), jumpJet);

--- a/src/megameklab/com/ui/protomek/ProtomekStructureTab.java
+++ b/src/megameklab/com/ui/protomek/ProtomekStructureTab.java
@@ -529,7 +529,7 @@ public class ProtomekStructureTab extends ITab implements ProtomekBuildListener,
             getProtomech().setOriginalJumpMP(0);
         }
         List<Mounted> jjs = getProtomech().getMisc().stream()
-                .filter(m -> m.getType() == jumpJet)
+                .filter(m -> jumpJet.equals(m.getType()))
                 .collect(Collectors.toList());
         while (jjs.size() > jumpMP) {
             UnitUtil.removeMounted(getProtomech(), jjs.remove(jjs.size() - 1));
@@ -555,7 +555,7 @@ public class ProtomekStructureTab extends ITab implements ProtomekBuildListener,
         List<Mounted> jjs = getProtomech().getMisc().stream()
                 .filter(m -> m.getType().hasFlag(MiscType.F_JUMP_JET)
                         || m.getType().hasFlag(MiscType.F_UMU))
-                .filter(m -> m.getType() != jumpJet)
+                .filter(m -> !jumpJet.equals(m.getType()))
                 .collect(Collectors.toList());
         jjs.forEach(jj -> UnitUtil.removeMounted(getProtomech(), jj));
         jumpChanged(panMovement.getJump(), jumpJet);
@@ -678,12 +678,12 @@ public class ProtomekStructureTab extends ITab implements ProtomekBuildListener,
 
     @Override
     public void setEnhancement(EquipmentType eq, boolean selected) {
-        if (null ==  eq) {
+        if (null == eq) {
             return;
         }
         if (selected) {
             for (Mounted m : getProtomech().getMisc()) {
-                if (m.getType() == eq) {
+                if (eq.equals(m.getType())) {
                     return;
                 }
             }
@@ -699,7 +699,7 @@ public class ProtomekStructureTab extends ITab implements ProtomekBuildListener,
             }
         } else {
             Optional<Mounted> mounted = getProtomech().getMisc().stream()
-                    .filter(m -> m.getType() == eq).findFirst();
+                    .filter(m -> eq.equals(m.getType())).findFirst();
             if (mounted.isPresent()) {
                 UnitUtil.removeMounted(getProtomech(), mounted.get());
             }

--- a/src/megameklab/com/ui/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/tabs/EquipmentTab.java
@@ -595,7 +595,7 @@ public class EquipmentTab extends ITab implements ActionListener {
 
     private void addProtomechAmmo(EquipmentType ammo, int shots) throws LocationFullException {
         Mounted aMount = getProtomech().getAmmo().stream()
-                .filter(m -> m.getType() == ammo).findFirst().orElse(null);
+                .filter(m -> ammo.equals(m.getType())).findFirst().orElse(null);
         if (null != aMount) {
             aMount.setShotsLeft(aMount.getUsableShotsLeft() + shots);
         } else {

--- a/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
+++ b/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
@@ -338,12 +338,12 @@ public class BayWeaponCriticalTree extends JTree {
      * @param shots The number of shots to remove.
      */
     private void removeAmmo(final Mounted ammo, int shots) {
-        AmmoType at = (AmmoType)ammo.getType();
+        AmmoType at = (AmmoType) ammo.getType();
         ammo.setShotsLeft(ammo.getBaseShotsLeft() - shots);
         Mounted unallocated = UnitUtil.findUnallocatedAmmo(eSource.getEntity(), at);
         for (Mounted m : eSource.getEntity().getAmmo()) {
             if ((m.getLocation() == Entity.LOC_NONE)
-                    && (m.getType() == at)) {
+                    && at.equals(m.getType())) {
                 unallocated = m;
                 break;
             }
@@ -1053,7 +1053,7 @@ public class BayWeaponCriticalTree extends JTree {
             // there.
             if (eq.getType() instanceof AmmoType) {
                 Optional<Mounted> addMount = bay.getBayAmmo().stream().map(n -> eSource.getEntity().getEquipment(n))
-                        .filter(m -> m.getType() == eq.getType()).findFirst();
+                        .filter(m -> eq.getType().equals(m.getType())).findFirst();
                 if (addMount.isPresent()) {
                     addMount.get().setShotsLeft(addMount.get().getBaseShotsLeft() + eq.getBaseShotsLeft());
                     updateAmmoCapacity(addMount.get());
@@ -1110,7 +1110,7 @@ public class BayWeaponCriticalTree extends JTree {
     }
     
     public void addAmmoToBay(Mounted bay, Mounted eq, int shots) {
-        AmmoType at = (AmmoType)eq.getType();
+        AmmoType at = (AmmoType) eq.getType();
         eq.setShotsLeft(eq.getBaseShotsLeft() - shots);
         if (eq.getBaseShotsLeft() <= 0) {
             UnitUtil.removeMounted(eSource.getEntity(), eq);
@@ -1118,7 +1118,7 @@ public class BayWeaponCriticalTree extends JTree {
             updateAmmoCapacity(eq);
         }
         Optional<Mounted> addMount = bay.getBayAmmo().stream().map(n -> eSource.getEntity().getEquipment(n))
-                .filter(m -> m.getType() == at).findFirst();
+                .filter(m -> at.equals(m.getType())).findFirst();
         if (addMount.isPresent()) {
             addMount.get().setShotsLeft(addMount.get().getBaseShotsLeft() + shots);
             updateAmmoCapacity(addMount.get());

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -1284,7 +1284,7 @@ public class UnitUtil {
     public static Mounted findUnallocatedAmmo(Entity unit, EquipmentType at) {
         for (Mounted m : unit.getAmmo()) {
             if ((m.getLocation() == Entity.LOC_NONE)
-                    && (m.getType() == at)
+                    && at.equals(m.getType())
                     && ((m.getLinkedBy() == null)
                             || !m.getLinkedBy().getType().hasFlag(WeaponType.F_ONESHOT))) {
                 return m;


### PR DESCRIPTION
Now that MM uses a consistent definition of EquipmentType::equals, I believe that MML should switch from reference equality to Object::equals.