### PR TITLE
Fix bay weapon and ammo indices after removing equipment

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2507,12 +2507,29 @@ public class UnitUtil {
                 }
             }
         }
+
+        // Removing equipment for construction purposes can shift the equipment indices.
+        // We need to be able to update bay weapon and ammo indices. This includes
+        // weapon bays and machine gun arrays.
+        List<Mounted> oldEquipmentList = new ArrayList<>(unit.getEquipment());
         UnitUtil.removeOneShotAmmo(unit);
 
         if (unit instanceof Mech) {
             UnitUtil.updateLoadedMech((Mech) unit);
         } else if (unit instanceof Aero) {
             UnitUtil.updateLoadedAero((Aero) unit);
+        }
+        // Replace bay weapon and ammo equipment numbers with the current index by looking
+        // up the old index in the old list
+        for (Mounted mounted : unit.getEquipment()) {
+            for (int i = 0; i < mounted.getBayWeapons().size(); i++) {
+                int eqNum = mounted.getBayWeapons().get(i);
+                mounted.getBayWeapons().set(i, unit.getEquipmentNum(oldEquipmentList.get(eqNum)));
+            }
+            for (int i = 0; i < mounted.getBayAmmo().size(); i++) {
+                int eqNum = mounted.getBayAmmo().get(i);
+                mounted.getBayAmmo().set(i, unit.getEquipmentNum(oldEquipmentList.get(eqNum)));
+            }
         }
     }
 


### PR DESCRIPTION
I noticed this while working on the fix for MegaMek/megamek#2195.

When a unit is loaded the one-shot ammo is removed, since in MML anything in LOC_NONE is treated as unallocated and it doesn't have any affect on construction. In mechs spreadable equipment such as endo steel and TSM  is also removed and replaced with multiple single-crit instances so they can be assigned locations separately. Since bay weapons and ammo are stored as the index in the equipment list, removing any equipment closer to the head of the list makes the values invalid. One-shot ammo is also removed as one-shot launchers are added, but since this happens at the tail of the list it has no impact.