### PR TITLE
MegaMek Issue #2465: Ignore crew effects in MP calculations

### DIFF
--- a/src/megameklab/com/printing/PrintInfantry.java
+++ b/src/megameklab/com/printing/PrintInfantry.java
@@ -156,7 +156,7 @@ public class PrintInfantry extends PrintEntity {
                 setTextField(MODE_1, "Mechanized SCUBA");
                 break;
             case INF_MOTORIZED:
-                setTextField(MP_1, formatMovement(infantry.getWalkMP(true, true, false)));
+                setTextField(MP_1, formatMovement(infantry.getWalkMP(true, true, false, true)));
                 setTextField(MODE_1, "Motorized");
                 break;
             case INF_LEG:
@@ -436,7 +436,7 @@ public class PrintInfantry extends PrintEntity {
     }
 
     private String formatGroundMP() {
-        int walk = infantry.getWalkMP(true, true, false);
+        int walk = infantry.getWalkMP(true, true, false, true);
         if (walk == 0) {
             return "0*";
         } else {

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -237,7 +237,7 @@ public class PrintMech extends PrintEntity {
                 hideElement(ASF_PILOTING_SKILL);
             }
         } else if (mech instanceof QuadVee) {
-            setTextField(MP_CRUISE, formatMovement(((QuadVee) mech).getCruiseMP(false, false, false)));
+            setTextField(MP_CRUISE, formatMovement(((QuadVee) mech).getCruiseMP(false, false, false, true)));
             setTextField(MP_FLANK, formatQuadVeeFlank());
             setTextField(LBL_VEE_MODE, ((QuadVee) mech).getMotiveTypeString() + "s");
         }
@@ -594,7 +594,7 @@ public class PrintMech extends PrintEntity {
     }
     
     private String formatQuadVeeFlank() {
-        double baseFlank = ((QuadVee) mech).getCruiseMP(false, false, false);
+        double baseFlank = ((QuadVee) mech).getCruiseMP(false, false, false, true);
         baseFlank *= 1.5;
         double fullFlank;
         if (mech.getSuperCharger() != null) {

--- a/src/megameklab/com/ui/Vehicle/StatusBar.java
+++ b/src/megameklab/com/ui/Vehicle/StatusBar.java
@@ -108,7 +108,7 @@ public class StatusBar extends ITab {
 
     public JLabel movementLabel() {
         int walk = getTank().getOriginalWalkMP();
-        int run = getTank().getRunMP(false, true, false);
+        int run = getTank().getRunMP(false, true, false, true);
         int jump = getTank().getOriginalJumpMP();
 
         move.setText("Movement: " + walk + "/" + run + "/" + jump);
@@ -143,7 +143,7 @@ public class StatusBar extends ITab {
 
     public void refresh() {
         int walk = getTank().getOriginalWalkMP();
-        int run = getTank().getRunMP(true, true, false);
+        int run = getTank().getRunMP(false, true, false, true);
         int jump = getTank().getOriginalJumpMP();
         double tonnage = getTank().getWeight();
         double currentTonnage;

--- a/src/megameklab/com/ui/supportvehicle/SVStatusBar.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStatusBar.java
@@ -94,7 +94,7 @@ class SVStatusBar extends ITab {
 
     private JLabel movementLabel() {
         int walk = eSource.getEntity().getOriginalWalkMP();
-        int run = eSource.getEntity().getRunMP(false, true, false);
+        int run = eSource.getEntity().getRunMP(false, true, false, true);
         int jump = eSource.getEntity().getOriginalJumpMP();
 
         move.setText("Movement: " + walk + "/" + run + "/" + jump);
@@ -129,7 +129,7 @@ class SVStatusBar extends ITab {
 
     public void refresh() {
         int walk = eSource.getEntity().getOriginalWalkMP();
-        int run = eSource.getEntity().getRunMP(true, true, false);
+        int run = eSource.getEntity().getRunMP(false, true, false, true);
         int jump = eSource.getEntity().getOriginalJumpMP();
         double tonnage = eSource.getEntity().getWeight();
         double currentTonnage;


### PR DESCRIPTION
This is the MML companion to https://github.com/MegaMek/megamek/issues/2465

If we decide to revert the changes to getWalkMP/getRunMP, this PR will be obsolete in most respects.

However, I did notice that Tanks and Support Vees had some inconsistency in how they asked the entity to calculate their Run MP. I don't think this matters in practice for MML, as there is no IGame object (I do not believe), but would be worth cleaning up. 