### PR TITLE
Reduce crit cost for superheavy patchwork armor

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -1360,6 +1360,9 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
                 }
                 break;
         }
+        if (getMech().isSuperHeavy()) {
+            crits = (crits + 1) / 2;
+        }
         if (getMech().getEmptyCriticals(location) < crits) {
             JOptionPane .showMessageDialog(
                     null, armor.getName()


### PR DESCRIPTION
Superheavy mechs have double-sized crits, so the number of crits taken up by patchwork armor should be divided by two, rounded up.

Fixes #841 