### PR TITLE
Retain and update Clan CASE

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -388,7 +388,8 @@ public class EquipmentTab extends ITab implements ActionListener {
                             && !etype.hasSubType(MiscType.S_SUPERCHARGER))
                     || ((getMech().getEntityType() & Entity.ETYPE_QUADVEE) == Entity.ETYPE_QUADVEE
                         && etype.hasFlag(MiscType.F_TRACKS))
-                    || UnitUtil.isArmorOrStructure(etype)) {
+                    || UnitUtil.isArmorOrStructure(etype)
+                    || (etype.hasFlag(MiscType.F_CASE) && etype.isClan())) {
                 continue;
             }
             //if (UnitUtil.isUnitEquipment(mount.getType(), unit) || UnitUtil.isUn) {

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2534,7 +2534,6 @@ public class UnitUtil {
     }
 
     public static void updateLoadedMech(Mech unit) {
-        UnitUtil.removeClanCase(unit);
         UnitUtil.expandUnitMounts(unit);
         UnitUtil.checkArmor(unit);
     }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -423,6 +423,9 @@ public class UnitUtil {
             boolean rearMounted) throws LocationFullException {
         unit.addEquipment(mounted, loc, rearMounted);
         mounted.setOmniPodMounted(canPodMount(unit, mounted));
+        if (mounted.getType().isExplosive(mounted, true) && (unit instanceof Mech) && unit.isClan()) {
+            ((Mech) unit).addClanCase();
+        }
     }
 
     /**
@@ -1226,6 +1229,9 @@ public class UnitUtil {
             } catch (EntityLoadingException ignored) {
                 // Exception thrown for not having equipment to link to yet, which is acceptable here
             }
+        }
+        if (eq.getType().isExplosive(eq, true) && (unit instanceof Mech) && unit.isClan()) {
+            ((Mech) unit).addClanCase();
         }
     }
 


### PR DESCRIPTION
MML removes Clan CASE from mechs when they are loaded, presumably to keep it from showing up in the installed equipment list. This causes an unforeseen side effect from some of my recent work on BV calculations in MM, assigning an explosive equipment penalty when there shouldn't be one. MM used to base the check on an assumption that all Clan mechs have CASE installed automatically, though the rules state that Clan CASE can be omitted to reduce cost. Though we don't support that at this point, the BV calculation implementation is ready for it.

To fix it I removed the line that removes Clan CASE on load, added Clan CASE to the equipment that gets filtered out of the equipment list, and added some code that installs it as necessary when explosive equipment is added to a location. Removing CASE when the last explosive equipment is removed is a more complex problem because it can shift equipment numbers and cause problems with machine gun arrays. This has no effect on BV or the way the unit is saved. It can have an effect on cost calculations, but those are already incorrect and I'm planning to tackle those after BV, post-stable.

Fixes #846