### PR TITLE
Allow MML config to be loaded in memory only

### DIFF
--- a/src/megameklab/com/MegaMekLab.java
+++ b/src/megameklab/com/MegaMekLab.java
@@ -163,7 +163,7 @@ public class MegaMekLab {
         } catch (IOException e) {
             getLogger().warning(MegaMekLab.class, "startup()", "Could not load quirks");
         }
-        new CConfig();
+        CConfig.load();
         UnitUtil.loadFonts();
 
         // Add additional themes

--- a/src/megameklab/com/util/CConfig.java
+++ b/src/megameklab/com/util/CConfig.java
@@ -116,23 +116,10 @@ public class CConfig {
     public static final String RS_SCALE_FACTOR = "rs_scale_factor";
     public static final String RS_SCALE_UNITS = "rs_scale_units";
 
-    private static Properties config;// config. player values.
-
-    // CONSTRUCTOR
-    public CConfig() {
-        
-        if(!new File(CONFIG_DIR).exists()) {
-            new File(CONFIG_DIR).mkdir();
-        }
-        
-        config = setDefaults();
-        // check to see if a config is present. if not, make one.
-        if (!(new File(CONFIG_FILE).exists()) && !(new File(CONFIG_BACKUP_FILE).exists())) {
-            createConfig();
-        }
-
-        CConfig.loadConfigFile();
-    }
+    /**
+     * Player configuration values.
+     */
+    private static Properties config = getDefaults();
 
     // METHODS
     /**
@@ -140,7 +127,7 @@ public class CConfig {
      * players config values, adding any new configs in their default position
      * and ensuring that no config value is even missing.
      */
-    private Properties setDefaults() {
+    private static Properties getDefaults() {
         Properties defaults = new Properties();
 
         // Window Locations
@@ -163,6 +150,15 @@ public class CConfig {
         defaults.setProperty(RS_SCALE_UNITS, RSScale.HEXES.toString());
 
         return defaults;
+    }
+
+    /**
+     * Loads the MegaMekLab configuration.
+     */
+    public static void load() {
+        ensureConfigFileExists();
+
+        loadConfigFile();
     }
 
     /**
@@ -203,17 +199,24 @@ public class CConfig {
             ex.printStackTrace();
         }
     }
+    
+    /**
+     * Creates a new Config file, and directories, if it is missing.
+     */
+    public static void ensureConfigFileExists() {
+        // check to see if a config is present. if not, make one.
+        if (!(new File(CONFIG_FILE).exists()) && !(new File(CONFIG_BACKUP_FILE).exists())) {
+            if(!new File(CONFIG_DIR).exists()) {
+                new File(CONFIG_DIR).mkdir();
+            }
 
-    // Creates a new config file
-    public void createConfig() {
-        try {
-            FileOutputStream fos = new FileOutputStream(CONFIG_FILE);
-            PrintStream ps = new PrintStream(fos);
-
-            ps.close();
-            fos.close();
-        } catch (Exception ex) {
-            System.exit(0);
+            try (FileOutputStream fos = new FileOutputStream(CONFIG_FILE);
+                PrintStream ps = new PrintStream(fos)) {
+                ps.close();
+                fos.close();
+            } catch (Exception ex) {
+                System.exit(0);
+            }
         }
     }
 


### PR DESCRIPTION
This refactors CConfig slightly to allow the MML configuration to be in-memory only, without any disk access. This supports headless usage of MML's printing features which may not live as part of a MM/MML distribution.

MekHQ companion: https://github.com/MegaMek/mekhq/pull/2361