### PR TITLE
Show 2/msl in damage column for all SRM types

### DIFF
--- a/src/megameklab/com/util/EquipmentTableModel.java
+++ b/src/megameklab/com/util/EquipmentTableModel.java
@@ -503,8 +503,12 @@ public class EquipmentTableModel extends AbstractTableModel {
                             return "0";
                     }
                 } else if ((wtype instanceof ATMWeapon) 
-                        ||(wtype.getAmmoType() == AmmoType.T_SRM)  
-                        || (wtype.getAmmoType() == AmmoType.T_SRM_STREAK)) {
+                        ||(wtype.getAmmoType() == AmmoType.T_SRM)
+                        || (wtype.getAmmoType() == AmmoType.T_SRM_STREAK)
+                        || (wtype.getAmmoType() == AmmoType.T_SRM_ADVANCED)
+                        || (wtype.getAmmoType() == AmmoType.T_SRM_IMP)
+                        || (wtype.getAmmoType() == AmmoType.T_SRM_PRIMITIVE)
+                        || (wtype.getAmmoType() == AmmoType.T_SRM_TORPEDO)) {
                     dmg = 2;
                 } else {
                     dmg = 1;


### PR DESCRIPTION
The equipment table shows damage as 2/msl for plain vanilla and streak SRMs, but not for the torpedo version, BA advanced SRMs, early Clan improved SRMs, or primitive SRMs. I think I got them all.

Fixes #861 