### PR TITLE
Moving to fully use isConventionalInfantry

### DIFF
--- a/src/megameklab/com/util/MenuBarCreator.java
+++ b/src/megameklab/com/util/MenuBarCreator.java
@@ -300,7 +300,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             unitMenu.add(item);
         }
 
-        if (!(parentFrame.getEntity() instanceof Infantry) || (parentFrame.getEntity() instanceof BattleArmor)) {
+        if (!parentFrame.getEntity().isConventionalInfantry()) {
             item = new JMenuItem();
             item.setText(resourceMap.getString("menu.file.unitType.infantry"));
             item.setMnemonic(KeyEvent.VK_I);


### PR DESCRIPTION
This is the MegaMekLab part of a full repository swapover from using instanceof to determine if a unit is conventional infantry to the isConventionalInfantry method, which returns true for Infantry and all inheritors outside of BattleArmor and inheritors. It does not rely on the other two branches.

Logic:
(Infantry && !BattleArmor): isConventionalInfantry 
(!Infantry || BattleArmor): !isConventionalInfantry