### PR TITLE
Rear modular armor

### DIFF
--- a/src/megameklab/com/util/Mech/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/Mech/DropTargetCriticalList.java
@@ -303,7 +303,7 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
                             }
                         }
 
-                        if (!(getUnit() instanceof BattleArmor) && canRearMount(mount)) {
+                        if (canRearMount(mount)) {
                             if (!mount.isRearMounted()) {
                                 info = new JMenuItem("Make " + mount.getName()
                                         + " Rear Facing");
@@ -592,6 +592,9 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
     }
 
     private boolean canRearMount(Mounted mount) {
+        if (mount.getEntity() instanceof BattleArmor) {
+            return false;
+        }
         if (mount.getType() instanceof MiscType) {
             if (mount.getType().hasFlag(MiscType.F_MODULAR_ARMOR)) {
                 return (mount.getEntity() instanceof Mech)

--- a/src/megameklab/com/util/Mech/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/Mech/DropTargetCriticalList.java
@@ -123,7 +123,9 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
 
                 final Mounted mount = getMounted();
                 if ((e.getModifiersEx() & InputEvent.ALT_DOWN_MASK) != 0) {
-                    changeWeaponFacing(!mount.isRearMounted());
+                    if (canRearMount(mount)) {
+                        changeWeaponFacing(!mount.isRearMounted());
+                    }
                     return;
                 }
                 

--- a/src/megameklab/com/util/Mech/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/Mech/DropTargetCriticalList.java
@@ -301,11 +301,7 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
                             }
                         }
 
-                        if (!(getUnit() instanceof BattleArmor)
-                                && ((mount.getType() instanceof WeaponType) || ((mount
-                                        .getType() instanceof MiscType) && mount
-                                        .getType()
-                                        .hasFlag(MiscType.F_LIFTHOIST)))) {
+                        if (!(getUnit() instanceof BattleArmor) && canRearMount(mount)) {
                             if (!mount.isRearMounted()) {
                                 info = new JMenuItem("Make " + mount.getName()
                                         + " Rear Facing");
@@ -592,7 +588,20 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
         int location = getCritLocation();
         changeMountStatus(mount, location, rear);
     }
-    
+
+    private boolean canRearMount(Mounted mount) {
+        if (mount.getType() instanceof MiscType) {
+            if (mount.getType().hasFlag(MiscType.F_MODULAR_ARMOR)) {
+                return (mount.getEntity() instanceof Mech)
+                        && ((Mech) mount.getEntity()).locationIsTorso(mount.getLocation());
+            } else {
+                return mount.getType().hasFlag(MiscType.F_LIFTHOIST);
+            }
+        } else {
+            return mount.getType() instanceof WeaponType;
+        }
+    }
+
     private void changeOmniMounting(boolean pod) {
         Mounted mount = getMounted();
         if (!pod || UnitUtil.canPodMount(getUnit(), mount)) {

--- a/src/megameklab/com/util/Mech/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/Mech/DropTargetCriticalList.java
@@ -597,7 +597,9 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
                 return (mount.getEntity() instanceof Mech)
                         && ((Mech) mount.getEntity()).locationIsTorso(mount.getLocation());
             } else {
-                return mount.getType().hasFlag(MiscType.F_LIFTHOIST);
+                return mount.getType().hasFlag(MiscType.F_LIFTHOIST)
+                        || mount.getType().hasFlag(MiscType.F_SPRAYER)
+                        || mount.getType().hasFlag(MiscType.F_LIGHT_FLUID_SUCTION_SYSTEM);
             }
         } else {
             return mount.getType() instanceof WeaponType;


### PR DESCRIPTION
Include a menu item to change facing of torso-mounted modular armor. This also fixes two other issues I discovered in the process:
1. Alt-right click toggles between forward and rear facing on any equipment whether it makes sense or not.
2. The sprayer and light suction system require a firing arc (TM, p. 247) and should be eligible for rear facing.

I double checked MM and verified that a hit against a torso location with modular armor checks the facing.

Fixes #879