### PR TITLE
Do not allow unit selector to become rooted

### DIFF
--- a/src/megameklab/com/ui/StartupGUI.java
+++ b/src/megameklab/com/ui/StartupGUI.java
@@ -36,7 +36,6 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.UIManager;
 
-import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.widget.MegamekButton;
 import megamek.client.ui.swing.widget.SkinSpecification;
 import megamek.client.ui.swing.widget.SkinXMLHandler;
@@ -364,14 +363,8 @@ public class StartupGUI extends javax.swing.JPanel {
     
     private void loadUnit() {
         EquipmentType.initializeTypes();
-        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(frame);
-        unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(frame, unitLoadingDialog);
 
-        Entity newUnit = viewer.getChosenEntity();
-        viewer.setVisible(false);
-        viewer.dispose();
-
+        Entity newUnit = MegaMekLabUnitSelectorDialog.showDialog(frame);
         if (null == newUnit) {
             return;
         }

--- a/src/megameklab/com/ui/dialog/MegaMekLabUnitSelectorDialog.java
+++ b/src/megameklab/com/ui/dialog/MegaMekLabUnitSelectorDialog.java
@@ -24,11 +24,15 @@ import megamek.client.ui.swing.dialog.AbstractUnitSelectorDialog;
 import megamek.common.Entity;
 import megamek.common.MechSummary;
 import megamek.common.TechConstants;
+import megamek.common.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
 
 public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
+
+    private static final long serialVersionUID = -5288332297317618337L;
+    
     //region Variable Declarations
     private Entity chosenEntity;
     //endregion Variable Declarations
@@ -95,5 +99,78 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
      */
     public Entity getChosenEntity() {
         return chosenEntity;
+    }
+
+    /**
+     * Shows the {@code MegaMekLabUnitSelectorDialog} and returns
+     * the selected entity, if any.
+     * @param parentFrame The parent {@link JFrame}.
+     * @return The selected {@link Entity}, or {@code null} if cancelled.
+     */
+    @Nullable
+    public static Entity showDialog(JFrame parentFrame) {
+        Result result = showDialogAndIncludeSummary(parentFrame);
+        return result.getEntity();
+    }
+
+    /**
+     * Shows the {@code MegaMekLabUnitSelectorDialog} and returns
+     * the result of the selection.
+     * @param parentFrame The parent {@link JFrame}.
+     * @return The result of the selection.
+     */
+    public static Result showDialogAndIncludeSummary(JFrame parentFrame) {
+        Entity entity = null;
+        MechSummary mechSummary = null;
+
+        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parentFrame);
+        try {
+            unitLoadingDialog.setVisible(true);
+            
+            MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parentFrame, unitLoadingDialog);
+            try {
+                entity = viewer.getChosenEntity();
+                mechSummary = viewer.getChosenMechSummary();
+
+                viewer.setVisible(false);
+            } finally {
+                viewer.dispose();
+            }
+        } finally {
+            unitLoadingDialog.dispose();
+        }
+
+        return new Result(entity, mechSummary);
+    }
+
+    /**
+     * Represents the result of a unit selection.
+     */
+    public static class Result {
+        private final Entity entity;
+        private final MechSummary mechSummary;
+
+        protected Result(Entity entity, MechSummary mechSummary) {
+            this.entity = entity;
+            this.mechSummary = mechSummary;
+        }
+
+        /**
+         * Gets the selected {@link Entity}, or {@code null}
+         * if the dialog was cancelled.
+         */
+        @Nullable
+        public Entity getEntity() {
+            return entity;
+        }
+
+        /**
+         * Gets the selected {@link MechSummary}, or {@code null}
+         * if the dialog was cancelled.
+         */
+        @Nullable
+        public MechSummary getMechSummary() {
+            return mechSummary;
+        }
     }
 }

--- a/src/megameklab/com/ui/dialog/UnitPrintQueueDialog.java
+++ b/src/megameklab/com/ui/dialog/UnitPrintQueueDialog.java
@@ -40,7 +40,6 @@ import javax.swing.ScrollPaneConstants;
 import javax.swing.WindowConstants;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
-import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.common.Entity;
 import megamek.common.MechFileParser;
 import megameklab.com.util.UnitPrintManager;
@@ -163,13 +162,7 @@ public class UnitPrintQueueDialog extends JDialog implements ActionListener, Key
         }
 
         if (ae.getSource().equals(bSelectCache)) {
-            UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(clientgui);
-            unitLoadingDialog.setVisible(true);
-            MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(clientgui, unitLoadingDialog);
-
-            viewer.setVisible(false);
-            Entity entity = viewer.getChosenEntity();
-
+            Entity entity = MegaMekLabUnitSelectorDialog.showDialog(clientgui);
             if (entity != null) {
                 units.add(entity);
                 refresh();

--- a/src/megameklab/com/util/MenuBarCreator.java
+++ b/src/megameklab/com/util/MenuBarCreator.java
@@ -529,69 +529,50 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private void jMenuGetUnitBVFromCache_actionPerformed() {
-        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parentFrame);
-        unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parentFrame, unitLoadingDialog);
-
-        Entity tempEntity = viewer.getChosenEntity();
-        if(null == tempEntity) {
+        Entity tempEntity = MegaMekLabUnitSelectorDialog.showDialog(parentFrame);
+        if (tempEntity == null) {
             return;
         }
-        tempEntity.calculateBattleValue(true, true);
-        UnitUtil.showBVCalculations(tempEntity.getBVText(), parentFrame);
 
+        tempEntity.calculateBattleValue(true, true);
+
+        UnitUtil.showBVCalculations(tempEntity.getBVText(), parentFrame);
     }
 
     private void jMenuGetUnitValidationFromCache_actionPerformed() {
-        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parentFrame);
-        unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parentFrame, unitLoadingDialog);
-
-        Entity tempEntity = viewer.getChosenEntity();
-        if(null == tempEntity) {
+        Entity tempEntity = MegaMekLabUnitSelectorDialog.showDialog(parentFrame);
+        if (tempEntity == null) {
             return;
         }
-        UnitUtil.showValidation(tempEntity, parentFrame);
 
+        UnitUtil.showValidation(tempEntity, parentFrame);
     }
 
     private void jMenuGetUnitSpecsFromCache_actionPerformed() {
-        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parentFrame);
-        unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parentFrame, unitLoadingDialog);
-
-        Entity tempEntity = viewer.getChosenEntity();
-        if(null == tempEntity) {
+        Entity tempEntity = MegaMekLabUnitSelectorDialog.showDialog(parentFrame);
+        if (tempEntity == null) {
             return;
         }
-        UnitUtil.showUnitSpecs(tempEntity, parentFrame);
 
+        UnitUtil.showUnitSpecs(tempEntity, parentFrame);
     }
 
     private void jMenuGetUnitBreakdownFromCache_actionPerformed() {
-        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parentFrame);
-        unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parentFrame, unitLoadingDialog);
-
-        Entity tempEntity = viewer.getChosenEntity();
-        if(null == tempEntity) {
+        Entity tempEntity = MegaMekLabUnitSelectorDialog.showDialog(parentFrame);
+        if (tempEntity == null) {
             return;
         }
-        UnitUtil.showUnitCostBreakDown(tempEntity, parentFrame);
 
+        UnitUtil.showUnitCostBreakDown(tempEntity, parentFrame);
     }
     
     private void jMenuGetUnitWeightBreakdownFromCache_actionPerformed() {
-        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parentFrame);
-        unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parentFrame, unitLoadingDialog);
-
-        Entity tempEntity = viewer.getChosenEntity();
-        if(null == tempEntity) {
+        Entity tempEntity = MegaMekLabUnitSelectorDialog.showDialog(parentFrame);
+        if (tempEntity == null) {
             return;
         }
-        UnitUtil.showUnitWeightBreakDown(tempEntity, parentFrame);
 
+        UnitUtil.showUnitWeightBreakDown(tempEntity, parentFrame);
     }
 
     private void jMenuGetUnitBVFromFile_actionPerformed() {
@@ -1118,15 +1099,11 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
     }
 
     private void loadUnit() {
-        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parentFrame);
-        unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parentFrame, unitLoadingDialog);
+        MegaMekLabUnitSelectorDialog.Result result 
+                = MegaMekLabUnitSelectorDialog.showDialogAndIncludeSummary(parentFrame);
 
-        Entity newUnit = viewer.getChosenEntity();
-        viewer.setVisible(false);
-        viewer.dispose();
-
-        if (null == newUnit) {
+        Entity newUnit = result.getEntity();
+        if (newUnit == null) {
             return;
         }
 
@@ -1166,13 +1143,13 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
         UnitUtil.updateLoadedUnit(newUnit);
 
-        if (viewer.getChosenMechSummary().getSourceFile().getName().endsWith(".zip")) {
-            String fileName = viewer.getChosenMechSummary().getSourceFile().getAbsolutePath();
+        if (result.getMechSummary().getSourceFile().getName().endsWith(".zip")) {
+            String fileName = result.getMechSummary().getSourceFile().getAbsolutePath();
             fileName = fileName.substring(0, fileName.lastIndexOf(File.separatorChar) + 1);
             fileName = fileName + createUnitFilename(newUnit);
             CConfig.updateSaveFiles(fileName);
         } else {
-            CConfig.updateSaveFiles(viewer.getChosenMechSummary().getSourceFile().getAbsolutePath());
+            CConfig.updateSaveFiles(result.getMechSummary().getSourceFile().getAbsolutePath());
         }
         parentFrame.setEntity(newUnit);
         reload();

--- a/src/megameklab/com/util/UnitPrintManager.java
+++ b/src/megameklab/com/util/UnitPrintManager.java
@@ -36,19 +36,9 @@ import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
-import megamek.client.ui.swing.UnitLoadingDialog;
-import megamek.common.Aero;
-import megamek.common.BattleArmor;
-import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.EntityListFile;
-import megamek.common.EntityMovementMode;
-import megamek.common.Infantry;
-import megamek.common.Jumpship;
-import megamek.common.Mech;
 import megamek.common.MechFileParser;
-import megamek.common.Protomech;
-import megamek.common.Tank;
 import megamek.common.util.EncodeControl;
 import megameklab.com.printing.*;
 import megameklab.com.ui.dialog.MegaMekLabUnitSelectorDialog;
@@ -392,20 +382,13 @@ public class UnitPrintManager {
     }
 
     public static void printSelectedUnit(JFrame parent, boolean pdf) {
-        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parent);
-        unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parent, unitLoadingDialog);
-
-        viewer.setVisible(false);
-        Entity entity = viewer.getChosenEntity();
-
+        Entity entity = MegaMekLabUnitSelectorDialog.showDialog(parent);
         if (entity != null) {
             if (pdf) {
                 exportEntity(entity, parent);
             } else {
                 printEntity(entity);
             }
-            viewer.dispose();
         }
     }
 

--- a/src/megameklab/com/util/UnitPrintManager.java
+++ b/src/megameklab/com/util/UnitPrintManager.java
@@ -36,9 +36,18 @@ import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
+import megamek.common.Aero;
+import megamek.common.BattleArmor;
+import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.EntityListFile;
+import megamek.common.EntityMovementMode;
+import megamek.common.Infantry;
+import megamek.common.Jumpship;
+import megamek.common.Mech;
 import megamek.common.MechFileParser;
+import megamek.common.Protomech;
+import megamek.common.Tank;
 import megamek.common.util.EncodeControl;
 import megameklab.com.printing.*;
 import megameklab.com.ui.dialog.MegaMekLabUnitSelectorDialog;


### PR DESCRIPTION
While debugging memory issues with MML on the new PDF exports branch I noticed N rooted copies of MegaMekLabUnitSelectorDialog due to cached visuals, where N equals the number of times I opened the unit selector. This refactors the launching of the unit selector dialog to ensure the resources are released. They are no longer part of the rooted list.

Before:
![image](https://user-images.githubusercontent.com/8238690/111042362-0b0f7080-840b-11eb-9a61-ff9c245e726c.png)

After:
![image](https://user-images.githubusercontent.com/8238690/111042394-2da18980-840b-11eb-9623-f61e819c0ed8.png)
