### PR TITLE
Exclude xml-apis on Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ repositories {
 
 configurations {
     jarbundler
+
+    all*.exclude group: 'xml-apis', module: 'xml-apis'
 }
 
 dependencies {


### PR DESCRIPTION
Fixes:
```
The package org.w3c.dom is accessible from more than one module: <unnamed>, java.xml
```