### PR TITLE
Industrialmech cockpits

### DIFF
--- a/src/megameklab/com/ui/view/MekChassisView.java
+++ b/src/megameklab/com/ui/view/MekChassisView.java
@@ -521,8 +521,9 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
         } else if (isSuperheavy()) {
             if (isIndustrial()){
                 cbCockpit.addItem(Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL);
-            } else {
-                cbCockpit.addItem(Mech.COCKPIT_SUPERHEAVY);
+            }
+            cbCockpit.addItem(Mech.COCKPIT_SUPERHEAVY);
+            if (techManager.isLegal(Mech.getCockpitTechAdvancement(Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE))) {
                 cbCockpit.addItem(Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE);
             }
         } else if (isPrimitive()) {

--- a/src/megameklab/com/ui/view/MekChassisView.java
+++ b/src/megameklab/com/ui/view/MekChassisView.java
@@ -526,7 +526,15 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
                 cbCockpit.addItem(Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE);
             }
         } else if (isPrimitive()) {
-            cbCockpit.addItem(isIndustrial() ? Mech.COCKPIT_PRIMITIVE_INDUSTRIAL : Mech.COCKPIT_PRIMITIVE);
+            if (isIndustrial()) {
+                cbCockpit.addItem(Mech.COCKPIT_PRIMITIVE_INDUSTRIAL);
+                // If the date is late enough, include primitive cockpit with advanced fire control
+                if (techManager.isLegal(Mech.getCockpitTechAdvancement(Mech.COCKPIT_PRIMITIVE))) {
+                    cbCockpit.addItem(Mech.COCKPIT_PRIMITIVE);
+                }
+            } else {
+                cbCockpit.addItem(Mech.COCKPIT_PRIMITIVE);
+            }
         } else if (isIndustrial()) {
             for (int cockpitType : INDUSTRIAL_COCKPITS) {
                 if (techManager.isLegal(Mech.getCockpitTechAdvancement(cockpitType))) {

--- a/src/megameklab/com/ui/view/MekChassisView.java
+++ b/src/megameklab/com/ui/view/MekChassisView.java
@@ -125,13 +125,17 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
     
     private boolean primitive = false;
     private int engineRating = 20;
-    
+
     private static final int[] GENERAL_COCKPITS = {
             Mech.COCKPIT_STANDARD, Mech.COCKPIT_SMALL, Mech.COCKPIT_COMMAND_CONSOLE,
-            Mech.COCKPIT_SMALL_COMMAND_CONSOLE, Mech.COCKPIT_TORSO_MOUNTED, 
+            Mech.COCKPIT_SMALL_COMMAND_CONSOLE, Mech.COCKPIT_TORSO_MOUNTED,
             Mech.COCKPIT_DUAL, Mech.COCKPIT_INTERFACE, Mech.COCKPIT_VRRP
     };
-    
+
+    private static final int[] INDUSTRIAL_COCKPITS = {
+            Mech.COCKPIT_INDUSTRIAL, Mech.COCKPIT_COMMAND_CONSOLE, Mech.COCKPIT_TORSO_MOUNTED
+    };
+
     private static final String[] ENHANCEMENT_NAMES = {
             EquipmentTypeLookup.IS_MASC, EquipmentTypeLookup.CLAN_MASC,
             EquipmentTypeLookup.TSM, EquipmentTypeLookup.SCM
@@ -515,23 +519,19 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
         } else if (getBaseTypeIndex() == BASE_TYPE_QUADVEE) {
             cbCockpit.addItem(Mech.COCKPIT_QUADVEE);
         } else if (isSuperheavy()) {
-            if(isIndustrial()){
+            if (isIndustrial()){
                 cbCockpit.addItem(Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL);
-                if (techManager.isLegal(Mech.getIndustrialAdvFireConTA())) {
-                    cbCockpit.addItem(Mech.COCKPIT_SUPERHEAVY);
-                    cbCockpit.addItem(Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE);
-                }
-            }else{
+            } else {
                 cbCockpit.addItem(Mech.COCKPIT_SUPERHEAVY);
                 cbCockpit.addItem(Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE);
             }
         } else if (isPrimitive()) {
-            cbCockpit.addItem(isIndustrial()? Mech.COCKPIT_PRIMITIVE_INDUSTRIAL : Mech.COCKPIT_PRIMITIVE);
+            cbCockpit.addItem(isIndustrial() ? Mech.COCKPIT_PRIMITIVE_INDUSTRIAL : Mech.COCKPIT_PRIMITIVE);
         } else if (isIndustrial()) {
-            cbCockpit.addItem(Mech.COCKPIT_INDUSTRIAL);
-            if (techManager.isLegal(Mech.getIndustrialAdvFireConTA())) {
-                cbCockpit.addItem(Mech.COCKPIT_STANDARD);
-                cbCockpit.addItem(Mech.COCKPIT_COMMAND_CONSOLE);
+            for (int cockpitType : INDUSTRIAL_COCKPITS) {
+                if (techManager.isLegal(Mech.getCockpitTechAdvancement(cockpitType))) {
+                    cbCockpit.addItem(cockpitType);
+                }
             }
         } else {
             for (int cockpitType : GENERAL_COCKPITS) {


### PR DESCRIPTION
1. Adds torso-mounted cockpit to list of available cockpits for industrialmechs (TO:AU&E, 112)
2. Makes standard primitive cockpit available to primitive industrialmechs, which is how MM indicates an industrial cockpit with advanced fire control. This is subject to a date check, since primitive industrialmechs predate battlemechs.
3. Fixes the check for command console date and tech level to match the command console itself. The current check for IM advanced fire control does nothing, since the only difference is availability and tech rating.

Fixes #638 