### PR TITLE
Remove prototype heatsinks from equipment tab

### DIFF
--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -552,17 +552,11 @@ public class EquipmentTab extends ITab implements ActionListener {
                 Mech mech = getMech();
                 EquipmentTableModel equipModel = entry.getModel();
                 EquipmentType etype = equipModel.getType(entry.getIdentifier());
-                WeaponType wtype = null;
-                if (etype instanceof WeaponType) {
-                    wtype = (WeaponType)etype;
-                }
-                AmmoType atype = null;
-                if (etype instanceof AmmoType) {
-                    atype = (AmmoType)etype;
-                }
                 if (UnitUtil.isHeatSink(etype) || UnitUtil.isJumpJet(etype)) {
                     return false;
                 }
+                WeaponType wtype = (etype instanceof WeaponType) ? (WeaponType) etype : null;
+                AmmoType atype = (etype instanceof AmmoType) ? (AmmoType) etype : null;
                 if ((etype instanceof MiscType) && (etype.hasFlag(MiscType.F_TSM)
                         || etype.hasFlag(MiscType.F_INDUSTRIAL_TSM)
                         || (etype.hasFlag(MiscType.F_SCM))

--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -544,9 +544,9 @@ public class EquipmentTab extends ITab implements ActionListener {
     }
 
     private void filterEquipment() {
-        RowFilter<EquipmentTableModel, Integer> equipmentTypeFilter = null;
+        RowFilter<EquipmentTableModel, Integer> equipmentTypeFilter;
         final int nType = choiceType.getSelectedIndex();
-        equipmentTypeFilter = new RowFilter<EquipmentTableModel,Integer>() {
+        equipmentTypeFilter = new RowFilter<>() {
             @Override
             public boolean include(Entry<? extends EquipmentTableModel, ? extends Integer> entry) {
                 Mech mech = getMech();
@@ -560,7 +560,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                 if (etype instanceof AmmoType) {
                     atype = (AmmoType)etype;
                 }
-                if (UnitUtil.isHeatSink(etype, true) || UnitUtil.isJumpJet(etype)) {
+                if (UnitUtil.isHeatSink(etype) || UnitUtil.isJumpJet(etype)) {
                     return false;
                 }
                 if ((etype instanceof MiscType) && (etype.hasFlag(MiscType.F_TSM)

--- a/src/megameklab/com/ui/view/HeatSinkView.java
+++ b/src/megameklab/com/ui/view/HeatSinkView.java
@@ -89,9 +89,9 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     private final JLabel lblWeightFreeText = new JLabel();
     private final JLabel lblWeightFreeCount = new JLabel();
     
-    private SpinnerNumberModel countModel = new SpinnerNumberModel(0, 0, null, 1);
-    private SpinnerNumberModel baseCountModel = new SpinnerNumberModel(0, 0, null, 1);
-    private SpinnerNumberModel prototypeCountModel = new SpinnerNumberModel(0, 0, null, 1);
+    private final SpinnerNumberModel countModel = new SpinnerNumberModel(0, 0, null, 1);
+    private final SpinnerNumberModel baseCountModel = new SpinnerNumberModel(0, 0, null, 1);
+    private final SpinnerNumberModel prototypeCountModel = new SpinnerNumberModel(0, 0, null, 1);
 
     private final ITechManager techManager;
     private boolean isAero;
@@ -187,7 +187,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         // If there are prototype doubles, we want to skip any singles and select that as the base type.
         Optional<EquipmentType> hs = mech.getMisc().stream().map(Mounted::getType)
                 .filter(et -> et.hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)).findAny();
-        if (!hs.isPresent()) {
+        if (hs.isEmpty()) {
             hs = mech.getMisc().stream().map(Mounted::getType)
                     .filter(UnitUtil::isHeatSink).findAny();
         }

--- a/src/megameklab/com/ui/view/HeatSinkView.java
+++ b/src/megameklab/com/ui/view/HeatSinkView.java
@@ -214,7 +214,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         spnPrototypeCount.setVisible(hasPrototypeDoubles);
         spnPrototypeCount.removeChangeListener(this);
         spnPrototypeCount.setValue(totalSinks - mech.heatSinks(false));
-        prototypeCountModel.setMaximum(capacity);
+        prototypeCountModel.setMaximum(totalSinks);
         prototypeCountModel.setMinimum(hasPrototypeDoubles ? 1 : 0);
         spnPrototypeCount.addChangeListener(this);
         lblCritFreeCount.setText(String.valueOf(UnitUtil.getCriticalFreeHeatSinks(mech, isCompact)));

--- a/src/megameklab/com/util/CriticalTableModel.java
+++ b/src/megameklab/com/util/CriticalTableModel.java
@@ -39,8 +39,7 @@ public class CriticalTableModel extends AbstractTableModel {
 
     private static final long serialVersionUID = 7615555055651822051L;
 
-    private Mounted[] sortedEquipment = {};
-    public List<Mounted> crits = new ArrayList<>();
+    private final List<Mounted> crits = new ArrayList<>();
     public Entity unit;
 
     public final static int NAME = 0;
@@ -91,11 +90,6 @@ public class CriticalTableModel extends AbstractTableModel {
     }
 
     public void refreshModel() {
-        // do a resort
-        sortedEquipment = new Mounted[] {};
-        if (crits.size() > 0) {
-            sortedEquipment = crits.toArray(sortedEquipment);
-        }
         // Support vehicle may switch between kg and ton standards. Other units will be constant
         if (kgStandard != (unit.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT)) {
             kgStandard = !kgStandard;
@@ -122,7 +116,7 @@ public class CriticalTableModel extends AbstractTableModel {
 
     @Override
     public int getRowCount() {
-        return sortedEquipment.length;
+        return crits.size();
     }
 
     @Override
@@ -139,9 +133,9 @@ public class CriticalTableModel extends AbstractTableModel {
     @Override
     public boolean isCellEditable(int row, int col) {
         if (col == SIZE) {
-            return (row >= 0) && (row < sortedEquipment.length)
-                    && (sortedEquipment[row].getType().isVariableSize()
-                    || (sortedEquipment[row].getType() instanceof InfantryWeapon));
+            return (row >= 0) && (row < crits.size())
+                    && (crits.get(row).getType().isVariableSize()
+                    || (crits.get(row).getType() instanceof InfantryWeapon));
         } else {
             return false;
         }
@@ -152,10 +146,10 @@ public class CriticalTableModel extends AbstractTableModel {
         if (row < 0) {
             return "";
         }
-        if (row >= sortedEquipment.length) {
+        if (row >= crits.size()) {
             return "";
         }
-        Mounted crit = sortedEquipment[row];
+        Mounted crit = crits.get(row);
         switch (col) {
             case NAME:
                 return UnitUtil.getCritName(unit, crit.getType());
@@ -227,7 +221,7 @@ public class CriticalTableModel extends AbstractTableModel {
     @Override
     public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
         if ((rowIndex >= 0) && (rowIndex < getRowCount()) && (columnIndex == SIZE)) {
-            Mounted crit = sortedEquipment[rowIndex];
+            Mounted crit = crits.get(rowIndex);
             if (crit.getType().isVariableSize()) {
                 double newSize = Double.parseDouble(aValue.toString());
                 double step = crit.getType().variableStepSize();
@@ -279,7 +273,7 @@ public class CriticalTableModel extends AbstractTableModel {
                 c.setText(table.getModel().getValueAt(row, column).toString());
             }
 
-            Mounted mount = sortedEquipment[row];
+            Mounted mount = crits.get(row);
             if ((unit instanceof BattleArmor) && column == NAME){
                 String modifier = "";
                 if (mount.getType() instanceof AmmoType){


### PR DESCRIPTION
Addresses three issues
1. All heat sinks are managed from the structure tab and should not be appearing on the equipment tab (cf #913).
2. CriticalTableModel duplicates its data in an array called sortedEquipment which, despite the name, does not appear to be sorted anywhere. The array is updated in refreshModel() but this is not always called between updates, and the class is not consistent in which is accessed when the data is modified. I removed the array.
3. While testing the heat sink panel on the structure tab I noticed that the spinner for the number of prototype sinks to use is sometimes inoperative. This is because the max value is being set to the integrated heat sink capacity, which can result in max < value. The correct maximum is the number of heat sinks. None of them have to be integrated (with prototypes, only the ones assigned slots are doubles, and you can put them all out there if you want to.)