### PR TITLE
Show unused tonnage in the status bar.

### DIFF
--- a/src/megameklab/com/ui/Aero/StatusBar.java
+++ b/src/megameklab/com/ui/Aero/StatusBar.java
@@ -118,7 +118,7 @@ public class StatusBar extends ITab {
         }
         heatSink.setVisible(getAero().getEntityType() == Entity.ETYPE_AERO);
 
-        tons.setText("Tonnage: " + currentTonnage + "/" + tonnage);
+        tons.setText(String.format("Tonnage: %.1f/%.1f (%.1f Remaining)", currentTonnage, tonnage, tonnage - currentTonnage));
         tons.setToolTipText("Current Tonnage/Max Tonnage");
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);

--- a/src/megameklab/com/ui/BattleArmor/StatusBar.java
+++ b/src/megameklab/com/ui/BattleArmor/StatusBar.java
@@ -125,7 +125,7 @@ public class StatusBar extends ITab {
 
         final int walk = getBattleArmor().getOriginalWalkMP();
         final int jump = getBattleArmor().getOriginalJumpMP();
-        final double maxKilos = getBattleArmor().getTrooperWeight();
+        final double maxKilos = getBattleArmor().getTrooperWeight() * 1000;
         double currentKilos;
         final int bv = getBattleArmor().calculateBattleValue();
         final long currentCost = Math.round(getBattleArmor().getCost(false));
@@ -134,9 +134,9 @@ public class StatusBar extends ITab {
                 null);
         currentKilos = testBA.calculateWeight(BattleArmor.LOC_SQUAD);
         currentKilos += UnitUtil.getUnallocatedAmmoTonnage(getBattleArmor());
+        currentKilos *= 1000;
 
-        tons.setText("Suit Weight: " + String.format("%1$.3f",currentKilos) + 
-                "/" + maxKilos);
+        tons.setText(String.format("Suit Weight: %,.0f/%,.0f (%,.0f Remaining)", currentKilos, maxKilos, maxKilos - currentKilos));
         tons.setToolTipText("This represents the weight of all squad-level " +
                 "equipment, it does not count individual equipment");
         if (currentKilos > maxKilos) {

--- a/src/megameklab/com/ui/Mek/StatusBar.java
+++ b/src/megameklab/com/ui/Mek/StatusBar.java
@@ -131,7 +131,7 @@ public class StatusBar extends ITab {
             heatSink.setForeground(UIManager.getColor("Label.foreground"));
         }
 
-        tons.setText("Tonnage: " + currentTonnage + "/" + tonnage);
+        tons.setText(String.format("Tonnage: %.1f/%.1f (%.1f Remaining)", currentTonnage, tonnage, tonnage - currentTonnage));
         tons.setToolTipText("Current Tonnage/Max Tonnage");
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);

--- a/src/megameklab/com/ui/Vehicle/StatusBar.java
+++ b/src/megameklab/com/ui/Vehicle/StatusBar.java
@@ -157,7 +157,7 @@ public class StatusBar extends ITab {
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getTank());
         long currentCost = Math.round(getTank().getCost(false));
 
-        tons.setText("Tonnage: " + currentTonnage + "/" + tonnage);
+        tons.setText(String.format("Tonnage: %.1f/%.1f (%.1f Remaining)", currentTonnage, tonnage, tonnage - currentTonnage));
         tons.setToolTipText("Current Tonnage/Max Tonnage");
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroStatusBar.java
@@ -121,8 +121,8 @@ public class AdvancedAeroStatusBar extends ITab {
         }
         heatSink.setVisible(getJumpship().getEntityType() == Entity.ETYPE_AERO);
 
-        tons.setText("Tonnage: " + currentTonnage + "/" + tonnage);
-        tons.setToolTipText("Current Tonnage/Max Tonnage");        
+        tons.setText(String.format("Tonnage: %,.1f/%,.1f (%,.1f Remaining)", currentTonnage, tonnage, tonnage - currentTonnage));
+        tons.setToolTipText("Current Tonnage/Max Tonnage");
         remainingTons.setText("Remaining: " + (tonnage - currentTonnage));
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);

--- a/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
+++ b/src/megameklab/com/ui/aerospace/DropshipStatusBar.java
@@ -121,7 +121,7 @@ public class DropshipStatusBar extends ITab {
         }
         heatSink.setVisible(getSmallCraft().getEntityType() == Entity.ETYPE_AERO);
 
-        tons.setText("Tonnage: " + currentTonnage + "/" + tonnage);
+        tons.setText(String.format("Tonnage: %,.1f/%,.1f (%,.1f Remaining)", currentTonnage, tonnage, tonnage - currentTonnage));
         tons.setToolTipText("Current Tonnage/Max Tonnage");
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);

--- a/src/megameklab/com/ui/protomek/ProtomekStatusBar.java
+++ b/src/megameklab/com/ui/protomek/ProtomekStatusBar.java
@@ -110,7 +110,7 @@ public class ProtomekStatusBar extends ITab {
 
         currentTonnage = testEntity.calculateWeight() * 1000;
 
-        tons.setText("Mass: " + currentTonnage + "/" + tonnage);
+        tons.setText(String.format("Tonnage: %,.0f/%,.0f (%,.0f Remaining)", currentTonnage, tonnage, tonnage - currentTonnage));
         tons.setToolTipText("Current Tonnage/Max Tonnage");
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);

--- a/src/megameklab/com/ui/supportvehicle/SVStatusBar.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStatusBar.java
@@ -18,6 +18,7 @@
  */
 package megameklab.com.ui.supportvehicle;
 
+import megamek.common.EntityWeightClass;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestSupportVehicle;
 import megameklab.com.ui.MegaMekLabMainUI;
@@ -143,7 +144,12 @@ class SVStatusBar extends ITab {
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(eSource.getEntity());
         long currentCost = Math.round(eSource.getEntity().getCost(false));
 
-        tons.setText("Tonnage: " + currentTonnage + "/" + tonnage);
+        if (eSource.getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+            tons.setText(String.format("Tonnage: %.0f/%.0f (%.0f Remaining)",
+                    currentTonnage * 1000, tonnage * 1000, (tonnage - currentTonnage) * 1000));
+        } else {
+            tons.setText(String.format("Tonnage: %.1f/%.1f (%.1f Remaining)", currentTonnage, tonnage, tonnage - currentTonnage));
+        }
         tons.setToolTipText("Current Tonnage/Max Tonnage");
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);


### PR DESCRIPTION
New format:
![Screenshot from 2021-06-03 11-16-55](https://user-images.githubusercontent.com/16927464/120678029-4e530b80-c45d-11eb-8911-8a5a8454272c.png)

Besides adding the remainder, BA and small support vehicles are now displayed in kg (protomechs were already displaying in kg), and large craft tonnages are commified (using locale-appropriate grouping character).

Closes #813