### PR TITLE
Show multiple equipment locations on the record sheet

### DIFF
--- a/src/megameklab/com/printing/StandardInventoryEntry.java
+++ b/src/megameklab/com/printing/StandardInventoryEntry.java
@@ -27,6 +27,7 @@ import megamek.common.weapons.missiles.MMLWeapon;
 import megamek.common.weapons.other.ISCenturionWeaponSystem;
 import megameklab.com.util.CConfig;
 import megameklab.com.util.StringUtils;
+import megameklab.com.util.UnitUtil;
 
 import java.math.BigInteger;
 import java.util.*;
@@ -319,13 +320,7 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
                 return AERODYNE_ARCS[mount.getLocation()];
             }
         }
-        List<Integer> locations = mount.allLocations();
-        if (locations.size() > 2) {
-            return (mount.getEntity() instanceof Mech) ? formatMechLocations(locations) : "*";
-        } else {
-            return locations.stream().sorted().map(l -> mount.getEntity().getLocationAbbr(l))
-                    .collect(Collectors.joining("/"));
-        }
+        return mount.getEntity().joinLocationAbbr(mount.allLocations(), 2);
     }
 
     /**

--- a/src/megameklab/com/util/CriticalTableModel.java
+++ b/src/megameklab/com/util/CriticalTableModel.java
@@ -204,7 +204,7 @@ public class CriticalTableModel extends AbstractTableModel {
                     return BattleArmor.getBaMountLocAbbr(crit
                             .getBaMountLoc());
                 } else {
-                    return unit.getLocationAbbr(crit.getLocation());
+                    return unit.joinLocationAbbr(crit.allLocations(), 2);
                 }
             case SIZE:
                 if (crit.getType().isVariableSize()) {


### PR DESCRIPTION
Show all locations for spreadable equipment on the record sheet. Equipment with more than two locations is abbreviated. Depends on MegaMek/megamek#2912.

Fixes #869