### PR TITLE
Include partial wing bonus in heat capacity on record sheet

### DIFF
--- a/data/images/recordsheets/templates_iso/mech_biped_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_biped_default.svg
@@ -2246,6 +2246,8 @@
                                                                             >Heat Sinks:</text
                                                                             ><text fill="#231f20" x="146.333" id="hsCount" y="31.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="end"
                                                                             >10</text
+                                                                            ><text x="146.333" y="38.000" fill="#231f20" text-anchor="end" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                            >(Partial Wing +3)</text
                                                                             ><rect fill="none" x="122.333" width="30.000" id="heatSinkPips" height="133.000" y="42.000"
                                                                           /></g
                                                                           ><g transform="translate (539.000 393.000)"

--- a/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
@@ -2332,6 +2332,8 @@
                                                                             >Heat Sinks:</text
                                                                             ><text fill="#231f20" x="6.000" id="hsCount" y="34.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                             >10</text
+                                                                            ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                            >(Partial Wing +3)</text
                                                                             ><rect fill="none" x="65.133" width="90.200" id="heatSinkPips" height="25.000" y="21.000"
                                                                           /></g
                                                                           ><g transform="translate (539.000 393.000)"

--- a/data/images/recordsheets/templates_iso/mech_quad_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_quad_default.svg
@@ -1879,6 +1879,8 @@
                                                                                   >Heat Sinks:</text
                                                                                   ><text fill="#231f20" x="146.333" id="hsCount" y="31.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="end"
                                                                                   >10</text
+                                                                                  ><text x="146.333" y="38.000" fill="#231f20" text-anchor="end" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                                  >(Partial Wing +3)</text
                                                                                   ><rect fill="none" x="122.333" width="30.000" id="heatSinkPips" height="133.000" y="42.000"
                                                                                 /></g
                                                                                 ><g transform="translate (539.000 393.000)"

--- a/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
@@ -1965,6 +1965,8 @@
                                                                                   >Heat Sinks:</text
                                                                                   ><text fill="#231f20" x="6.000" id="hsCount" y="34.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                                   >10</text
+                                                                                  ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                                  >(Partial Wing +3)</text
                                                                                   ><rect fill="none" x="65.133" width="90.200" id="heatSinkPips" height="25.000" y="21.000"
                                                                                 /></g
                                                                                 ><g transform="translate (539.000 393.000)"

--- a/data/images/recordsheets/templates_iso/mech_quadvee_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_quadvee_default.svg
@@ -1997,6 +1997,8 @@
                                                                                 >Heat Sinks:</text
                                                                                 ><text fill="#231f20" x="146.333" id="hsCount" y="31.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="end"
                                                                                 >10</text
+                                                                                ><text x="146.333" y="38.000" fill="#231f20" text-anchor="end" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                                >(Partial Wing +3)</text
                                                                                 ><rect fill="none" x="122.333" width="30.000" id="heatSinkPips" height="133.000" y="42.000"
                                                                               /></g
                                                                               ><g transform="translate (539.000 393.000)"

--- a/data/images/recordsheets/templates_iso/mech_quadvee_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_quadvee_toheat.svg
@@ -2083,6 +2083,8 @@
                                                                                 >Heat Sinks:</text
                                                                                 ><text fill="#231f20" x="6.000" id="hsCount" y="34.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                                 >10</text
+                                                                                ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                                >(Partial Wing +3)</text
                                                                                 ><rect fill="none" x="65.133" width="90.200" id="heatSinkPips" height="25.000" y="21.000"
                                                                               /></g
                                                                               ><g transform="translate (539.000 393.000)"

--- a/data/images/recordsheets/templates_iso/mech_tripod_default.svg
+++ b/data/images/recordsheets/templates_iso/mech_tripod_default.svg
@@ -2469,6 +2469,8 @@
                                                                             >Heat Sinks:</text
                                                                             ><text fill="#231f20" x="146.333" id="hsCount" y="31.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="end"
                                                                             >10</text
+                                                                            ><text x="146.333" y="38.000" fill="#231f20" text-anchor="end" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                            >(Partial Wing +3)</text
                                                                             ><rect fill="none" x="122.333" width="30.000" id="heatSinkPips" height="133.000" y="42.000"
                                                                           /></g
                                                                           ><g transform="translate (539.000 393.000)"

--- a/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
+++ b/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
@@ -2555,6 +2555,8 @@
                                                                             >Heat Sinks:</text
                                                                             ><text fill="#231f20" x="6.000" id="hsCount" y="34.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                             >10</text
+                                                                            ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                            >(Partial Wing +3)</text
                                                                             ><rect fill="none" x="65.133" width="90.200" id="heatSinkPips" height="25.000" y="21.000"
                                                                           /></g
                                                                           ><g transform="translate (539.000 393.000)"

--- a/data/images/recordsheets/templates_us/mech_biped_default.svg
+++ b/data/images/recordsheets/templates_us/mech_biped_default.svg
@@ -2246,6 +2246,8 @@
                                                                             >Heat Sinks:</text
                                                                             ><text fill="#231f20" x="152.000" id="hsCount" y="31.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="end"
                                                                             >10</text
+                                                                            ><text x="152.000" y="38.000" fill="#231f20" text-anchor="end" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                            >(Partial Wing +3)</text
                                                                             ><rect fill="none" x="128.000" width="30.000" id="heatSinkPips" height="120.500" y="42.000"
                                                                           /></g
                                                                           ><g transform="translate (556.000 368.000)"

--- a/data/images/recordsheets/templates_us/mech_biped_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_biped_toheat.svg
@@ -2332,6 +2332,8 @@
                                                                             >Heat Sinks:</text
                                                                             ><text fill="#231f20" x="6.000" id="hsCount" y="34.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                             >10</text
+                                                                            ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                            >(Partial Wing +3)</text
                                                                             ><rect fill="none" x="67.400" width="93.600" id="heatSinkPips" height="25.000" y="21.000"
                                                                           /></g
                                                                           ><g transform="translate (556.000 368.000)"

--- a/data/images/recordsheets/templates_us/mech_quad_default.svg
+++ b/data/images/recordsheets/templates_us/mech_quad_default.svg
@@ -1879,6 +1879,8 @@
                                                                                   >Heat Sinks:</text
                                                                                   ><text fill="#231f20" x="152.000" id="hsCount" y="31.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="end"
                                                                                   >10</text
+                                                                                  ><text x="152.000" y="38.000" fill="#231f20" text-anchor="end" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                                  >(Partial Wing +3)</text
                                                                                   ><rect fill="none" x="128.000" width="30.000" id="heatSinkPips" height="120.500" y="42.000"
                                                                                 /></g
                                                                                 ><g transform="translate (556.000 368.000)"

--- a/data/images/recordsheets/templates_us/mech_quad_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_quad_toheat.svg
@@ -1965,6 +1965,8 @@
                                                                                   >Heat Sinks:</text
                                                                                   ><text fill="#231f20" x="6.000" id="hsCount" y="34.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                                   >10</text
+                                                                                  ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                                  >(Partial Wing +3)</text
                                                                                   ><rect fill="none" x="67.400" width="93.600" id="heatSinkPips" height="25.000" y="21.000"
                                                                                 /></g
                                                                                 ><g transform="translate (556.000 368.000)"

--- a/data/images/recordsheets/templates_us/mech_quadvee_default.svg
+++ b/data/images/recordsheets/templates_us/mech_quadvee_default.svg
@@ -1997,6 +1997,8 @@
                                                                                 >Heat Sinks:</text
                                                                                 ><text fill="#231f20" x="152.000" id="hsCount" y="31.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="end"
                                                                                 >10</text
+                                                                                ><text x="152.000" y="38.000" fill="#231f20" text-anchor="end" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                                >(Partial Wing +3)</text
                                                                                 ><rect fill="none" x="128.000" width="30.000" id="heatSinkPips" height="120.500" y="42.000"
                                                                               /></g
                                                                               ><g transform="translate (556.000 368.000)"

--- a/data/images/recordsheets/templates_us/mech_quadvee_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_quadvee_toheat.svg
@@ -2083,6 +2083,8 @@
                                                                                 >Heat Sinks:</text
                                                                                 ><text fill="#231f20" x="6.000" id="hsCount" y="34.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                                 >10</text
+                                                                                ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                                >(Partial Wing +3)</text
                                                                                 ><rect fill="none" x="67.400" width="93.600" id="heatSinkPips" height="25.000" y="21.000"
                                                                               /></g
                                                                               ><g transform="translate (556.000 368.000)"

--- a/data/images/recordsheets/templates_us/mech_tripod_default.svg
+++ b/data/images/recordsheets/templates_us/mech_tripod_default.svg
@@ -2469,6 +2469,8 @@
                                                                             >Heat Sinks:</text
                                                                             ><text fill="#231f20" x="152.000" id="hsCount" y="31.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="end"
                                                                             >10</text
+                                                                            ><text x="152.000" y="38.000" fill="#231f20" text-anchor="end" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                            >(Partial Wing +3)</text
                                                                             ><rect fill="none" x="128.000" width="30.000" id="heatSinkPips" height="120.500" y="42.000"
                                                                           /></g
                                                                           ><g transform="translate (556.000 368.000)"

--- a/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
+++ b/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
@@ -2555,6 +2555,8 @@
                                                                             >Heat Sinks:</text
                                                                             ><text fill="#231f20" x="6.000" id="hsCount" y="34.000" style="font-family:Eurostile;font-size:8.440px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                             >10</text
+                                                                            ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.800px;font-weight:normal;font-style:normal" visibility="hidden" id="partialWingBonus" textLength="41.646" lengthAdjust="spacingAndGlyphs"
+                                                                            >(Partial Wing +3)</text
                                                                             ><rect fill="none" x="67.400" width="93.600" id="heatSinkPips" height="25.000" y="21.000"
                                                                           /></g
                                                                           ><g transform="translate (556.000 368.000)"

--- a/src/megameklab/com/printing/IdConstants.java
+++ b/src/megameklab/com/printing/IdConstants.java
@@ -126,6 +126,7 @@ public interface IdConstants {
     String HEAT_SINK_PIPS = "heatSinkPips";
     String HS_TYPE = "hsType";
     String HS_COUNT = "hsCount";
+    String PARTIAL_WING_BONUS = "partialWingBonus";
     String EXTERNAL_STORES = "external_stores";
     String BOMB_BOXES = "bomb_boxes";
     String EXTERNAL_STORES_KEY = "external_stores_key";

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -210,6 +210,9 @@ public class PrintMech extends PrintEntity {
 
         setTextField(HS_TYPE, formatHeatSinkType());
         setTextField(HS_COUNT, formatHeatSinkCount());
+        if (mech.hasWorkingMisc(MiscType.F_PARTIAL_WING)) {
+            hideElement(PARTIAL_WING_BONUS, false);
+        }
         
         if (mech instanceof LandAirMech) {
             LandAirMech lam = (LandAirMech) mech;
@@ -629,7 +632,7 @@ public class PrintMech extends PrintEntity {
     
     private String formatHeatSinkCount() {
         int hsCount = mech.heatSinks();
-        int capacity = mech.getHeatCapacity(false, false);
+        int capacity = mech.getHeatCapacity(true, false);
         if (hsCount != capacity) {
             return String.format("%d (%d)", hsCount, capacity);
         } else {


### PR DESCRIPTION
In addition to including the partial wing in the total heat dissipation, there is a note underneath explaining where the extra three points come from.

Screenshot:
![Screenshot from 2021-06-07 12-17-18](https://user-images.githubusercontent.com/16927464/121063978-a145ff00-c78c-11eb-8a8a-11786cc51f0f.png)

Closes #871