### PR TITLE
Fix reengineered laser type on record sheet

### DIFF
--- a/src/megameklab/com/util/StringUtils.java
+++ b/src/megameklab/com/util/StringUtils.java
@@ -181,7 +181,7 @@ public class StringUtils {
                 }
                 if (UnitUtil.isAMS(weapon) || (weapon.hasFlag(WeaponType.F_B_POD))) {
                     info += "PB,";
-                } else if (weapon.hasFlag(WeaponType.F_PULSE)) {
+                } else if (weapon.hasFlag(WeaponType.F_PULSE) || (weapon instanceof ReengineeredLaserWeapon)) {
                     info += "P,";
                 } else if (weapon.hasFlag(WeaponType.F_ENERGY) || weapon.hasFlag(WeaponType.F_PLASMA)) {
                     info += "DE,";


### PR DESCRIPTION
As a type of pulse laser, the reengineered lasers should have a damage type of [P] instead of [DE].

Fixes #884