### PR TITLE
Prototype TSM

### DIFF
--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -566,7 +566,7 @@ public class PrintMech extends PrintEntity {
 
     @Override
     protected String formatWalk() {
-        if (mech.hasTSM()) {
+        if (mech.hasTSM(false)) {
             return formatMovement(mech.getWalkMP(), mech.getWalkMP() + 1);
         } else {
             return super.formatWalk();
@@ -578,7 +578,7 @@ public class PrintMech extends PrintEntity {
         double baseRun = mech.getWalkMP();
         double fullRun = baseRun;
         baseRun *= 1.5;
-        if (mech.hasTSM()) {
+        if (mech.hasTSM(false)) {
             fullRun++;
         }
         if ((mech.getMASC() != null) && (mech.getSuperCharger() != null)) {

--- a/src/megameklab/com/ui/view/MekChassisView.java
+++ b/src/megameklab/com/ui/view/MekChassisView.java
@@ -138,7 +138,7 @@ public class MekChassisView extends BuildView implements ActionListener, ChangeL
 
     private static final String[] ENHANCEMENT_NAMES = {
             EquipmentTypeLookup.IS_MASC, EquipmentTypeLookup.CLAN_MASC,
-            EquipmentTypeLookup.TSM, EquipmentTypeLookup.SCM
+            EquipmentTypeLookup.TSM, EquipmentTypeLookup.P_TSM, EquipmentTypeLookup.SCM
     };
     
     private final ITechManager techManager;


### PR DESCRIPTION
1. Makes prototype TSM available as a construction option.
2. Conforms to an API change in Mech, accounting for additional movement due to TSM only for standard.

Depends on MegaMek/megamek#2923

Closes #886