### PR TITLE
Compact heat sink fixes

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -766,9 +766,8 @@ public class UnitUtil {
         if ((restHS % 2) == 1) {
             if (null == singleCompact) {
                 try {
-                    unit.addEquipment(new Mounted(unit, EquipmentType
-                                    .get("IS1 Compact Heat Sink")),
-                            Entity.LOC_NONE, false);
+                    unit.addEquipment(new Mounted(unit, EquipmentType.get(EquipmentTypeLookup.COMPACT_HS_1)),
+                        Entity.LOC_NONE, false);
                 } catch (Exception ex) {
                     MegaMekLab.getLogger().error(ex);
                 }
@@ -777,10 +776,8 @@ public class UnitUtil {
                 // remove singleCompact mount and replace with a double
                 UnitUtil.removeMounted(unit, singleCompact);
                 try {
-                    addMounted(unit,
-                            new Mounted(unit, EquipmentType.get(UnitUtil
-                                    .getHeatSinkType("Compact", unit.isClan()))),
-                            loc, false);
+                    addMounted(unit,new Mounted(unit, EquipmentType.get(EquipmentTypeLookup.COMPACT_HS_2)),
+                        loc, false);
                 } catch (Exception ex) {
                     MegaMekLab.getLogger().error(ex);
                 }
@@ -789,9 +786,8 @@ public class UnitUtil {
         }
         for (; restHS > 0; restHS -= 2) {
             try {
-                unit.addEquipment(new Mounted(unit, EquipmentType.get(UnitUtil
-                                .getHeatSinkType("Compact", unit.isClan()))),
-                        Entity.LOC_NONE, false);
+                unit.addEquipment(new Mounted(unit, EquipmentType.get(EquipmentTypeLookup.COMPACT_HS_2)),
+                    Entity.LOC_NONE, false);
             } catch (Exception ex) {
                 MegaMekLab.getLogger().error(ex);
             }


### PR DESCRIPTION
1. When switching to compact heat sinks on a mixed tech Clan mech, laser heat sinks are installed instead. This is a problem in `UnitUtil#getHeatSinkType`, which did not allow for mixed tech. I think the method needs to be removed, but the call chain goes several levels deep in other places and it's best left for another time. In this case the fix was simpler.
2. The number of compact heat sinks showing on the build tab to be allocated is not reduced when the engine rating increases. This is because of a requirement that engine heat sinks are always one per mount, which means that the paired mounts need to be split. Decreasing the engine rating requires that some of those singles must be allocated, which means they get paired up. I couldn't find any sign that MML ever did that properly, though I may have rewritten some code at some point and broken it.

Fixes #890