### PR TITLE
Don't show protomech-only ammo on equipment tab for non-protomechs

### DIFF
--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -4006,6 +4006,9 @@ public class UnitUtil {
                 && !atype.canAeroUse()) {
             return false;
         }
+        if (atype.hasFlag(AmmoType.F_PROTOMECH) && !(unit instanceof Protomech)) {
+            return false;
+        }
 
         for (Mounted m : unit.getTotalWeaponList()) {
             if (m.getType() instanceof AmmoWeapon) {


### PR DESCRIPTION
This affects Clan machine guns.

Fixes #897