### PR TITLE
update recordsheet printing

### DIFF
--- a/src/megameklab/com/printing/PrintInfantry.java
+++ b/src/megameklab/com/printing/PrintInfantry.java
@@ -201,7 +201,8 @@ public class PrintInfantry extends PrintEntity {
         if (infantry.hasSpaceSuit()) {
             sj.add("Can operate in vacuum.");
         }
-        if (rangeWeapon.hasFlag(WeaponType.F_INF_BURST)) {
+        if (rangeWeapon.hasFlag(WeaponType.F_INF_BURST) ||
+               infantry.primaryWeaponDamageCapped()) {
             sj.add("+1D6 damage vs. conventional infantry.");
         }
         if (rangeWeapon.hasFlag(WeaponType.F_INF_NONPENETRATING)) {


### PR DESCRIPTION
On infantry recordsheets, indicate the +1d6 "burst fire" modifier if the infantry is using a weapon that has been nerfed.