### PR TITLE
Tooltip info

### DIFF
--- a/src/megameklab/com/util/CritListCellRenderer.java
+++ b/src/megameklab/com/util/CritListCellRenderer.java
@@ -158,7 +158,7 @@ public class CritListCellRenderer extends DefaultListCellRenderer {
             label.setBorder(BorderFactory.createMatteBorder(1, 0, 1, 0, Color.black));
         } else if ((cs != null) && UnitUtil.isLastCrit(unit, cs, index, loc)) {
             label.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, Color.black));
-        } else if ((cs != null) && UnitUtil.isPreviousCritEmpty(unit, cs, index, loc)){
+        } else if ((cs != null) && UnitUtil.isPreviousCritEmpty(unit, cs, index, loc)) {
             label.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.black));
         } 
 

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -2288,7 +2288,7 @@ public class UnitUtil {
         sb.append(eq.getName());
         if (eq.getType() instanceof AmmoType) {
             sb.append(" (" + eq.getBaseShotsLeft() + " shot");
-            sb.append(eq.getBaseShotsLeft() == 1 ? ")" : "s)");
+            sb.append((eq.getBaseShotsLeft() == 1) ? ")" : "s)");
         }
         if ((eq.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK)
                 || eq.getType().hasFlag(MiscType.F_AP_MOUNT))
@@ -2322,7 +2322,7 @@ public class UnitUtil {
                 sb.append("<br>Heat: ");
                 sb.append(eq.getType().getHeat());
                 sb.append("<br>Maximum Damage: ");
-                sb.append(getWeaponDamageInfo((WeaponType)eq.getType()));
+                sb.append(getWeaponDamageInfo((WeaponType) eq.getType()));
             }
         }
         sb.append("<Br>Cost: ");
@@ -2373,8 +2373,8 @@ public class UnitUtil {
             int damage = wType.getDamage();
             if (wType.getAmmoType() == AmmoType.T_AC_ROTARY) {
                 damage *= 6;
-            } else if (wType.getAmmoType() == AmmoType.T_AC_ULTRA
-                    || wType.getAmmoType() == AmmoType.T_AC_ULTRA_THB) {
+            } else if ((wType.getAmmoType() == AmmoType.T_AC_ULTRA)
+                    || (wType.getAmmoType() == AmmoType.T_AC_ULTRA_THB)) {
                 damage *= 2;
             }
             return Integer.toString(damage);
@@ -2455,10 +2455,7 @@ public class UnitUtil {
 
         } else {
             CriticalSlot nextCrit = unit.getCritical(location, slot + 1);
-            if (nextCrit == null) {
-                return true;
-            } else return (nextCrit.getMount() == null) || !nextCrit.getMount().equals(cs.getMount());
-
+            return (nextCrit == null) || (nextCrit.getMount() == null) || !nextCrit.getMount().equals(cs.getMount());
         }
 
         return slot == lastIndex;

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -36,7 +36,6 @@ import javax.swing.ScrollPaneConstants;
 import javax.swing.text.DefaultCaret;
 import javax.swing.text.html.HTMLEditorKit;
 
-import megamek.client.ui.Messages;
 import megamek.client.ui.dialogs.BVDisplayDialog;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -76,6 +76,7 @@ import megamek.common.weapons.lrms.LRMWeapon;
 import megamek.common.weapons.lrms.LRTWeapon;
 import megamek.common.weapons.lrms.StreakLRMWeapon;
 import megamek.common.weapons.mgs.MGWeapon;
+import megamek.common.weapons.missiles.MMLWeapon;
 import megamek.common.weapons.missiles.MRMWeapon;
 import megamek.common.weapons.missiles.RLWeapon;
 import megamek.common.weapons.missiles.ThunderBoltWeapon;
@@ -2358,7 +2359,7 @@ public class UnitUtil {
     private static String getWeaponDamageInfo(WeaponType wType) {
         if (wType.getDamage() == WeaponType.DAMAGE_BY_CLUSTERTABLE) {
             int perMissile = 1;
-            if ((wType instanceof SRMWeapon) || (wType instanceof SRTWeapon)) {
+            if ((wType instanceof SRMWeapon) || (wType instanceof SRTWeapon) ||(wType instanceof MMLWeapon)) {
                 perMissile = 2;
             }
             return Integer.toString(wType.getRackSize() * perMissile);


### PR DESCRIPTION
- Issue 953: For ammo, shows the shots in the tooltip
- Issue 646: For weapons, shows a maximum damage value in the tooltip. Obviously there's weapons for which this is difficult, so this should be taken with a grain of salt.
- corrects a small bug that would show the last hovered weapon tooltip when hovering something like the Engine or an actuator or empty slot. Now removes the tooltip instead when hovering these.
- a few code format improvements
![image](https://user-images.githubusercontent.com/17069663/140642633-c6b702fa-48eb-4d88-b7a9-7a93a5c3b631.png)
![image](https://user-images.githubusercontent.com/17069663/140642660-29951f53-7680-42ce-85e2-606dd3c06a48.png)

Resolves #953 
Resolves #646