### PR TITLE
Add CASE info to ammo on non-Mech Record Sheets

### DIFF
--- a/src/megameklab/com/printing/InventoryWriter.java
+++ b/src/megameklab/com/printing/InventoryWriter.java
@@ -177,7 +177,7 @@ public class InventoryWriter {
                 .collect(Collectors.joining(", "));
         String ammoPrefix = "Ammo: ";
         if (sheet.getEntity().hasWorkingMisc(MiscType.F_CASE)
-                && (sheet.getEntity().getEntityType() & Entity.ETYPE_MECH) == 0) {
+                && ((sheet.getEntity().getEntityType() & Entity.ETYPE_MECH) == 0)) {
             ammoPrefix = "Ammo (CASE): ";
         }
         ammoText = str.isEmpty() ? str : ammoPrefix + str;

--- a/src/megameklab/com/printing/InventoryWriter.java
+++ b/src/megameklab/com/printing/InventoryWriter.java
@@ -175,7 +175,12 @@ public class InventoryWriter {
         String str = ammo.entrySet().stream()
                 .map(e -> String.format("(%s) %d", e.getKey(), e.getValue()))
                 .collect(Collectors.joining(", "));
-        ammoText = str.isEmpty() ? str : "Ammo: " + str;
+        String ammoPrefix = "Ammo: ";
+        if (sheet.getEntity().hasWorkingMisc(MiscType.F_CASE)
+                && (sheet.getEntity().getEntityType() & Entity.ETYPE_MECH) == 0) {
+            ammoPrefix = "Ammo (CASE): ";
+        }
+        ammoText = str.isEmpty() ? str : ammoPrefix + str;
         fuelText = sheet.formatTacticalFuel();
         str = sheet.formatFeatures();
         featuresText = str.isEmpty() ? str : "Features " + str;


### PR DESCRIPTION
- Adds CASE info for **all non-mech units** that have a **CASE in their equipment list**. 
- Does not check for CASEII as this is explicitly listed in the equipment list (as per official RS)
- Shows CASE even for Clan units  (as per official RS)

![image](https://user-images.githubusercontent.com/17069663/140642720-4fde5663-526d-4d57-af95-530326f96c86.png)

Resolves #943 