### PR TITLE
Remove main scrollbar from the equipment tabs

### DIFF
--- a/src/megameklab/com/ui/Aero/MainUI.java
+++ b/src/megameklab/com/ui/Aero/MainUI.java
@@ -76,7 +76,7 @@ public class MainUI extends MegaMekLabMainUI {
         statusbar.addRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
-        configPane.addTab("Equipment", new TabScrollPane(equipmentTab));
+        configPane.addTab("Equipment", equipmentTab);
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Preview", previewTab);

--- a/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
@@ -179,8 +179,6 @@ public class EquipmentTab extends ITab implements ActionListener {
             }
         });
         equipmentScroll.setViewportView(equipmentTable);
-        equipmentScroll.setMinimumSize(new java.awt.Dimension(300, 200));
-        equipmentScroll.setPreferredSize(new java.awt.Dimension(300, 200));
 
         masterEquipmentList = new EquipmentTableModel(eSource.getEntity(), eSource.getTechManager());
         masterEquipmentTable.setModel(masterEquipmentList);
@@ -251,8 +249,6 @@ public class EquipmentTab extends ITab implements ActionListener {
         });
 
         txtFilter.setText("");
-        txtFilter.setMinimumSize(new java.awt.Dimension(200, 28));
-        txtFilter.setPreferredSize(new java.awt.Dimension(200, 28));
         txtFilter.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void changedUpdate(DocumentEvent e) {
@@ -292,7 +288,14 @@ public class EquipmentTab extends ITab implements ActionListener {
         gbc = new GridBagConstraints();
 
         JPanel loadoutPanel = new JPanel(new GridBagLayout());
-        JPanel databasePanel = new JPanel(new GridBagLayout());
+        JPanel databasePanel = new JPanel(new GridBagLayout()) {
+            @Override
+            // Allow downsizing the database with the Splitpane for small screen sizes
+            public Dimension getMinimumSize() {
+                Dimension prefSize = super.getPreferredSize();
+                return new Dimension(prefSize.width / 2, prefSize.height);
+            }
+        };
 
         loadoutPanel.setBorder(BorderFactory.createTitledBorder("Current Loadout"));
         databasePanel.setBorder(BorderFactory.createTitledBorder("Equipment Database"));
@@ -386,9 +389,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         gbc.weighty = 1.0;
         loadoutPanel.add(equipmentScroll, gbc);
 
-        JSplitPane pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
-                new JScrollPane(loadoutPanel),
-                new JScrollPane(databasePanel));
+        JSplitPane pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, loadoutPanel, databasePanel);
         pane.setOneTouchExpandable(true);
         setLayout(new BorderLayout());
         add(pane, BorderLayout.CENTER);

--- a/src/megameklab/com/ui/BattleArmor/MainUI.java
+++ b/src/megameklab/com/ui/BattleArmor/MainUI.java
@@ -69,7 +69,7 @@ public class MainUI extends MegaMekLabMainUI {
         fluffTab.setRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
-        configPane.addTab("Equipment", new TabScrollPane(equipTab));
+        configPane.addTab("Equipment", equipTab);
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
 

--- a/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
@@ -240,8 +240,6 @@ public class EquipmentTab extends ITab implements ActionListener {
         });
 
         txtFilter.setText("");
-        txtFilter.setMinimumSize(new java.awt.Dimension(200, 28));
-        txtFilter.setPreferredSize(new java.awt.Dimension(200, 28));
         txtFilter.getDocument().addDocumentListener(new DocumentListener() {
             public void changedUpdate(DocumentEvent e) {
                 filterEquipment();
@@ -278,7 +276,14 @@ public class EquipmentTab extends ITab implements ActionListener {
         gbc = new GridBagConstraints();
 
         JPanel loadoutPanel = new JPanel(new GridBagLayout());
-        JPanel databasePanel = new JPanel(new GridBagLayout());
+        JPanel databasePanel = new JPanel(new GridBagLayout()) {
+            @Override
+            // Allow downsizing the database with the Splitpane for small screen sizes
+            public Dimension getMinimumSize() {
+                Dimension prefSize = super.getPreferredSize();
+                return new Dimension(prefSize.width / 2, prefSize.height);
+            }
+        };
 
         loadoutPanel.setBorder(BorderFactory.createTitledBorder("Current Loadout"));
         databasePanel.setBorder(BorderFactory.createTitledBorder("Equipment Database"));
@@ -351,9 +356,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         gbc.weighty = 1.0;
         loadoutPanel.add(equipmentScroll, gbc);
 
-        JSplitPane pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
-                new JScrollPane(loadoutPanel),
-                new JScrollPane(databasePanel));
+        JSplitPane pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, loadoutPanel, databasePanel);
         pane.setOneTouchExpandable(true);
         setLayout(new BorderLayout());
         add(pane, BorderLayout.CENTER);

--- a/src/megameklab/com/ui/Mek/MainUI.java
+++ b/src/megameklab/com/ui/Mek/MainUI.java
@@ -72,7 +72,7 @@ public class MainUI extends MegaMekLabMainUI {
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
         //ConfigPane.addTab("Armor", armorTab);
-        configPane.addTab("Equipment", new TabScrollPane(equipmentTab));
+        configPane.addTab("Equipment", equipmentTab);
         //ConfigPane.addTab("Weapons", weaponTab);
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));

--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -172,8 +172,6 @@ public class EquipmentTab extends ITab implements ActionListener {
             }
         });
         equipmentScroll.setViewportView(equipmentTable);
-        equipmentScroll.setMinimumSize(new java.awt.Dimension(300, 200));
-        equipmentScroll.setPreferredSize(new java.awt.Dimension(300, 200));
 
         masterEquipmentList = new EquipmentTableModel(eSource.getEntity(), eSource.getTechManager());
         masterEquipmentTable.setModel(masterEquipmentList);
@@ -243,8 +241,6 @@ public class EquipmentTab extends ITab implements ActionListener {
         });
 
         txtFilter.setText("");
-        txtFilter.setMinimumSize(new java.awt.Dimension(200, 28));
-        txtFilter.setPreferredSize(new java.awt.Dimension(200, 28));
         txtFilter.getDocument().addDocumentListener(new DocumentListener() {
             public void changedUpdate(DocumentEvent e) {
                 filterEquipment();
@@ -281,7 +277,14 @@ public class EquipmentTab extends ITab implements ActionListener {
         gbc = new GridBagConstraints();
 
         JPanel loadoutPanel = new JPanel(new GridBagLayout());
-        JPanel databasePanel = new JPanel(new GridBagLayout());
+        JPanel databasePanel = new JPanel(new GridBagLayout()) {
+            @Override
+            // Allow downsizing the database with the Splitpane for small screen sizes
+            public Dimension getMinimumSize() {
+                Dimension prefSize = super.getPreferredSize();
+                return new Dimension(prefSize.width / 2, prefSize.height);
+            }
+        };
 
         loadoutPanel.setBorder(BorderFactory.createTitledBorder("Current Loadout"));
         databasePanel.setBorder(BorderFactory.createTitledBorder("Equipment Database"));
@@ -354,9 +357,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         gbc.weighty = 1.0;
         loadoutPanel.add(equipmentScroll, gbc);
 
-        JSplitPane pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
-                new JScrollPane(loadoutPanel),
-                new JScrollPane(databasePanel));
+        JSplitPane pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, loadoutPanel, databasePanel);
         pane.setOneTouchExpandable(true);
         setLayout(new BorderLayout());
         add(pane, BorderLayout.CENTER);

--- a/src/megameklab/com/ui/Vehicle/MainUI.java
+++ b/src/megameklab/com/ui/Vehicle/MainUI.java
@@ -78,7 +78,7 @@ public class MainUI extends MegaMekLabMainUI {
         previewTab = new PreviewTab(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
-        configPane.addTab("Equipment", new TabScrollPane(equipmentTab));
+        configPane.addTab("Equipment", equipmentTab);
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Preview", previewTab);

--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -169,8 +169,6 @@ public class EquipmentTab extends ITab implements ActionListener {
             }
         });
         equipmentScroll.setViewportView(equipmentTable);
-        equipmentScroll.setMinimumSize(new java.awt.Dimension(300, 200));
-        equipmentScroll.setPreferredSize(new java.awt.Dimension(300, 200));
 
         masterEquipmentList = new EquipmentTableModel(getTank(), eSource.getTechManager());
         masterEquipmentTable.setModel(masterEquipmentList);
@@ -241,8 +239,6 @@ public class EquipmentTab extends ITab implements ActionListener {
         });
 
         txtFilter.setText("");
-        txtFilter.setMinimumSize(new java.awt.Dimension(200, 28));
-        txtFilter.setPreferredSize(new java.awt.Dimension(200, 28));
         txtFilter.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void changedUpdate(DocumentEvent e) {
@@ -282,7 +278,15 @@ public class EquipmentTab extends ITab implements ActionListener {
         gbc = new GridBagConstraints();
 
         JPanel loadoutPanel = new JPanel(new GridBagLayout());
-        JPanel databasePanel = new JPanel(new GridBagLayout());
+        JPanel databasePanel = new JPanel(new GridBagLayout())
+        {
+            @Override
+            // Allow downsizing the database with the Splitpane for small screen sizes
+            public Dimension getMinimumSize() {
+                Dimension prefSize = super.getPreferredSize();
+                return new Dimension(prefSize.width / 2, prefSize.height);
+            }
+        };
 
         loadoutPanel.setBorder(BorderFactory.createTitledBorder("Current Loadout"));
         databasePanel.setBorder(BorderFactory.createTitledBorder("Equipment Database"));
@@ -355,9 +359,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         gbc.weighty = 1.0;
         loadoutPanel.add(equipmentScroll, gbc);
 
-        JSplitPane pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
-                new JScrollPane(loadoutPanel),
-                new JScrollPane(databasePanel));
+        JSplitPane pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, loadoutPanel, databasePanel);
         pane.setOneTouchExpandable(true);
         setLayout(new BorderLayout());
         add(pane, BorderLayout.CENTER);

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroUI.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroUI.java
@@ -187,7 +187,7 @@ public class AdvancedAeroUI extends MegaMekLabMainUI {
         statusbar.addRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
-        configPane.addTab("Equipment", new TabScrollPane(equipmentTab));
+        configPane.addTab("Equipment", equipmentTab);
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Transport Bays", new TabScrollPane(transportTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));

--- a/src/megameklab/com/ui/aerospace/DropshipMainUI.java
+++ b/src/megameklab/com/ui/aerospace/DropshipMainUI.java
@@ -169,7 +169,7 @@ public class DropshipMainUI extends MegaMekLabMainUI {
         fluffTab.setRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
-        configPane.addTab("Equipment", new TabScrollPane(equipmentTab));
+        configPane.addTab("Equipment", equipmentTab);
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Transport Bays", new TabScrollPane(transportTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));

--- a/src/megameklab/com/ui/protomek/ProtomekMainUI.java
+++ b/src/megameklab/com/ui/protomek/ProtomekMainUI.java
@@ -74,7 +74,7 @@ public class ProtomekMainUI extends MegaMekLabMainUI {
         fluffTab.setRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
-        configPane.addTab("Equipment", new TabScrollPane(equipmentTab));
+        configPane.addTab("Equipment", equipmentTab);
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Preview", previewTab);

--- a/src/megameklab/com/ui/supportvehicle/SVMainUI.java
+++ b/src/megameklab/com/ui/supportvehicle/SVMainUI.java
@@ -74,7 +74,7 @@ public class SVMainUI extends MegaMekLabMainUI {
 
         configPane.addTab("Structure", new TabScrollPane(structureTab));
         configPane.addTab("Armor", new TabScrollPane(armorTab));
-        configPane.addTab("Equipment", new TabScrollPane(equipmentTab));
+        configPane.addTab("Equipment", equipmentTab);
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Transport", new TabScrollPane(transportTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));

--- a/src/megameklab/com/ui/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/tabs/EquipmentTab.java
@@ -207,10 +207,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                 refresh.refreshSummary();
             }
         });
-        JScrollPane equipmentScroll = new JScrollPane();
-        equipmentScroll.setViewportView(equipmentTable);
-        equipmentScroll.setMinimumSize(new java.awt.Dimension(300, 200));
-        equipmentScroll.setPreferredSize(new java.awt.Dimension(300, 200));
+        JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
 
         masterEquipmentList = new EquipmentTableModel(eSource.getEntity(), eSource.getTechManager());
         masterEquipmentTable.setModel(masterEquipmentList);
@@ -287,8 +284,6 @@ public class EquipmentTab extends ITab implements ActionListener {
         choiceType.setRenderer(new CategoryListCellRenderer());
 
         txtFilter.setText("");
-        txtFilter.setMinimumSize(new java.awt.Dimension(200, 28));
-        txtFilter.setPreferredSize(new java.awt.Dimension(200, 28));
         txtFilter.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void changedUpdate(DocumentEvent e) {
@@ -329,7 +324,14 @@ public class EquipmentTab extends ITab implements ActionListener {
         gbc = new GridBagConstraints();
 
         JPanel loadoutPanel = new JPanel(new GridBagLayout());
-        JPanel databasePanel = new JPanel(new GridBagLayout());
+        JPanel databasePanel = new JPanel(new GridBagLayout()) {
+            @Override
+            // Allow downsizing the database with the Splitpane for small screen sizes
+            public Dimension getMinimumSize() {
+                Dimension prefSize = super.getPreferredSize();
+                return new Dimension(prefSize.width / 2, prefSize.height);
+            }
+        };
 
         loadoutPanel.setBorder(BorderFactory.createTitledBorder("Current Loadout"));
         databasePanel.setBorder(BorderFactory.createTitledBorder("Equipment Database"));
@@ -423,9 +425,7 @@ public class EquipmentTab extends ITab implements ActionListener {
         gbc.weighty = 1.0;
         loadoutPanel.add(equipmentScroll, gbc);
 
-        JSplitPane pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
-                new JScrollPane(loadoutPanel),
-                new JScrollPane(databasePanel));
+        JSplitPane pane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, loadoutPanel, databasePanel);
         pane.setOneTouchExpandable(true);
         setLayout(new BorderLayout());
         add(pane, BorderLayout.CENTER);


### PR DESCRIPTION
An addendum to #957: 
Removes the "master" scrollpane from the equipment tabs, as those consist mainly of two lists that have their own internal scrollbars and dont need one for the whole tab. This makes the equipment tab behave gracefully when being sized down. 
Also gives the equipment database list a minimum size that will allow the splitpane divider to be reasonably moved.
(I must say that this has limits. When someone sizes the window down to 600x400 pixels a master scrollpane will prevent horizontal squishing of the lists. But on normal window sizes any horizontal scrollbar is annoying and useless. Id opt to assume that people can work MML at 1000x700 pixels at least, anything smaller is at user's risk)

![image](https://user-images.githubusercontent.com/17069663/141660341-fe1aa66b-29b4-4af6-a7ce-717fdbb0923f.png)
