### PR TITLE
Large Aero Crit View Bug Fixes

### DIFF
--- a/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
@@ -553,14 +553,10 @@ public class EquipmentTab extends ITab implements ActionListener {
                 equipmentList.removeMounted(row);
             }
             equipmentList.removeCrits(selectedRows);
-            if (getAero().usesWeaponBays()) {
-                removeEmptyBays();
-            }
+            UnitUtil.removeEmptyBays(getAero());
         } else if (e.getActionCommand().equals(REMOVEALL_COMMAND)) {
             removeAllEquipment();
-            if (getAero().usesWeaponBays()) {
-                removeEmptyBays();
-            }
+            UnitUtil.removeEmptyBays(getAero());
         } else {
             return;
         }
@@ -581,14 +577,6 @@ public class EquipmentTab extends ITab implements ActionListener {
         equipmentList.removeAllCrits();
     }
     
-    private void removeEmptyBays() {
-        List<Mounted> emptyBays = getAero().getWeaponBayList().stream()
-                .filter(bay -> bay.getBayWeapons().isEmpty()).collect(Collectors.toList());
-        for (Mounted bay : emptyBays) {
-            UnitUtil.removeMounted(getAero(), bay);
-        }
-    }
-
     private void fireTableRefresh() {
         equipmentList.updateUnit(getAero());
         equipmentList.refreshModel();

--- a/src/megameklab/com/ui/util/AeroBayTransferHandler.java
+++ b/src/megameklab/com/ui/util/AeroBayTransferHandler.java
@@ -53,6 +53,8 @@ public class AeroBayTransferHandler extends TransferHandler {
     private static final long serialVersionUID = 2534394664060762469L;
     
     private EntitySource eSource;
+
+    public static final String EMTPYSLOT = "EmptySlot";
     
     /* Aliases for local usage.
      * When moving ammo, the default is to move a single ton (or whatever the atomic value is) at a time.
@@ -194,6 +196,9 @@ public class AeroBayTransferHandler extends TransferHandler {
         List<Mounted> mounted = new ArrayList<>();
         try {
             String str = (String) support.getTransferable().getTransferData(DataFlavor.stringFlavor);
+            if (str.equals(EMTPYSLOT)) {
+                return false;
+            }
             if (str.contains(":")) {
                 str = str.substring(0, str.indexOf(":"));
             }

--- a/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
+++ b/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
@@ -52,6 +52,8 @@ import megameklab.com.util.CConfig;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
 
+import static megameklab.com.ui.util.AeroBayTransferHandler.EMTPYSLOT;
+
 /**
  * Variant of DropTargetCriticalList for aerospace units that groups weapons into bays. Also
  * includes support for treating spheroid small craft and dropships firing arcs separately
@@ -1179,7 +1181,7 @@ public class BayWeaponCriticalTree extends JTree {
     /**
      * Called by the transfer handler when equipment is dropped on this location.
      *  
-     * @param eq The equipment dropped on this location 
+     * @param eq The equipment dropped on this location
      * @param path The tree node under the drop point
      */
     public void addToArc(Mounted eq, TreePath path) {
@@ -1451,7 +1453,7 @@ public class BayWeaponCriticalTree extends JTree {
             }
             return sj.toString();
         } else {
-            return "-1"; 
+            return EMTPYSLOT;
         }
     }
     

--- a/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
+++ b/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
@@ -1187,6 +1187,7 @@ public class BayWeaponCriticalTree extends JTree {
     public void addToArc(Mounted eq, TreePath path) {
         if ((null == path) || !(path.getLastPathComponent() instanceof EquipmentNode)) {
             addToBay(null, eq);
+            return;
         }
         EquipmentNode node = (EquipmentNode)path.getLastPathComponent();
         if (node instanceof BayNode) {

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -4427,4 +4427,15 @@ public class UnitUtil {
         
         assignQuarters(aero, officer + firstClass, standardCrew, secondClass, steerageCrew + steeragePsgr);
     }
+
+    /**
+     * Removes all empty Weapon Bays from the given entity. May be called and has no effect
+     * for entities that do not use weapon bays.
+     */
+    public static void removeEmptyBays(Entity entity) {
+        List<Mounted> emptyBays = entity.getWeaponBayList().stream()
+                .filter(bay -> bay.getBayWeapons().isEmpty())
+                .collect(Collectors.toList());
+        emptyBays.forEach(bay -> UnitUtil.removeMounted(entity, bay));
+    }
 }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -3720,21 +3720,20 @@ public class UnitUtil {
          * First we remove any equipment already in the location, but keep a list of it
          * to use as much as possible. 
          */
-        List<Mounted> removed = new ArrayList<>();
-        // Create copy to iterate since we may be modifying it.
-        List<Mounted> mountList = new ArrayList<>(entity.getEquipment());
-        for (Mounted m : mountList) {
-            if ((m.getLocation() == toLoc)
-                    && (m.isRearMounted() ? includeRear : includeForward)) {
-                removed.add(m);
-                UnitUtil.removeCriticals(entity, m);
-                if (m.getType() instanceof BayWeapon) {
-                    removeMounted(entity, m);
-                } else {
-                    changeMountStatus(entity, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
-                }
-            }
-        }
+        List<Mounted> removed = entity.getEquipment().stream()
+                .filter(m -> m.getLocation() == toLoc)
+                .filter(m -> m.isRearMounted() ? includeRear : includeForward)
+                .collect(Collectors.toList());
+
+        removed.stream().forEach(m -> UnitUtil.removeCriticals(entity, m));
+
+        removed.stream()
+                .filter(m -> !(m.getType() instanceof BayWeapon))
+                .forEach(m-> changeMountStatus(entity, m, Entity.LOC_NONE, Entity.LOC_NONE, false));
+
+        removed.stream()
+                .filter(m -> (m.getType() instanceof BayWeapon))
+                .forEach(m -> removeMounted(entity, m));
         
         /*
          * Now we go through the equipment in the location to copy and add it to the other location.
@@ -3744,10 +3743,10 @@ public class UnitUtil {
          * in the same order to be nice and tidy.
          */
         if (entity.usesWeaponBays()) {
-            mountList = entity.getWeaponBayList().stream()
+            List<Mounted> bayList = entity.getWeaponBayList().stream()
                     .filter(bay -> (bay.getLocation() == fromLoc) && (bay.isRearMounted() ? includeRear : includeForward))
                     .collect(Collectors.toList());
-            for (Mounted bay : mountList) {
+            for (Mounted bay : bayList) {
                 if ((bay.getLocation() == fromLoc)
                         && (bay.isRearMounted() ? includeRear : includeForward)) {
                     Mounted newBay = new Mounted(entity, bay.getType());
@@ -3763,8 +3762,8 @@ public class UnitUtil {
                 }
             }
             // Now we copy any other equipment
-            mountList = new ArrayList<>(entity.getMisc());
-            for (Mounted m : mountList) {
+            bayList = new ArrayList<>(entity.getMisc());
+            for (Mounted m : bayList) {
                 if ((m.getLocation() == fromLoc)
                         && (m.isRearMounted() ? includeRear : includeForward)) {
                     copyEquipment(entity, toLoc, m, removed);


### PR DESCRIPTION
In the Large Aero Crit View:
- No longer throws exceptions when dragging an "--Empty--" slot
- No longer sometimes adds duplicate equipment when using the Copy from other side buttons
- Weapons dragged from one location to another will no longer sometimes not disappear from the source arc

I thought I would need removeEmptyBays() as a utility at another class but in the end I didnt. It still seemed like a valid change to move this method to the UnitUtils so I left it in.