### PR TITLE
Crit unification

### DIFF
--- a/src/megameklab/com/ui/Aero/tabs/BuildTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/BuildTab.java
@@ -61,7 +61,7 @@ public class BuildTab extends ITab implements ActionListener {
 
         GridBagConstraints gbc = new GridBagConstraints();
 
-        critView = new CriticalView(eSource, true, refresh);
+        critView = new CriticalView(eSource, refresh);
         buildView = new BuildView(eSource,refresh);
 
         resetButton.setMnemonic('R');
@@ -79,9 +79,7 @@ public class BuildTab extends ITab implements ActionListener {
         gbc.fill = GridBagConstraints.NONE;
         gbc.weighty = 0.0;
         mainPanel.add(buttonPanel, gbc);
-        this.add(Box.createHorizontalStrut(100));
         this.add(critView);
-        this.add(Box.createHorizontalStrut(200));
         this.add(mainPanel);
         refresh();
     }

--- a/src/megameklab/com/ui/Aero/views/CriticalView.java
+++ b/src/megameklab/com/ui/Aero/views/CriticalView.java
@@ -1,7 +1,6 @@
 /*
  * MegaMekLab - Copyright (C) 2008
- *
- * Original author - jtighe (torren@users.sourceforge.net)
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -14,120 +13,84 @@
  * for more details.
  */
 
+
 package megameklab.com.ui.Aero.views;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Font;
-import java.util.Vector;
-
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.ListSelectionModel;
-import javax.swing.border.TitledBorder;
-
-import megamek.common.Aero;
-import megamek.common.CriticalSlot;
-import megamek.common.LocationFullException;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
-import megamek.common.loaders.MtfFile;
+import megamek.common.*;
 import megamek.common.verifier.TestAero;
 import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
+import megameklab.com.ui.util.CritCellUtil;
 import megameklab.com.util.IView;
+import megameklab.com.util.Mech.DropTargetCriticalList;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
-import megameklab.com.util.Mech.DropTargetCriticalList;
 
+import javax.swing.*;
+import java.awt.*;
+import java.util.Vector;
+
+/**
+ * The Crit Slots view for a Fighter (Aerospacce and Conventional)
+ *
+ * Original author - jtighe (torren@users.sourceforge.net)
+ * @author arlith
+ * @author neoancient
+ * @author Simon (Juliez)
+ */
 public class CriticalView extends IView {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6960975031034494605L;
+    private final Box leftWingPanel = Box.createVerticalBox();
+    private final Box rightWingPanel = Box.createVerticalBox();
+    private final Box nosePanel = Box.createVerticalBox();
+    private final Box aftPanel = Box.createVerticalBox();
+    private final Box fuselagePanel = Box.createVerticalBox();
+    
+    private final JLabel noseSpace = new JLabel();
+    private final JLabel leftSpace = new JLabel();
+    private final JLabel rightSpace = new JLabel();
+    private final JLabel aftSpace = new JLabel();
+    
+    private final JButton btnCopyLW = new JButton("Copy from Left Wing");
+    private final JButton btnCopyRW = new JButton("Copy from Right Wing");
 
-    private JPanel leftWingPanel = new JPanel();
-    private JPanel rightWingPanel = new JPanel();
-    private JPanel nosePanel = new JPanel();
-    private JPanel aftPanel = new JPanel();
-    private JPanel fuselagePanel = new JPanel();
-    
-    private JLabel noseSpace = new JLabel("",JLabel.LEFT);
-    private JLabel leftSpace = new JLabel("",JLabel.LEFT);
-    private JLabel rightSpace = new JLabel("",JLabel.LEFT);
-    private JLabel aftSpace = new JLabel("",JLabel.LEFT);
-    
-    private JButton btnCopyLW = new JButton("Copy Left Wing");
-    private JButton btnCopyRW = new JButton("Copy Right Wing");
-    
-    private JPanel topPanel = new JPanel();
-    private JPanel middlePanel = new JPanel();   
-    private JPanel bottomPanel = new JPanel();
-    
     private RefreshListener refresh;
 
-    private boolean showEmpty = false;
-
-    public CriticalView(EntitySource eSource, boolean showEmpty, RefreshListener refresh) {
+    public CriticalView(EntitySource eSource, RefreshListener refresh) {
         super(eSource);
-        this.showEmpty = showEmpty;
         this.refresh = refresh;
 
-        JPanel mainPanel = new JPanel();
+        Box mainPanel = Box.createHorizontalBox();
+        Box leftPanel = Box.createVerticalBox();
+        Box middlePanel = Box.createVerticalBox();
+        Box rightPanel = Box.createVerticalBox();
 
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+        leftSpace.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+        rightSpace.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+        noseSpace.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+        aftSpace.setAlignmentX(JComponent.CENTER_ALIGNMENT);
 
-        mainPanel.add(Box.createVerticalStrut(50));
-        
-        topPanel.setLayout(new BoxLayout(topPanel, BoxLayout.X_AXIS));
-        middlePanel.setLayout(new BoxLayout(middlePanel, BoxLayout.X_AXIS));       
-        bottomPanel.setLayout(new BoxLayout(bottomPanel, BoxLayout.X_AXIS));
-        
-        leftSpace.setAlignmentX(JLabel.CENTER_ALIGNMENT);
-        rightSpace.setAlignmentX(JLabel.CENTER_ALIGNMENT);
-        noseSpace.setAlignmentX(JLabel.CENTER_ALIGNMENT);
-        aftSpace.setAlignmentX(JLabel.CENTER_ALIGNMENT);
+        nosePanel.setBorder(CritCellUtil.locationBorder("Nose"));
+        leftWingPanel.setBorder(CritCellUtil.locationBorder("Left Wing"));
+        fuselagePanel.setBorder(CritCellUtil.locationBorder("Fuselage"));
+        rightWingPanel.setBorder(CritCellUtil.locationBorder("Right Wing"));
+        aftPanel.setBorder(CritCellUtil.locationBorder("Aft"));
 
-        topPanel.add(nosePanel);
-        nosePanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Nose", TitledBorder.TOP,
-                TitledBorder.DEFAULT_POSITION));
-        nosePanel.setLayout(new BoxLayout(nosePanel, BoxLayout.Y_AXIS));
-        mainPanel.add(topPanel);
-
-        middlePanel.add(leftWingPanel);
-        leftWingPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Left Wing"));  
-        leftWingPanel.setLayout(new BoxLayout(leftWingPanel, BoxLayout.Y_AXIS));
-        middlePanel.add(fuselagePanel);
-        fuselagePanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Fuselage"));  
-        fuselagePanel.setLayout(new BoxLayout(fuselagePanel, BoxLayout.Y_AXIS));
-        middlePanel.add(rightWingPanel);
-        rightWingPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Right Wing"));
-        rightWingPanel.setLayout(new BoxLayout(rightWingPanel, BoxLayout.Y_AXIS));
-        mainPanel.add(middlePanel);
-        
-        aftPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Aft", TitledBorder.TOP,
-                TitledBorder.DEFAULT_POSITION));
-        aftPanel.setLayout(new BoxLayout(aftPanel, BoxLayout.Y_AXIS));
-        bottomPanel.add(aftPanel);
-        mainPanel.add(bottomPanel);
-        
-        btnCopyLW.setAlignmentX(Component.CENTER_ALIGNMENT);
-        btnCopyRW.setAlignmentX(Component.CENTER_ALIGNMENT);
+        btnCopyLW.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+        btnCopyRW.setAlignmentX(JComponent.CENTER_ALIGNMENT);
         btnCopyLW.addActionListener(ev -> copyLocation(Aero.LOC_LWING, Aero.LOC_RWING));
         btnCopyRW.addActionListener(ev -> copyLocation(Aero.LOC_RWING, Aero.LOC_LWING));
 
-        this.add(mainPanel);
+        leftPanel.add(leftWingPanel);
+        middlePanel.add(nosePanel);
+        middlePanel.add(fuselagePanel);
+        middlePanel.add(aftPanel);
+        rightPanel.add(rightWingPanel);
+
+        mainPanel.add(leftPanel);
+        mainPanel.add(middlePanel);
+        mainPanel.add(rightPanel);
+        add(mainPanel);
     }
 
     public void updateRefresh(RefreshListener refresh) {
@@ -154,127 +117,81 @@ public class CriticalView extends IView {
                 if (location == Aero.LOC_WINGS) {
                     continue;
                 }
-                Vector<String> critNames = new Vector<String>(1, 1);
+                Vector<String> critNames = new Vector<>(1, 1);
                 int numWeapons = 0;
-                for (int slot = 0; slot < getAero().getNumberOfCriticals(location); 
-                        slot++) {
+                for (int slot = 0; slot < getAero().getNumberOfCriticals(location); slot++) {
                     CriticalSlot cs = getAero().getCritical(location, slot);
-                    if (cs == null) {
-                        continue;
-                    } else if (cs.getType() == CriticalSlot.TYPE_SYSTEM) {
-                        // Aeros shouldn't have system types
-                        continue;
-                    } else if (cs.getType() == CriticalSlot.TYPE_EQUIPMENT) {
-                        try {
-                            Mounted m = cs.getMount();
-                            // Critical didn't get removed. Remove it now.
-                            if (m == null) {
-
-                                m = cs.getMount();
-
-                                if (m == null) {
-                                    getAero().setCritical(location, slot, null);
-                                    continue;
-                                }
-                                cs.setMount(m);
-                            }
-                            // Ignore weapon groups
-                            if (m.isWeaponGroup()){
-                                continue;
-                            }
-                            if (m.getType() instanceof WeaponType){
-                                numWeapons++;
-                            }
-                            StringBuffer critName = 
-                                    new StringBuffer(m.getName());
-                            if (critName.length() > 25) {
-                                critName.setLength(25);
-                                critName.append("...");
-                            }
-                            if (m.isRearMounted()) {
-                                critName.append(" (R)");
-                            }
-                            if (m.isSponsonTurretMounted()) {
-                                critName.append(" (ST)");
-                            }
-                            if (m.isPintleTurretMounted()) {
-                                critName.append(" (PT)");
-                            }
-                            critName.append(":" + slot);
-                            critNames.add(critName.toString());
-
-                        } catch (Exception ex) {
-                            MegaMekLab.getLogger().error(ex);
+                    if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
+                        Mounted m = cs.getMount();
+                        // Critical didn't get removed. Remove it now.
+                        if (m == null) {
+                            getAero().setCritical(location, slot, null);
+                            continue;
                         }
+                        // Ignore weapon groups
+                        if (m.isWeaponGroup()) {
+                            continue;
+                        }
+                        if (m.getType() instanceof WeaponType) {
+                            numWeapons++;
+                        }
+                        StringBuilder critName = new StringBuilder(m.getName());
+                        if (m.isRearMounted()) {
+                            critName.append(" (R)");
+                        }
+                        if (m.isSponsonTurretMounted()) {
+                            critName.append(" (ST)");
+                        }
+                        if (m.isPintleTurretMounted()) {
+                            critName.append(" (PT)");
+                        }
+                        critName.append(":").append(slot);
+                        critNames.add(critName.toString());
                     }
                 }
 
                 if (critNames.size() == 0) {
-                    critNames.add(MtfFile.EMPTY);
+                    critNames.add(CritCellUtil.EMPTYCELLTEXT);
                 }
-                DropTargetCriticalList<String> criticalSlotList = null;                
-
-                DropTargetCriticalList<String> dropTargetCriticalList = new DropTargetCriticalList<String>(
-                        critNames, eSource, refresh, showEmpty);
-                criticalSlotList = dropTargetCriticalList;
+                DropTargetCriticalList<String> criticalSlotList = new DropTargetCriticalList<>(
+                        critNames, eSource, refresh, true);
                 criticalSlotList.setAlignmentX(JLabel.CENTER_ALIGNMENT);
                 criticalSlotList.setVisibleRowCount(critNames.size());
-                criticalSlotList.setSelectionMode(
-                        ListSelectionModel.SINGLE_SELECTION);
-                criticalSlotList.setFont(new Font("Arial", Font.PLAIN, 10));
-                criticalSlotList.setName(Integer.toString(location));
-                criticalSlotList.setBorder(BorderFactory.createEtchedBorder(
-                        Color.WHITE.brighter(), Color.BLACK.darker()));
+                criticalSlotList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+                criticalSlotList.setName(location + "");
+                criticalSlotList.setBorder(BorderFactory.createLineBorder(Color.BLACK));
                 
                 switch (location) {
                     case Aero.LOC_NOSE:
                         nosePanel.add(criticalSlotList);
-                        noseSpace.setText("Weapons: " + 
-                                numWeapons + "/" + availSpace[location]);
+                        noseSpace.setText("Weapons: " + numWeapons + " / " + availSpace[location]);
                         break;
                     case Aero.LOC_LWING:
                         leftWingPanel.add(criticalSlotList);
-                        leftSpace.setText("Weapons: " + 
-                                numWeapons + "/" + availSpace[location]);
+                        leftSpace.setText("Weapons: " + numWeapons + " / " + availSpace[location]);
                         break;
                     case Aero.LOC_RWING:
                         rightWingPanel.add(criticalSlotList);
-                        rightSpace.setText("Weapons: " + 
-                                numWeapons + "/" + availSpace[location]);
+                        rightSpace.setText("Weapons: " + numWeapons + " / " + availSpace[location]);
                         break;
                     case Aero.LOC_AFT:
                         aftPanel.add(criticalSlotList);
-                        aftSpace.setText("Weapons: " + 
-                                numWeapons + "/" + availSpace[location]);
+                        aftSpace.setText("Weapons: " + numWeapons + " / " + availSpace[location]);
                         break;
                     case Aero.LOC_FUSELAGE:
                         fuselagePanel.add(criticalSlotList);
                         break;
                 }
-                    
-                
             }
             
             leftWingPanel.add(leftSpace);
             leftWingPanel.add(btnCopyRW);
-            leftWingPanel.add(Box.createVerticalStrut(8));
             rightWingPanel.add(rightSpace);
             rightWingPanel.add(btnCopyLW);
-            rightWingPanel.add(Box.createVerticalStrut(8));
             nosePanel.add(noseSpace);
-            nosePanel.add(Box.createVerticalStrut(8));
             aftPanel.add(aftSpace);
-            aftPanel.add(Box.createVerticalStrut(8));
-            
-            nosePanel.repaint();
-            leftWingPanel.repaint();
-            rightWingPanel.repaint();
-            aftPanel.repaint();
-            
-            nosePanel.invalidate();
-            leftWingPanel.invalidate();
-            rightWingPanel.invalidate();
-            aftPanel.invalidate();
+
+            validate();
         }
     }
     

--- a/src/megameklab/com/ui/Aero/views/CriticalView.java
+++ b/src/megameklab/com/ui/Aero/views/CriticalView.java
@@ -151,7 +151,7 @@ public class CriticalView extends IView {
                 }
 
                 if (critNames.size() == 0) {
-                    critNames.add(CritCellUtil.EMPTYCELLTEXT);
+                    critNames.add(CritCellUtil.EMPTY_CRITCELL_TEXT);
                 }
                 DropTargetCriticalList<String> criticalSlotList = new DropTargetCriticalList<>(
                         critNames, eSource, refresh, true);

--- a/src/megameklab/com/ui/BattleArmor/tabs/BuildTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/BuildTab.java
@@ -16,30 +16,18 @@
 
 package megameklab.com.ui.BattleArmor.tabs;
 
-import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.ArrayList;
-
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.ScrollPaneConstants;
-import javax.swing.SpringLayout;
-
 import megamek.common.BattleArmor;
 import megamek.common.Mounted;
-import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.BattleArmor.CriticalSuit;
 import megameklab.com.ui.BattleArmor.views.BuildView;
 import megameklab.com.ui.BattleArmor.views.CriticalView;
+import megameklab.com.ui.EntitySource;
 import megameklab.com.util.ITab;
 import megameklab.com.util.RefreshListener;
-import megameklab.com.util.SpringLayoutHelper;
 import megameklab.com.util.UnitUtil;
+
+import javax.swing.*;
+import java.util.ArrayList;
 
 /**
  * A component that creates a table for building the criticals of a unit.  This
@@ -50,85 +38,38 @@ import megameklab.com.util.UnitUtil;
  * @author arlith
  *
  */
-public class BuildTab extends ITab implements ActionListener {
-
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6756011847500605874L;
+public class BuildTab extends ITab {
 
     private RefreshListener refresh = null;
-    private ArrayList<CriticalView> critViews = new ArrayList<CriticalView>();
-    private BuildView buildView = null;
+    private final ArrayList<CriticalView> critViews = new ArrayList<>();
+    private final BuildView buildView;
 
-    private JScrollPane critScrollPanel;
-
-    /**
-     * Panel for displaying the critical trees for each trooper in the squad.
-     */
-    private JPanel critPanel = new JPanel();
-    /**
-     * Panel that displays autoFill and reset buttons.
-     */
-
-    private JPanel buttonPanel = new JPanel();
-    /**
-     * Panel that holds the <code>UnallocatedView</code> and buttonPanel
-     */
-    private JPanel mainPanel = new JPanel();
-
-    private JButton autoFillButton = new JButton("Auto Fill");
-    private JButton resetButton = new JButton("Reset");
-
-    private String AUTOFILLCOMMAND = "autofillbuttoncommand";
-    private String RESETCOMMAND = "resetbuttoncommand";
+    /** Panel for displaying the critical trees for each trooper in the squad. */
+    private final Box critPanel = Box.createVerticalBox();
 
     public BuildTab(EntitySource eSource) {
         super(eSource);
         setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
-        buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
-        critPanel.setLayout(new BoxLayout(critPanel, BoxLayout.Y_AXIS));
-        critScrollPanel = new JScrollPane(critPanel);
-        critScrollPanel.setHorizontalScrollBarPolicy(
-                ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
-        critScrollPanel.setBorder(BorderFactory.createEmptyBorder());
-        critScrollPanel.setMinimumSize(new java.awt.Dimension(400, 500));
-        critScrollPanel.setPreferredSize(new java.awt.Dimension(400, 500));
-        critScrollPanel.getVerticalScrollBar().setUnitIncrement(20);
-
         createCriticalViews();
-
         buildView = new BuildView(eSource);
 
-        mainPanel.add(buildView);
-
+        JButton autoFillButton = new JButton("Auto Fill");
         autoFillButton.setMnemonic('A');
-        autoFillButton.setActionCommand(AUTOFILLCOMMAND);
+        autoFillButton.addActionListener(ev -> autoFillCrits());
+        JButton resetButton = new JButton("Reset");
         resetButton.setMnemonic('R');
-        resetButton.setActionCommand(RESETCOMMAND);
+        resetButton.addActionListener(ev -> resetCrits());
+
+        JPanel buttonPanel = new JPanel();
         buttonPanel.add(autoFillButton);
         buttonPanel.add(resetButton);
 
+        Box mainPanel = Box.createVerticalBox();
+        mainPanel.add(buildView);
         mainPanel.add(buttonPanel);
-
-        this.add(critScrollPanel);
-        this.add(mainPanel);
+        add(critPanel);
+        add(mainPanel);
         refresh();
-    }
-
-    public JPanel availableCritsPanel() {
-        JPanel masterPanel = new JPanel(new SpringLayout());
-        Dimension maxSize = new Dimension();
-
-        masterPanel.add(buildView);
-
-        SpringLayoutHelper.setupSpringGrid(masterPanel, 1);
-        maxSize.setSize(300, 5);
-        masterPanel.setPreferredSize(maxSize);
-        masterPanel.setMinimumSize(maxSize);
-        masterPanel.setMaximumSize(maxSize);
-        return masterPanel;
     }
 
     /**
@@ -139,46 +80,30 @@ public class BuildTab extends ITab implements ActionListener {
      * we will need to adjust the number of <code>CriticalView</code>s.  This
      * method will create the proper number of <code>CriticalView</code>s.
      */
-    private void createCriticalViews(){
+    private void createCriticalViews() {
         critViews.clear();
-        for (int i = 0; i < (getBattleArmor()).getTroopers(); i++){
-            critViews.add(new CriticalView(eSource, i + 1, true,
-                    refresh));
+        for (int i = 0; i < (getBattleArmor()).getTroopers(); i++) {
+            critViews.add(new CriticalView(eSource, i + 1, true, refresh));
             critPanel.add(critViews.get(i));
             critPanel.add(Box.createVerticalStrut(20));
         }
     }
 
     public void refresh() {
-        removeAllActionListeners();
-
         // We need to have a CritView for each trooper
-        if (critViews.size() != (getBattleArmor()).getTroopers()){
+        if (critViews.size() != (getBattleArmor()).getTroopers()) {
             critPanel.removeAll();
             createCriticalViews();
         }
-
-        for (CriticalView critView : critViews){
+        for (CriticalView critView : critViews) {
             critView.refresh();
         }
         critPanel.validate();
-
         buildView.refresh();
-
-        addAllActionListeners();
-    }
-
-    public void actionPerformed(ActionEvent e) {
-        if (e.getActionCommand().equals(AUTOFILLCOMMAND)) {
-            autoFillCrits();
-        } else if (e.getActionCommand().equals(RESETCOMMAND)) {
-            resetCrits();
-        }
     }
 
     private void autoFillCrits() {
-        // BattleArmor doesn't track crits implicitly, so they need to be
-        // tracked explicitly
+        // BattleArmor doesn't track crits implicitly, so they need to be tracked explicitly
         CriticalSuit crits = new CriticalSuit(getBattleArmor());
         // Populate with equipment that is already installed
         for (Mounted m : getBattleArmor().getEquipment()) {
@@ -205,34 +130,22 @@ public class BuildTab extends ITab implements ActionListener {
                 }
             }
         }
-        refresh.refreshAll();
+        refreshAll();
     }
 
     private void resetCrits() {
         for (Mounted mount : getBattleArmor().getEquipment()) {
-            if (UnitUtil.isFixedLocationSpreadEquipment(mount.getType())){
+            if (UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
                 continue;
             }
             mount.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
         }
-        refresh.refreshAll();
-    }
-
-    public void removeAllActionListeners() {
-        autoFillButton.removeActionListener(this);
-        resetButton.removeActionListener(this);
-    }
-
-    public void addAllActionListeners() {
-        autoFillButton.addActionListener(this);
-        resetButton.addActionListener(this);
+        refreshAll();
     }
 
     public void addRefreshedListener(RefreshListener l) {
         refresh = l;
-        for (CriticalView critView : critViews){
-            critView.updateRefresh(refresh);
-        }
+        critViews.forEach(v -> v.updateRefresh(refresh));
         buildView.addRefreshedListener(refresh);
     }
 

--- a/src/megameklab/com/ui/BattleArmor/views/CriticalView.java
+++ b/src/megameklab/com/ui/BattleArmor/views/CriticalView.java
@@ -66,7 +66,7 @@ public class CriticalView extends IView {
         Box rightPanel = Box.createVerticalBox();
 
         mainPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createMatteBorder(2, 0, 0, 0, CritCellUtil.CRITCELL_BORDERCOLOR),
+                BorderFactory.createMatteBorder(2, 0, 0, 0, CritCellUtil.CRITCELL_BORDER_COLOR),
                 " Trooper " + trooper + " ",
                 TitledBorder.TOP,
                 TitledBorder.DEFAULT_POSITION));
@@ -104,7 +104,7 @@ public class CriticalView extends IView {
         int[] numAMWeapons = new int[BattleArmor.MOUNT_NUM_LOCS];
          
         for (Mounted m : getBattleArmor().getEquipment()) {
-            if (m.getLocation() == BattleArmor.LOC_SQUAD || m.getLocation() == trooper) {
+            if ((m.getLocation() == BattleArmor.LOC_SQUAD) || (m.getLocation() == trooper)) {
                 critSuit.addMounted(m.getBaMountLoc(), m);
                 // Weapons mounted in a quad turret count against the body limits
                 int useLoc = m.getBaMountLoc();
@@ -129,13 +129,13 @@ public class CriticalView extends IView {
                     CriticalSlot cs = critSuit.getCritical(location, slot);
                     if (cs == null) {
                         if (showEmpty) {
-                            critNames.add(CritCellUtil.EMPTYCELLTEXT);
+                            critNames.add(CritCellUtil.EMPTY_CRITCELL_TEXT);
                         }
                     } else if (cs.getType() == CriticalSlot.TYPE_EQUIPMENT) {
                         Mounted m = cs.getMount();
                         if (m == null) {
                             if (showEmpty) {
-                                critNames.add(CritCellUtil.EMPTYCELLTEXT);
+                                critNames.add(CritCellUtil.EMPTY_CRITCELL_TEXT);
                             }
                         } else {
                             critNames.add(m.getName() + ":" + slot + ":" + getBattleArmor().getEquipmentNum(m));
@@ -149,7 +149,7 @@ public class CriticalView extends IView {
                 criticalSlotList.setAlignmentX(JComponent.CENTER_ALIGNMENT);
                 criticalSlotList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
                 criticalSlotList.setName(location + ":" + trooper);
-                criticalSlotList.setBorder(BorderFactory.createLineBorder(CritCellUtil.CRITCELL_BORDERCOLOR));
+                criticalSlotList.setBorder(BorderFactory.createLineBorder(CritCellUtil.CRITCELL_BORDER_COLOR));
                 
                 switch (location) {
                     case BattleArmor.MOUNT_LOC_LARM:

--- a/src/megameklab/com/ui/BattleArmor/views/CriticalView.java
+++ b/src/megameklab/com/ui/BattleArmor/views/CriticalView.java
@@ -1,7 +1,6 @@
 /*
  * MegaMekLab - Copyright (C) 2008
- * 
- * Original author - jtighe (torren@users.sourceforge.net)
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  * 
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -16,154 +15,78 @@
 
 package megameklab.com.ui.BattleArmor.views;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.io.File;
-import java.util.Vector;
-
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.ListSelectionModel;
-import javax.swing.border.TitledBorder;
-
-import megamek.common.BattleArmor;
-import megamek.common.CriticalSlot;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
-import megamek.common.loaders.MtfFile;
+import megamek.common.*;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestBattleArmor;
 import megamek.common.weapons.infantry.InfantryWeapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.BattleArmor.CriticalSuit;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.ui.util.CritCellUtil;
 import megameklab.com.util.IView;
-import megameklab.com.util.RefreshListener;
 import megameklab.com.util.Mech.DropTargetCriticalList;
+import megameklab.com.util.RefreshListener;
 
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import java.io.File;
+import java.util.Vector;
+
+/**
+ * The Crit Slots view for a single suit of BattleArmor
+ *
+ * Original author - jtighe (torren@users.sourceforge.net)
+ * @author arlith
+ * @author Simon (Juliez)
+ */
 public class CriticalView extends IView {
 
-    /**
-     *  Component for displaying information related to criticals on a suit of
-     *  <code>BattleArmor</code>.  This will display a list of criticals for
-     *  each location and what equipment is currently located there.  There 
-     *  should be a <code>CriticalView</code> for each trooper in the squad.
-     */
-    private static final long serialVersionUID = -6960975031034494605L;
-
-    /**
-     * JPanel that holds all the components
-     */
-    private JPanel suitPanel = new JPanel();
-    
-    /**
-     * JPanel for all of the left arm components
-     */
-    private JPanel leftPanel = new JPanel();
-    /**
-     * JPanel for all of hte right arm components
-     */
-    private JPanel rightPanel = new JPanel();
-    /**
-     * JPanel for all of the body components
-     */
-    private JPanel bodyPanel = new JPanel();
-    
-    /**
-     * JPanel for all of the turret components
-     */
-    private JPanel turretPanel = new JPanel();
-
-    private JLabel weightLabel = new JLabel();
+    private final Box leftArmPanel = Box.createVerticalBox();
+    private final Box rightArmPanel = Box.createVerticalBox();
+    private final Box bodyPanel = Box.createVerticalBox();
+    private final Box turretPanel = Box.createVerticalBox();
+    private final JLabel weightLabel = new JLabel();
     
     private RefreshListener refresh;
-
-    private boolean showEmpty = false;
-    
+    private final boolean showEmpty;
     private CriticalSuit critSuit;
     
-    private Dimension lblSz = new Dimension(100, 25);
-    
-    /**
-     * Keeps track of which trooper in the squad this <code>CriticalView</code>
-     * is for.
-     */
+    /** The trooper in the squad this CriticalView is for. */
     int trooper;
     
-    public CriticalView(EntitySource eSource, int t, boolean showEmpty,
-            RefreshListener refresh) {
+    public CriticalView(EntitySource eSource, int t, boolean showEmpty, RefreshListener refresh) {
         super(eSource);
         trooper = t;
         critSuit = new CriticalSuit(getBattleArmor());
         this.showEmpty = showEmpty;
         this.refresh = refresh;
 
-        JPanel mainPanel = new JPanel();
+        Box mainPanel = Box.createHorizontalBox();
+        Box leftPanel = Box.createVerticalBox();
+        Box middlePanel = Box.createVerticalBox();
+        Box rightPanel = Box.createVerticalBox();
 
-        mainPanel.setOpaque(false);
-        suitPanel.setOpaque(false);
+        mainPanel.setBorder(BorderFactory.createTitledBorder(
+                BorderFactory.createMatteBorder(2, 0, 0, 0, CritCellUtil.CRITCELL_BORDERCOLOR),
+                " Trooper " + trooper + " ",
+                TitledBorder.TOP,
+                TitledBorder.DEFAULT_POSITION));
 
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
-
-        suitPanel.setLayout(new GridBagLayout());
-        suitPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Trooper " + trooper,
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-
-        GridBagConstraints gbc = new GridBagConstraints();
-        
-        
-        gbc.gridx = gbc.gridy = 0;
-        gbc.gridwidth = gbc.gridheight = 1;
-        leftPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(),
-                BattleArmor.MOUNT_LOC_NAMES[BattleArmor.MOUNT_LOC_LARM],
-                TitledBorder.CENTER, TitledBorder.TOP));
-        leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.Y_AXIS));
-        suitPanel.add(leftPanel,gbc);
-
-        gbc.gridx++;
-        bodyPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(),
-                BattleArmor.MOUNT_LOC_NAMES[BattleArmor.MOUNT_LOC_BODY],
-                TitledBorder.CENTER, TitledBorder.TOP));
-        bodyPanel.setLayout(new BoxLayout(bodyPanel, BoxLayout.Y_AXIS));
-        suitPanel.add(bodyPanel,gbc);
-        
-        gbc.gridy++;
-        turretPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(),
-                BattleArmor.MOUNT_LOC_NAMES[BattleArmor.MOUNT_LOC_TURRET],
-                TitledBorder.CENTER, TitledBorder.TOP));
-        turretPanel.setLayout(new BoxLayout(turretPanel, BoxLayout.Y_AXIS));
-        suitPanel.add(turretPanel,gbc);
-        
-        gbc.gridx++;
-        gbc.gridy = 0;
-        rightPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(),
-                BattleArmor.MOUNT_LOC_NAMES[BattleArmor.MOUNT_LOC_RARM],
-                TitledBorder.CENTER, TitledBorder.TOP));
-        rightPanel.setLayout(new BoxLayout(rightPanel, BoxLayout.Y_AXIS));
-        suitPanel.add(rightPanel,gbc);
-        
-        gbc.gridx = 0;
-        gbc.gridy++;
-        gbc.gridwidth = 3;
-        gbc.anchor = GridBagConstraints.CENTER;
+        leftArmPanel.setBorder(CritCellUtil.locationBorder(BattleArmor.MOUNT_LOC_NAMES[BattleArmor.MOUNT_LOC_LARM]));
+        bodyPanel.setBorder(CritCellUtil.locationBorder(BattleArmor.MOUNT_LOC_NAMES[BattleArmor.MOUNT_LOC_BODY]));
+        turretPanel.setBorder(CritCellUtil.locationBorder(BattleArmor.MOUNT_LOC_NAMES[BattleArmor.MOUNT_LOC_TURRET]));
+        rightArmPanel.setBorder(CritCellUtil.locationBorder(BattleArmor.MOUNT_LOC_NAMES[BattleArmor.MOUNT_LOC_RARM]));
         weightLabel.setAlignmentX(JLabel.CENTER_ALIGNMENT);
-        suitPanel.add(weightLabel,gbc);
-        
-        mainPanel.add(suitPanel);
-        this.add(mainPanel);
+
+        leftPanel.add(leftArmPanel);
+        middlePanel.add(bodyPanel);
+        middlePanel.add(weightLabel);
+        rightPanel.add(rightArmPanel);
+        rightPanel.add(turretPanel);
+
+        mainPanel.add(leftPanel);
+        mainPanel.add(middlePanel);
+        mainPanel.add(rightPanel);
+        add(mainPanel);
     }
 
     public void updateRefresh(RefreshListener refresh) {
@@ -172,17 +95,16 @@ public class CriticalView extends IView {
 
     public void refresh() {
         critSuit = new CriticalSuit(getBattleArmor());
-        leftPanel.removeAll();
-        rightPanel.removeAll();
+        leftArmPanel.removeAll();
+        rightArmPanel.removeAll();
         bodyPanel.removeAll();
         turretPanel.removeAll();
         
-        int [] numAPWeapons = new int[BattleArmor.MOUNT_NUM_LOCS];
-        int [] numAMWeapons = new int[BattleArmor.MOUNT_NUM_LOCS];
+        int[] numAPWeapons = new int[BattleArmor.MOUNT_NUM_LOCS];
+        int[] numAMWeapons = new int[BattleArmor.MOUNT_NUM_LOCS];
          
         for (Mounted m : getBattleArmor().getEquipment()) {
-            if (m.getLocation() == BattleArmor.LOC_SQUAD 
-                    || m.getLocation() == trooper) {
+            if (m.getLocation() == BattleArmor.LOC_SQUAD || m.getLocation() == trooper) {
                 critSuit.addMounted(m.getBaMountLoc(), m);
                 // Weapons mounted in a quad turret count against the body limits
                 int useLoc = m.getBaMountLoc();
@@ -190,8 +112,7 @@ public class CriticalView extends IView {
                     useLoc = BattleArmor.MOUNT_LOC_BODY;
                 }
                 if (useLoc != BattleArmor.MOUNT_LOC_NONE) {
-                    if ((m.getType() instanceof WeaponType) 
-                            && !(m.getType() instanceof InfantryWeapon)) {
+                    if ((m.getType() instanceof WeaponType) && !(m.getType() instanceof InfantryWeapon)) {
                         numAMWeapons[useLoc]++;
                     }
                     if (m.getType().hasFlag(MiscType.F_AP_MOUNT)) {
@@ -203,60 +124,39 @@ public class CriticalView extends IView {
 
         synchronized (getBattleArmor()) {
             for (int location = 0; location < critSuit.locations(); location++) {
-                Vector<String> critNames = new Vector<String>(1, 1);
-                for (int slot = 0; slot < critSuit.getNumCriticals(location); 
-                        slot++) {
+                Vector<String> critNames = new Vector<>(1, 1);
+                for (int slot = 0; slot < critSuit.getNumCriticals(location); slot++) {
                     CriticalSlot cs = critSuit.getCritical(location, slot);
                     if (cs == null) {
                         if (showEmpty) {
-                            critNames.add(MtfFile.EMPTY);
+                            critNames.add(CritCellUtil.EMPTYCELLTEXT);
                         }
-                        continue;
-                    } else if (cs.getType() == CriticalSlot.TYPE_SYSTEM) {
-                        // BattleArmor shouldn't have system type crits
-                        continue;
                     } else if (cs.getType() == CriticalSlot.TYPE_EQUIPMENT) {
-                        try {
-                            Mounted m = cs.getMount();
-                            // Critical didn't get removed. Remove it now.
-                            if (m == null) {
-                                if (showEmpty) {
-                                    critNames.add(MtfFile.EMPTY);
-                                }
-                                continue;
+                        Mounted m = cs.getMount();
+                        if (m == null) {
+                            if (showEmpty) {
+                                critNames.add(CritCellUtil.EMPTYCELLTEXT);
                             }
-                            
-                            StringBuffer critName = 
-                                    new StringBuffer(m.getName());
-
-                            critName.append(":" + slot + ":"
-                                    + getBattleArmor().getEquipmentNum(m));
-                            critNames.add(critName.toString());
-                        } catch (Exception ex) {
-                            MegaMekLab.getLogger().error(ex);
+                        } else {
+                            critNames.add(m.getName() + ":" + slot + ":" + getBattleArmor().getEquipmentNum(m));
                         }
                     }
                 }
 
-                DropTargetCriticalList<String> criticalSlotList = null;                
-
-                criticalSlotList = new DropTargetCriticalList<String>(
+                DropTargetCriticalList<String> criticalSlotList = new DropTargetCriticalList<>(
                         critNames, eSource, refresh, showEmpty);
-                criticalSlotList.setAlignmentX(JLabel.CENTER_ALIGNMENT);
                 criticalSlotList.setVisibleRowCount(critNames.size());
-                criticalSlotList.setSelectionMode(
-                        ListSelectionModel.SINGLE_SELECTION);
-                criticalSlotList.setFont(new Font("Arial", Font.PLAIN, 10));
+                criticalSlotList.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+                criticalSlotList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
                 criticalSlotList.setName(location + ":" + trooper);
-                criticalSlotList.setBorder(BorderFactory.createEtchedBorder(
-                        Color.WHITE.brighter(), Color.BLACK.darker()));
+                criticalSlotList.setBorder(BorderFactory.createLineBorder(CritCellUtil.CRITCELL_BORDERCOLOR));
                 
                 switch (location) {
                     case BattleArmor.MOUNT_LOC_LARM:
-                        leftPanel.add(criticalSlotList);
+                        leftArmPanel.add(criticalSlotList);
                         break;
                     case BattleArmor.MOUNT_LOC_RARM:
-                        rightPanel.add(criticalSlotList);
+                        rightArmPanel.add(criticalSlotList);
                         break;
                     case BattleArmor.MOUNT_LOC_BODY:
                         bodyPanel.add(criticalSlotList);
@@ -267,95 +167,58 @@ public class CriticalView extends IView {
                 }
             }
             
-            String amTxt[] = new String[BattleArmor.MOUNT_NUM_LOCS];
-            String apTxt[] = new String[BattleArmor.MOUNT_NUM_LOCS];
+            String[] amTxt = new String[BattleArmor.MOUNT_NUM_LOCS];
+            String[] apTxt = new String[BattleArmor.MOUNT_NUM_LOCS];
             for (int loc = 0; loc < BattleArmor.MOUNT_NUM_LOCS; loc++) {
-                amTxt[loc] = "AM Wpn: " + numAMWeapons[loc] + "/"
+                amTxt[loc] = "Anti-Mech Weapons: " + numAMWeapons[loc] + "/" 
                         + getBattleArmor().getNumAllowedAntiMechWeapons(loc);
-                apTxt[loc] = "AP Wpn: " + numAPWeapons[loc] + "/"
-                        + getBattleArmor().getNumAllowedAntiPersonnelWeapons(
-                                loc, trooper);
-                if (numAMWeapons[loc] 
-                        > getBattleArmor().getNumAllowedAntiMechWeapons(loc)) {
-                    amTxt[loc] = "<html><font color='C00000'>" + amTxt[loc] 
-                            + "</font></html>";  
+                apTxt[loc] = "Anti-Personnel Weapons: " + numAPWeapons[loc] + "/" 
+                        + getBattleArmor().getNumAllowedAntiPersonnelWeapons(loc, trooper);
+                if (numAMWeapons[loc] > getBattleArmor().getNumAllowedAntiMechWeapons(loc)) {
+                    amTxt[loc] = "<html><font color='C00000'>" + amTxt[loc] + "</font></html>";
                 }
-                if (numAPWeapons[loc]
-                        > getBattleArmor().getNumAllowedAntiMechWeapons(loc)) {
-                    apTxt[loc] = "<html><font color='C00000'>" + apTxt[loc] 
-                            + "</font></html>";
+                if (numAPWeapons[loc] > getBattleArmor().getNumAllowedAntiMechWeapons(loc)) {
+                    apTxt[loc] = "<html><font color='C00000'>" + apTxt[loc] + "</font></html>";
                 }
             }
-                    
 
-            leftPanel.add(makeLabel(amTxt[BattleArmor.MOUNT_LOC_LARM], lblSz));
-            leftPanel.add(makeLabel(apTxt[BattleArmor.MOUNT_LOC_LARM], lblSz));
+            leftArmPanel.add(makeLabel(amTxt[BattleArmor.MOUNT_LOC_LARM]));
+            leftArmPanel.add(makeLabel(apTxt[BattleArmor.MOUNT_LOC_LARM]));
             
-            rightPanel.add(makeLabel(amTxt[BattleArmor.MOUNT_LOC_RARM], lblSz));
-            rightPanel.add(makeLabel(apTxt[BattleArmor.MOUNT_LOC_RARM], lblSz));
+            rightArmPanel.add(makeLabel(amTxt[BattleArmor.MOUNT_LOC_RARM]));
+            rightArmPanel.add(makeLabel(apTxt[BattleArmor.MOUNT_LOC_RARM]));
             
-            bodyPanel.add(makeLabel(amTxt[BattleArmor.MOUNT_LOC_BODY], lblSz));
-            bodyPanel.add(makeLabel(apTxt[BattleArmor.MOUNT_LOC_BODY], lblSz));
-
+            bodyPanel.add(makeLabel(amTxt[BattleArmor.MOUNT_LOC_BODY]));
+            bodyPanel.add(makeLabel(apTxt[BattleArmor.MOUNT_LOC_BODY]));
 
             // Hide the arm panels if we are a quad
-            if (getBattleArmor().getChassisType() == 
-                    BattleArmor.CHASSIS_TYPE_QUAD) {
-                leftPanel.setVisible(false);
-                rightPanel.setVisible(false);
-                turretPanel.setVisible(getBattleArmor().getTurretCapacity() > 0);
-            } else {
-                leftPanel.setVisible(true);
-                rightPanel.setVisible(true);
-                turretPanel.setVisible(false);
-            }
+            boolean isQuad = getBattleArmor().getChassisType() == BattleArmor.CHASSIS_TYPE_QUAD;
+            leftArmPanel.setVisible(!isQuad);
+            rightArmPanel.setVisible(!isQuad);
+            turretPanel.setVisible(isQuad && (getBattleArmor().getTurretCapacity() > 0));
             
             EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
                     "data/mechfiles/UnitVerifierOptions.xml"));
-            TestBattleArmor testBA = new TestBattleArmor(getBattleArmor(),
-                    entityVerifier.baOption, null);
+            TestBattleArmor testBA = new TestBattleArmor(getBattleArmor(), entityVerifier.baOption, null);
             
             String weightTxt = "Weight: "
                     + String.format("%1$.3f", testBA.calculateWeight(trooper))
                     + "/" + getBattleArmor().getTrooperWeight();
-            if (testBA.calculateWeight(trooper) 
-                    > getBattleArmor().getTrooperWeight()) {
-                weightTxt = "<html><font color='C00000'>" + weightTxt 
-                        + "</font></html>";
+            if (testBA.calculateWeight(trooper) > getBattleArmor().getTrooperWeight()) {
+                weightTxt = "<html><font color='C00000'>" + weightTxt + "</font></html>";
             }
-                    
             weightLabel.setText(weightTxt);
-             
-            leftPanel.add(Box.createVerticalStrut(8));
-            rightPanel.add(Box.createVerticalStrut(8));
-            bodyPanel.add(Box.createVerticalStrut(8));
-            turretPanel.add(Box.createVerticalStrut(8));
-            
-            leftPanel.invalidate();
-            leftPanel.invalidate();
-            rightPanel.invalidate();
-            turretPanel.invalidate();
-            
-            bodyPanel.repaint();
-            leftPanel.repaint();
-            rightPanel.repaint();
-            turretPanel.repaint();
+
+            leftArmPanel.validate();
+            leftArmPanel.validate();
+            rightArmPanel.validate();
+            turretPanel.validate();
         }
     }
     
-    private JLabel makeLabel(String text, Dimension maxSize) {
-
-        JLabel label = new JLabel(text, JLabel.CENTER);
+    private JLabel makeLabel(String text) {
+        JLabel label = new JLabel(text);
         label.setAlignmentX(JLabel.CENTER_ALIGNMENT);
-        label.setAlignmentY(JLabel.CENTER_ALIGNMENT);
-
-        setFieldSize(label, maxSize);
         return label;
-    }
-    
-    private void setFieldSize(JComponent box, Dimension maxSize) {
-        box.setPreferredSize(maxSize);
-        box.setMaximumSize(maxSize);
-        box.setMinimumSize(maxSize);
     }
 }

--- a/src/megameklab/com/ui/BattleArmor/views/CriticalView.java
+++ b/src/megameklab/com/ui/BattleArmor/views/CriticalView.java
@@ -209,10 +209,7 @@ public class CriticalView extends IView {
             }
             weightLabel.setText(weightTxt);
 
-            leftArmPanel.validate();
-            leftArmPanel.validate();
-            rightArmPanel.validate();
-            turretPanel.validate();
+            validate();
         }
     }
     

--- a/src/megameklab/com/ui/Mek/tabs/BuildTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/BuildTab.java
@@ -64,7 +64,7 @@ public class BuildTab extends ITab implements ActionListener {
 
         GridBagConstraints gbc = new GridBagConstraints();
 
-        critView = new CriticalView(eSource, true, refresh);
+        critView = new CriticalView(eSource, refresh);
         buildView = new BuildView(eSource, refresh);
 
         autoFillButton.setMnemonic('A');

--- a/src/megameklab/com/ui/Mek/views/CriticalView.java
+++ b/src/megameklab/com/ui/Mek/views/CriticalView.java
@@ -129,7 +129,7 @@ public class CriticalView extends IView {
                 for (int slot = 0; slot < getMech().getNumberOfCriticals(location); slot++) {
                     CriticalSlot cs = getMech().getCritical(location, slot);
                     if (cs == null) {
-                        critNames.add(CritCellUtil.EMPTYCELLTEXT);
+                        critNames.add(CritCellUtil.EMPTY_CRITCELL_TEXT);
                     } else if (cs.getType() == CriticalSlot.TYPE_SYSTEM) {
                         critNames.add(getMech().getSystemName(cs.getIndex()));
                     } else if (cs.getType() == CriticalSlot.TYPE_EQUIPMENT) {
@@ -137,7 +137,7 @@ public class CriticalView extends IView {
                         if (m == null) {
                             // Critical didn't get removed. Remove it now.
                             getMech().setCritical(location, slot, null);
-                            critNames.add(CritCellUtil.EMPTYCELLTEXT);
+                            critNames.add(CritCellUtil.EMPTY_CRITCELL_TEXT);
                         } else {
                             StringBuilder critName = new StringBuilder(m.getName());
                             if (m.isRearMounted()) {
@@ -156,7 +156,7 @@ public class CriticalView extends IView {
                 criticalSlotList.setVisibleRowCount(critNames.size());
                 criticalSlotList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
                 criticalSlotList.setName(location + "");
-                criticalSlotList.setBorder(BorderFactory.createLineBorder(CritCellUtil.CRITCELL_BORDERCOLOR));
+                criticalSlotList.setBorder(BorderFactory.createLineBorder(CritCellUtil.CRITCELL_BORDER_COLOR));
                 if (mekPanels.containsKey(location)) {
                     mekPanels.get(location).add(criticalSlotList);
                 }

--- a/src/megameklab/com/ui/Mek/views/CriticalView.java
+++ b/src/megameklab/com/ui/Mek/views/CriticalView.java
@@ -1,7 +1,6 @@
 /*
  * MegaMekLab - Copyright (C) 2008
- *
- * Original author - jtighe (torren@users.sourceforge.net)
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -16,100 +15,58 @@
 
 package megameklab.com.ui.Mek.views;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
+import megamek.common.*;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.ui.util.CritCellUtil;
+import megameklab.com.util.IView;
+import megameklab.com.util.Mech.DropTargetCriticalList;
+import megameklab.com.util.RefreshListener;
+
+import javax.swing.*;
+import java.util.Map;
 import java.util.Vector;
 
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JPanel;
-import javax.swing.ListSelectionModel;
-import javax.swing.border.TitledBorder;
-
-import megamek.common.CriticalSlot;
-import megamek.common.Mech;
-import megamek.common.Mounted;
-import megamek.common.QuadMech;
-import megamek.common.loaders.MtfFile;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.IView;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.Mech.DropTargetCriticalList;
-
+/**
+ * The Crit Slots view for a Mek (including Quad and Tripod)
+ *
+ * Original author - jtighe (torren@users.sourceforge.net)
+ * @author arlith
+ * @author Simon (Juliez)
+ */
 public class CriticalView extends IView {
 
-    /**
-     *
-     */
-    private static final long serialVersionUID = -6960975031034494605L;
-
-    private JPanel laPanel = new JPanel();
-    private JPanel raPanel = new JPanel();
-    private JPanel llPanel = new JPanel();
-    private JPanel rlPanel = new JPanel();
-    private JPanel clPanel = new JPanel();
-    private JPanel ltPanel = new JPanel();
-    private JPanel rtPanel = new JPanel();
-    private JPanel ctPanel = new JPanel();
-    private JPanel headPanel = new JPanel();
+    private final JPanel laPanel = new JPanel();
+    private final JPanel raPanel = new JPanel();
+    private final JPanel llPanel = new JPanel();
+    private final JPanel rlPanel = new JPanel();
+    private final JPanel clPanel = new JPanel();
+    private final JPanel ltPanel = new JPanel();
+    private final JPanel rtPanel = new JPanel();
+    private final JPanel ctPanel = new JPanel();
+    private final JPanel hdPanel = new JPanel();
     private RefreshListener refresh;
 
-    private boolean showEmpty = false;
+    private final Map<Integer, JComponent> mekPanels = Map.of(Mech.LOC_HEAD, hdPanel, Mech.LOC_LARM, laPanel,
+            Mech.LOC_RARM, raPanel, Mech.LOC_CT, ctPanel, Mech.LOC_LT, ltPanel, Mech.LOC_RT, rtPanel,
+            Mech.LOC_LLEG, llPanel, Mech.LOC_RLEG, rlPanel, Mech.LOC_CLEG, clPanel);
 
-    public CriticalView(EntitySource eSource, boolean showEmpty, RefreshListener refresh) {
+    public CriticalView(EntitySource eSource, RefreshListener refresh) {
         super(eSource);
-        this.showEmpty = showEmpty;
         this.refresh = refresh;
 
-        JPanel mainPanel = new JPanel();
-        JPanel laAlignPanel = new JPanel();
-        JPanel leftAlignPanel = new JPanel();
-        JPanel centerAlignPanel = new JPanel();
-        JPanel rightAlignPanel = new JPanel();
-        JPanel raAlignPanel = new JPanel();
+        Box mainPanel = Box.createHorizontalBox();
+        Box laAlignPanel = Box.createVerticalBox();
+        Box leftAlignPanel = Box.createVerticalBox();
+        Box centerAlignPanel = Box.createVerticalBox();
+        Box rightAlignPanel = Box.createVerticalBox();
+        Box raAlignPanel = Box.createVerticalBox();
 
-        mainPanel.setOpaque(false);
-        headPanel.setOpaque(false);
-        ltPanel.setOpaque(false);
-        rtPanel.setOpaque(false);
-        ctPanel.setOpaque(false);
-        raPanel.setOpaque(false);
-        laPanel.setOpaque(false);
-        rlPanel.setOpaque(false);
-        clPanel.setOpaque(false);
-        llPanel.setOpaque(false);
+        hdPanel.setBorder(CritCellUtil.locationBorderNoLine("Head"));
+        ltPanel.setBorder(CritCellUtil.locationBorderNoLine("Left Torso"));
+        ctPanel.setBorder(CritCellUtil.locationBorderNoLine("Center Torso"));
+        rtPanel.setBorder(CritCellUtil.locationBorderNoLine("Right Torso"));
+        clPanel.setBorder(CritCellUtil.locationBorderNoLine("Center Leg"));
 
-        // Set panel layouts
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.X_AXIS));
-        laAlignPanel.setLayout(
-                new BoxLayout(laAlignPanel, BoxLayout.Y_AXIS));
-        leftAlignPanel.setLayout(
-                new BoxLayout(leftAlignPanel, BoxLayout.Y_AXIS));
-        centerAlignPanel.setLayout(
-                new BoxLayout(centerAlignPanel, BoxLayout.Y_AXIS));
-        rightAlignPanel.setLayout(
-                new BoxLayout(rightAlignPanel, BoxLayout.Y_AXIS));
-        raAlignPanel.setLayout(
-                new BoxLayout(raAlignPanel, BoxLayout.Y_AXIS));
-
-
-        // Set Borders, used for titles
-        headPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Head", TitledBorder.TOP,
-                TitledBorder.DEFAULT_POSITION));
-        ltPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Left Torso",
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-        ctPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Center Torso",
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-        rtPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Right Torso",
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-        
         laAlignPanel.add(Box.createVerticalStrut(100));
         laAlignPanel.add(laPanel);
         
@@ -118,7 +75,7 @@ public class CriticalView extends IView {
         leftAlignPanel.add(Box.createVerticalStrut(50));
         leftAlignPanel.add(llPanel);
         
-        centerAlignPanel.add(headPanel);
+        centerAlignPanel.add(hdPanel);
         centerAlignPanel.add(ctPanel);
         centerAlignPanel.add(clPanel);
         centerAlignPanel.add(Box.createVerticalStrut(75));
@@ -137,7 +94,7 @@ public class CriticalView extends IView {
         mainPanel.add(rightAlignPanel);
         mainPanel.add(raAlignPanel);
 
-        this.add(mainPanel);
+        add(mainPanel);
     }
 
     public void updateRefresh(RefreshListener refresh) {
@@ -153,212 +110,59 @@ public class CriticalView extends IView {
         ltPanel.removeAll();
         rtPanel.removeAll();
         ctPanel.removeAll();
-        headPanel.removeAll();
-        clPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(),
-                "", TitledBorder.TOP,
-                TitledBorder.DEFAULT_POSITION));
-
-        // the CritListCellRenderer has a default size of 110x15 and
-        // the border has a width of 1 so this should make each one the right
-        // size
-        Dimension size = new Dimension(112, 182);
-        Dimension legSize = new Dimension(112, 92);
+        hdPanel.removeAll();
 
         synchronized (getMech()) {
+            clPanel.setVisible(getMech() instanceof TripodMech);
+            String title = getMech() instanceof QuadMech ? "Front Left Leg" : "Left Arm";
+            laPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+            title = getMech() instanceof QuadMech ? "Front Right Leg" : "Right Arm";
+            raPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+            title = getMech() instanceof QuadMech ? "Rear Left Leg" : "Left Leg";
+            llPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+            title = getMech() instanceof QuadMech ? "Rear Right Leg" : "Right Leg";
+            rlPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+
             for (int location = 0; location < getMech().locations(); location++) {
-                // JPanel locationPanel = new JPanel();
-                Vector<String> critNames = new Vector<String>(1, 1);
+                Vector<String> critNames = new Vector<>(1, 1);
 
                 for (int slot = 0; slot < getMech().getNumberOfCriticals(location); slot++) {
                     CriticalSlot cs = getMech().getCritical(location, slot);
                     if (cs == null) {
-                        if (showEmpty) {
-                            critNames.add(MtfFile.EMPTY);
-                        }
+                        critNames.add(CritCellUtil.EMPTYCELLTEXT);
                     } else if (cs.getType() == CriticalSlot.TYPE_SYSTEM) {
                         critNames.add(getMech().getSystemName(cs.getIndex()));
                     } else if (cs.getType() == CriticalSlot.TYPE_EQUIPMENT) {
-                        try {
-                            Mounted m = cs.getMount();
+                        Mounted m = cs.getMount();
+                        if (m == null) {
                             // Critical didn't get removed. Remove it now.
-                            if (m == null) {
-
-                                m = cs.getMount();
-
-                                if (m == null) {
-                                    getMech().setCritical(location, slot, null);
-                                    if (showEmpty) {
-                                        critNames.add(MtfFile.EMPTY);
-                                    }
-                                    continue;
-                                }
-                                cs.setMount(m);
-                            }
-                            StringBuffer critName = new StringBuffer(
-                                    m.getName());
-                            if (critName.length() > 25) {
-                                critName.setLength(25);
-                                critName.append("...");
-                            }
+                            getMech().setCritical(location, slot, null);
+                            critNames.add(CritCellUtil.EMPTYCELLTEXT);
+                        } else {
+                            StringBuilder critName = new StringBuilder(m.getName());
                             if (m.isRearMounted()) {
                                 critName.append(" (R)");
                             }
                             if (m.isMechTurretMounted()) {
                                 critName.append(" (T)");
                             }
-
                             critNames.add(critName.toString());
-
-                        } catch (Exception ex) {
-                            MegaMekLab.getLogger().error(ex);
                         }
                     }
                 }
-                if (critNames.size() == 0) {
-                    critNames.add(MtfFile.EMPTY);
-                }
-                DropTargetCriticalList<String> criticalSlotList = new DropTargetCriticalList<String>(
-                        critNames, eSource, refresh, showEmpty);
+
+                DropTargetCriticalList<String> criticalSlotList = new DropTargetCriticalList<>(
+                        critNames, eSource, refresh, true);
                 criticalSlotList.setVisibleRowCount(critNames.size());
-                criticalSlotList
-                        .setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-                criticalSlotList.setFont(new Font("Arial", Font.PLAIN, 10));
-                criticalSlotList.setName(Integer.toString(location));
-                criticalSlotList.setBorder(BorderFactory.createLineBorder(
-                        Color.BLACK, 1));
-                switch (location) {
-                    case Mech.LOC_HEAD:
-                        criticalSlotList.setSize(legSize);
-                        criticalSlotList.setPreferredSize(legSize);
-                        criticalSlotList.setMaximumSize(legSize);
-                        headPanel.add(criticalSlotList);
-                        break;
-                    case Mech.LOC_LARM:
-                        if (getMech() instanceof QuadMech) {
-                            laPanel.setBorder(BorderFactory.createTitledBorder(
-                                    BorderFactory.createEmptyBorder(),
-                                    "Front Left Leg", TitledBorder.TOP,
-                                    TitledBorder.DEFAULT_POSITION));
-                            criticalSlotList.setSize(legSize);
-                            criticalSlotList.setPreferredSize(legSize);
-                            criticalSlotList.setMaximumSize(legSize);
-                        } else {
-                            laPanel.setBorder(BorderFactory.createTitledBorder(
-                                    BorderFactory.createEmptyBorder(),
-                                    "Left Arm", TitledBorder.TOP,
-                                    TitledBorder.DEFAULT_POSITION));
-                            criticalSlotList.setSize(size);
-                            criticalSlotList.setPreferredSize(size);
-                            criticalSlotList.setMaximumSize(size);
-                        }
-                        laPanel.add(criticalSlotList);
-                        break;
-                    case Mech.LOC_RARM:
-                        if (getMech() instanceof QuadMech) {
-                            raPanel.setBorder(BorderFactory.createTitledBorder(
-                                    BorderFactory.createEmptyBorder(),
-                                    "Front Right Leg", TitledBorder.TOP,
-                                    TitledBorder.DEFAULT_POSITION));
-                            criticalSlotList.setSize(legSize);
-                            criticalSlotList.setPreferredSize(legSize);
-                            criticalSlotList.setMaximumSize(legSize);
-                        } else {
-                            raPanel.setBorder(BorderFactory.createTitledBorder(
-                                    BorderFactory.createEmptyBorder(),
-                                    "Right Arm", TitledBorder.TOP,
-                                    TitledBorder.DEFAULT_POSITION));
-                            criticalSlotList.setSize(size);
-                            criticalSlotList.setPreferredSize(size);
-                            criticalSlotList.setMaximumSize(size);
-                        }
-                        
-                        raPanel.add(criticalSlotList);
-                        break;
-                    case Mech.LOC_CT:
-                        criticalSlotList.setSize(size);
-                        criticalSlotList.setPreferredSize(size);
-                        criticalSlotList.setMaximumSize(size);
-                        ctPanel.add(criticalSlotList);
-                        break;
-                    case Mech.LOC_LT:
-                        criticalSlotList.setSize(size);
-                        criticalSlotList.setPreferredSize(size);
-                        criticalSlotList.setMaximumSize(size);
-                        ltPanel.add(criticalSlotList);
-                        break;
-                    case Mech.LOC_RT:
-                        criticalSlotList.setSize(size);
-                        criticalSlotList.setPreferredSize(size);
-                        criticalSlotList.setMaximumSize(size);
-                        rtPanel.add(criticalSlotList);
-                        break;
-                    case Mech.LOC_LLEG:
-                        if (getMech() instanceof QuadMech) {
-                            llPanel.setBorder(BorderFactory.createTitledBorder(
-                                    BorderFactory.createEmptyBorder(),
-                                    "Rear Left Leg", TitledBorder.TOP,
-                                    TitledBorder.DEFAULT_POSITION));
-                        } else {
-                            llPanel.setBorder(BorderFactory.createTitledBorder(
-                                    BorderFactory.createEmptyBorder(),
-                                    "Left Leg", TitledBorder.TOP,
-                                    TitledBorder.DEFAULT_POSITION));
-                        }
-                        criticalSlotList.setSize(legSize);
-                        criticalSlotList.setPreferredSize(legSize);
-                        criticalSlotList.setMaximumSize(legSize);
-                        llPanel.add(criticalSlotList);
-                        break;
-                    case Mech.LOC_RLEG:
-                        if (getMech() instanceof QuadMech) {
-                            rlPanel.setBorder(BorderFactory.createTitledBorder(
-                                    BorderFactory.createEmptyBorder(),
-                                    "Rear Right Leg", TitledBorder.TOP,
-                                    TitledBorder.DEFAULT_POSITION));
-                        } else {
-                            rlPanel.setBorder(BorderFactory.createTitledBorder(
-                                    BorderFactory.createEmptyBorder(),
-                                    "Right Leg", TitledBorder.TOP,
-                                    TitledBorder.DEFAULT_POSITION));
-                        }
-                        criticalSlotList.setSize(legSize);
-                        criticalSlotList.setPreferredSize(legSize);
-                        criticalSlotList.setMaximumSize(legSize);
-                        rlPanel.add(criticalSlotList);
-                        break;
-                    case Mech.LOC_CLEG:
-                        clPanel.setBorder(BorderFactory.createTitledBorder(
-                                BorderFactory.createEmptyBorder(),
-                                "Center Leg", TitledBorder.TOP,
-                                TitledBorder.DEFAULT_POSITION));
-                        criticalSlotList.setSize(legSize);
-                        criticalSlotList.setPreferredSize(legSize);
-                        criticalSlotList.setMaximumSize(legSize);
-                        clPanel.add(criticalSlotList);
-                        break;
+                criticalSlotList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+                criticalSlotList.setName(location + "");
+                criticalSlotList.setBorder(BorderFactory.createLineBorder(CritCellUtil.CRITCELL_BORDERCOLOR));
+                if (mekPanels.containsKey(location)) {
+                    mekPanels.get(location).add(criticalSlotList);
                 }
             }
             
-            ctPanel.invalidate();
-            raPanel.invalidate();
-            headPanel.invalidate();
-            laPanel.invalidate();
-            ltPanel.invalidate();
-            rtPanel.invalidate();
-            llPanel.invalidate();
-            rlPanel.invalidate();
-            clPanel.invalidate();
-            
-            ctPanel.repaint();
-            raPanel.repaint();
-            headPanel.repaint();
-            laPanel.repaint();
-            ltPanel.repaint();
-            rtPanel.repaint();
-            llPanel.repaint();
-            rlPanel.repaint();
-            clPanel.invalidate();
+            validate();
         }
     }
 

--- a/src/megameklab/com/ui/Vehicle/tabs/BuildTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/BuildTab.java
@@ -65,7 +65,7 @@ public class BuildTab extends ITab implements ActionListener {
         JPanel buttonPanel = new JPanel();
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
 
-        critView = new CriticalView(eSource, true, refresh);
+        critView = new CriticalView(eSource, refresh);
         unallocatedView = new UnallocatedView(eSource, () -> refresh);
 
         mainPanel.add(unallocatedView);

--- a/src/megameklab/com/ui/Vehicle/views/CriticalView.java
+++ b/src/megameklab/com/ui/Vehicle/views/CriticalView.java
@@ -176,7 +176,7 @@ public final class CriticalView extends IView {
                 }
 
                 if (critNames.size() == 0) {
-                    critNames.add(CritCellUtil.EMPTYCELLTEXT);
+                    critNames.add(CritCellUtil.EMPTY_CRITCELL_TEXT);
                 }
                 DropTargetCriticalList<String> criticalSlotList =
                         new DropTargetCriticalList<>(critNames, eSource, refresh, true);

--- a/src/megameklab/com/ui/aerospace/LargeCraftCriticalView.java
+++ b/src/megameklab/com/ui/aerospace/LargeCraftCriticalView.java
@@ -1,5 +1,6 @@
 /*
  * MegaMekLab - Copyright (C) 2017 - The MegaMek Team
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -14,7 +15,10 @@
 package megameklab.com.ui.aerospace;
 
 import megamek.client.ui.swing.util.UIUtil;
-import megamek.common.*;
+import megamek.common.Jumpship;
+import megamek.common.LocationFullException;
+import megamek.common.SmallCraft;
+import megamek.common.Warship;
 import megamek.common.annotations.Nullable;
 import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestAdvancedAerospace;
@@ -23,24 +27,23 @@ import megamek.common.verifier.TestEntity;
 import megamek.common.verifier.TestSmallCraft;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.util.BayWeaponCriticalTree;
-import megameklab.com.ui.util.LocationBorder;
+import megameklab.com.ui.util.CritCellUtil;
 import megameklab.com.util.IView;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
 
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
-import java.awt.*;
 import java.util.ResourceBundle;
 
 /**
- * For allocating Large Craft (and Small Craft) weapons to critical spaces. Aft side arcs on spheroid
- * small craft and dropships are implemented as rear-mounted weapons in the left/right side locations
- * but here they are shown as separate locations both to make it less confusing to the user and for the
- * need to maintain a separate count of the number of slots filled in that arc.
+ * The Crit Slots view for Large Craft (including Small Craft)
+ * Aft side arcs on spheroid small craft and dropships are implemented as rear-mounted weapons in the
+ * left/right side locations but here they are shown as separate locations both to make it less confusing
+ * to the user and for the need to maintain a separate count of the number of slots filled in that arc.
  * 
  * @author Neoancient
- *
+ * @author Simon (Juliez)
  */
 public class LargeCraftCriticalView extends IView {
 
@@ -178,12 +181,7 @@ public class LargeCraftCriticalView extends IView {
     private JComponent createArcPanel(int arc, ResourceBundle resourceMap, boolean isWeaponArc, @Nullable JButton copyButton) {
         Box arcPanel = Box.createVerticalBox();
         String arcTitle = isJumpShip() ? capitalArcNames[arc] : spheroidArcNames[arc];
-        arcPanel.setBorder(BorderFactory.createTitledBorder(
-                new LocationBorder(Color.BLACK, 2f),
-                " " + arcTitle + " ",
-                TitledBorder.TOP,
-                TitledBorder.DEFAULT_POSITION));
-
+        arcPanel.setBorder(CritCellUtil.locationBorder(arcTitle));
         arcPanel.add(arcTrees[arc]);
 
         lblSlotCount[arc] = new JLabel();

--- a/src/megameklab/com/ui/protomek/ProtomekCriticalView.java
+++ b/src/megameklab/com/ui/protomek/ProtomekCriticalView.java
@@ -1,5 +1,6 @@
 /*
  * MegaMekLab - Copyright (C) 2018 - The MegaMek Team
+ * Copyright (c) 2021 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -13,40 +14,31 @@
  */
 package megameklab.com.ui.protomek;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import javax.swing.BorderFactory;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.border.TitledBorder;
-
 import megamek.common.Mounted;
 import megamek.common.Protomech;
 import megamek.common.verifier.TestProtomech;
 import megameklab.com.ui.EntitySource;
+import megameklab.com.ui.util.CritCellUtil;
 import megameklab.com.ui.util.ProtomekMountList;
 import megameklab.com.util.IView;
 import megameklab.com.util.RefreshListener;
 
+import javax.swing.*;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 /**
- * Displays protomech equipment by location
- * 
- * @author Neoancient
+ * The Crit Slots view for a ProtoMek
  *
+ * @author neoancient
+ * @author Simon (Juliez)
  */
 public class ProtomekCriticalView extends IView {
-    private static final long serialVersionUID = 1556099212988732928L;
-    
-    private final JPanel mainGunPanel = new JPanel();
-    private final JPanel torsoPanel = new JPanel();
-    private final JPanel leftPanel = new JPanel();
-    private final JPanel rightPanel = new JPanel();
-    private final JPanel bodyPanel = new JPanel();
+
+    private final Box mainGunPanel = Box.createVerticalBox();
+    private final Box leftArmPanel = Box.createVerticalBox();
+    private final Box rightArmPanel = Box.createVerticalBox();
 
     private final ProtomekMountList mainGunList;
     private final ProtomekMountList torsoList;
@@ -54,103 +46,70 @@ public class ProtomekCriticalView extends IView {
     private final ProtomekMountList rightList;
     private final ProtomekMountList bodyList;
 
-    private final JLabel mainGunSpace = new JLabel("",JLabel.LEFT);
-    private final JLabel torsoSpace = new JLabel("",JLabel.LEFT);
-    private final JLabel leftSpace = new JLabel("",JLabel.LEFT);
-    private final JLabel rightSpace = new JLabel("",JLabel.LEFT);
+    private final JLabel mainGunSpace = new JLabel();
+    private final JLabel torsoSpace = new JLabel();
+    private final JLabel leftSpace = new JLabel();
+    private final JLabel rightSpace = new JLabel();
 
-    private final JLabel torsoWeight = new JLabel("",JLabel.LEFT);
-    private final JLabel leftWeight = new JLabel("",JLabel.LEFT);
-    private final JLabel rightWeight = new JLabel("",JLabel.LEFT);
+    private final JLabel torsoWeight = new JLabel();
+    private final JLabel leftWeight = new JLabel();
+    private final JLabel rightWeight = new JLabel();
 
     public ProtomekCriticalView(EntitySource eSource, RefreshListener refresh) {
         super(eSource);
 
-        JPanel mainPanel = new JPanel();
+        Box mainPanel = Box.createHorizontalBox();
+        Box leftPanel = Box.createVerticalBox();
+        Box middlePanel = Box.createVerticalBox();
+        Box rightPanel = Box.createVerticalBox();
 
-        mainPanel.setLayout(new GridBagLayout());
+        mainGunSpace.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+        torsoSpace.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+        leftSpace.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+        rightSpace.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+        torsoWeight.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+        leftWeight.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+        rightWeight.setAlignmentX(JComponent.CENTER_ALIGNMENT);
 
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.fill = GridBagConstraints.BOTH;
-        gbc.anchor = GridBagConstraints.CENTER;
-        gbc.insets = new Insets(10, 10, 10, 10);
-        gbc.gridx = 1;
-        gbc.gridy = 0;
-        mainPanel.add(mainGunPanel, gbc);
-        gbc.gridx = 0;
-        gbc.gridy = 1;
-        mainPanel.add(leftPanel, gbc);
-        gbc.gridx = 1;
-        gbc.gridy = 1;
-        mainPanel.add(torsoPanel, gbc);
-        gbc.gridx = 2;
-        gbc.gridy = 1;
-        mainPanel.add(rightPanel, gbc);
-        gbc.gridx = 1;
-        gbc.gridy = 2;
-        mainPanel.add(bodyPanel, gbc);
-        
-        gbc = new GridBagConstraints();
-        gbc.anchor = GridBagConstraints.WEST;
-        gbc.insets = new Insets(5, 5, 5, 5);
-        gbc.gridx = 0;
-
-        mainGunPanel.setLayout(new GridBagLayout());
-        mainGunPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Main Gun",
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
+        mainGunPanel.setBorder(CritCellUtil.locationBorder("Main Gun"));
         mainGunList = new ProtomekMountList(eSource, refresh, Protomech.LOC_MAINGUN);
-        gbc.gridy = 0;
-        mainGunPanel.add(mainGunList, gbc);
-        gbc.gridy++;
-        mainGunPanel.add(mainGunSpace, gbc);
+        mainGunPanel.add(mainGunList);
+        mainGunPanel.add(mainGunSpace);
         
-        leftPanel.setLayout(new GridBagLayout());
-        leftPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Left Arm",
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
+        leftArmPanel.setBorder(CritCellUtil.locationBorder("Left Arm"));
         leftList = new ProtomekMountList(eSource, refresh, Protomech.LOC_LARM);
-        gbc.gridy = 0;
-        leftPanel.add(leftList, gbc);
-        gbc.gridy++;
-        leftPanel.add(leftSpace, gbc);
-        gbc.gridy++;
-        leftPanel.add(leftWeight, gbc);
-        gbc.gridy++;
+        leftArmPanel.add(leftList);
+        leftArmPanel.add(leftSpace);
+        leftArmPanel.add(leftWeight);
 
-        torsoPanel.setLayout(new GridBagLayout());
-        torsoPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Torso", TitledBorder.TOP,
-                TitledBorder.DEFAULT_POSITION));
+        Box torsoPanel = Box.createVerticalBox();
+        torsoPanel.setBorder(CritCellUtil.locationBorder("Torso"));
         torsoList = new ProtomekMountList(eSource, refresh, Protomech.LOC_TORSO);
-        gbc.gridy = 0;
-        torsoPanel.add(torsoList, gbc);
-        gbc.gridy++;
-        torsoPanel.add(torsoSpace, gbc);
-        gbc.gridy++;
-        torsoPanel.add(torsoWeight, gbc);
-        gbc.gridy++;
+        torsoPanel.add(torsoList);
+        torsoPanel.add(torsoSpace);
+        torsoPanel.add(torsoWeight);
 
-        rightPanel.setLayout(new GridBagLayout());
-        rightPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Right Arm",
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
+        rightArmPanel.setBorder(CritCellUtil.locationBorder("Right Arm"));
         rightList = new ProtomekMountList(eSource, refresh, Protomech.LOC_RARM);
-        gbc.gridy = 0;
-        rightPanel.add(rightList, gbc);
-        gbc.gridy++;
-        rightPanel.add(rightSpace, gbc);
-        gbc.gridy++;
-        rightPanel.add(rightWeight, gbc);
+        rightArmPanel.add(rightList);
+        rightArmPanel.add(rightSpace);
+        rightArmPanel.add(rightWeight);
 
-        bodyPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "General", TitledBorder.TOP,
-                TitledBorder.DEFAULT_POSITION));
+        Box bodyPanel = Box.createVerticalBox();
+        bodyPanel.setBorder(CritCellUtil.locationBorder("General"));
         bodyList = new ProtomekMountList(eSource, refresh, Protomech.LOC_BODY);
         bodyPanel.add(bodyList);
 
-        this.add(mainPanel);
+        leftPanel.add(leftArmPanel);
+        middlePanel.add(mainGunPanel);
+        middlePanel.add(torsoPanel);
+        middlePanel.add(bodyPanel);
+        rightPanel.add(rightArmPanel);
 
+        mainPanel.add(leftPanel);
+        mainPanel.add(middlePanel);
+        mainPanel.add(rightPanel);
+        add(mainPanel);
     }
 
     public void updateRefresh(RefreshListener refresh) {
@@ -163,8 +122,8 @@ public class ProtomekCriticalView extends IView {
 
     public void refresh() {
         mainGunPanel.setVisible(getProtomech().hasMainGun());
-        leftPanel.setVisible(!getProtomech().isQuad());
-        rightPanel.setVisible(!getProtomech().isQuad());
+        leftArmPanel.setVisible(!getProtomech().isQuad());
+        rightArmPanel.setVisible(!getProtomech().isQuad());
 
         mainGunList.refreshContents();
         torsoList.refreshContents();
@@ -173,7 +132,7 @@ public class ProtomekCriticalView extends IView {
         bodyList.refreshContents();
         
         Map<Integer, List<Mounted>> eqByLocation = getProtomech().getEquipment().stream()
-                .collect(Collectors.groupingBy(m -> m.getLocation()));
+                .collect(Collectors.groupingBy(Mounted::getLocation));
         for (int location = 0; location < getProtomech().locations(); location++) {
             int slotsUsed = 0;
             double weightUsed = 0.0;

--- a/src/megameklab/com/ui/supportvehicle/SVBuildTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVBuildTab.java
@@ -58,7 +58,7 @@ public class SVBuildTab extends ITab implements ActionListener {
         JPanel buttonPanel = new JPanel();
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
 
-        critView = new SVCriticalView(eSource, true, refresh);
+        critView = new SVCriticalView(eSource, refresh);
         unallocatedView = new UnallocatedView(eSource, () -> refresh);
 
         mainPanel.add(unallocatedView);

--- a/src/megameklab/com/ui/supportvehicle/SVCriticalView.java
+++ b/src/megameklab/com/ui/supportvehicle/SVCriticalView.java
@@ -1,6 +1,6 @@
 /*
  * MegaMekLab
- * Copyright (C) 2019 The MegaMek Team
+ * Copyright (C) 2019, 2021 The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -18,100 +18,107 @@
  */
 package megameklab.com.ui.supportvehicle;
 
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
-import megamek.common.loaders.MtfFile;
-import megameklab.com.MegaMekLab;
+import megamek.common.annotations.Nullable;
 import megameklab.com.ui.EntitySource;
+import megameklab.com.ui.util.CritCellUtil;
 import megameklab.com.util.DropTargetCriticalList;
 import megameklab.com.util.IView;
 import megameklab.com.util.RefreshListener;
 
 import javax.swing.*;
-import javax.swing.border.TitledBorder;
 import java.awt.*;
+import java.util.Map;
 import java.util.Vector;
 
 /**
+ * The Crit Slots view for a Support Vehicle (all motive types)
  *
+ * @author neoancient
+ * @author Simon (Juliez)
  */
 public class SVCriticalView extends IView {
 
-    private JPanel leftPanel = new JPanel();
-    private JPanel rightPanel = new JPanel();
-    private JPanel frontPanel = new JPanel();
-    private JPanel rearPanel = new JPanel();
-    private JPanel bodyPanel = new JPanel();
-    private JPanel turretPanel = new JPanel();
-    private JPanel dualTurretPanel = new JPanel();
-
-    private JPanel rearLeftPanel = new JPanel();
-    private JPanel rearRightPanel = new JPanel();
-
-    private JPanel middlePanel2 = new JPanel();
-    private JPanel fullTurretPanel = new JPanel();
+    private final JPanel leftPanel = new JPanel();
+    private final JPanel rightPanel = new JPanel();
+    private final JPanel frontPanel = new JPanel();
+    private final JPanel rearPanel = new JPanel();
+    private final JPanel bodyPanel = new JPanel();
+    private final JPanel rearLeftPanel = new JPanel();
+    private final JPanel rearRightPanel = new JPanel();
+    private final JPanel middlePanel2 = new JPanel();
+    private final JPanel turretPanel = new UIUtil.FixedYPanel();
+    private final JPanel dualTurretPanel = new UIUtil.FixedYPanel();
+    private final JPanel rotorPanel = new UIUtil.FixedYPanel();
     private RefreshListener refresh;
 
-    private boolean showEmpty;
+    private final Map<Integer, JComponent> aeroLocations = Map.of(FixedWingSupport.LOC_NOSE, frontPanel, FixedWingSupport.LOC_LWING, leftPanel,
+            FixedWingSupport.LOC_RWING, rightPanel, FixedWingSupport.LOC_BODY, bodyPanel, FixedWingSupport.LOC_AFT, rearPanel);
 
-    SVCriticalView(EntitySource eSource, boolean showEmpty, RefreshListener refresh) {
+    private final Map<Integer, JComponent> vtolLocations = Map.of(Tank.LOC_FRONT, frontPanel, Tank.LOC_LEFT, leftPanel,
+            Tank.LOC_RIGHT, rightPanel, Tank.LOC_BODY, bodyPanel, Tank.LOC_REAR, rearPanel, VTOL.LOC_ROTOR, rotorPanel,
+            VTOL.LOC_TURRET, turretPanel);
+
+    private final Map<Integer, JComponent> tankLocations = Map.of(Tank.LOC_FRONT, frontPanel, Tank.LOC_LEFT, leftPanel,
+            Tank.LOC_RIGHT, rightPanel, Tank.LOC_BODY, bodyPanel, Tank.LOC_REAR, rearPanel, Tank.LOC_TURRET, turretPanel,
+            Tank.LOC_TURRET_2, dualTurretPanel);
+
+    private final Map<Integer, JComponent> superHvyLocations = Map.of(Tank.LOC_FRONT, frontPanel,
+            SuperHeavyTank.LOC_FRONTLEFT, leftPanel, SuperHeavyTank.LOC_FRONTRIGHT, rightPanel,
+            Tank.LOC_BODY, bodyPanel, SuperHeavyTank.LOC_REAR, rearPanel, SuperHeavyTank.LOC_TURRET, turretPanel,
+            SuperHeavyTank.LOC_TURRET_2, dualTurretPanel,
+            SuperHeavyTank.LOC_REARLEFT, rearLeftPanel, SuperHeavyTank.LOC_REARRIGHT, rearRightPanel);
+
+    SVCriticalView(EntitySource eSource, RefreshListener refresh) {
         super(eSource);
-        this.showEmpty = showEmpty;
         this.refresh = refresh;
 
-        JPanel mainPanel = new JPanel();
+        frontPanel.setBorder(CritCellUtil.locationBorderNoLine("Front"));
+        leftPanel.setBorder(CritCellUtil.locationBorderNoLine("Left Side"));
+        bodyPanel.setBorder(CritCellUtil.locationBorderNoLine("Body"));
+        rightPanel.setBorder(CritCellUtil.locationBorderNoLine("Right Side"));
+        rearLeftPanel.setBorder(CritCellUtil.locationBorderNoLine("Rear Left Side"));
+        rearRightPanel.setBorder(CritCellUtil.locationBorderNoLine("Rear Right Side"));
+        rearPanel.setBorder(CritCellUtil.locationBorderNoLine("Rear"));
+        rotorPanel.setBorder(CritCellUtil.locationBorderNoLine("Rotor"));
+        dualTurretPanel.setBorder(CritCellUtil.locationBorderNoLine("Front Turret"));
 
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
-
-        JPanel topPanel = new JPanel();
-        topPanel.setLayout(new BoxLayout(topPanel, BoxLayout.X_AXIS));
-        JPanel middlePanel = new JPanel();
-        middlePanel.setLayout(new BoxLayout(middlePanel, BoxLayout.X_AXIS));
-        middlePanel2.setLayout(new BoxLayout(middlePanel2, BoxLayout.X_AXIS));
-        JPanel bottomPanel = new JPanel();
-        bottomPanel.setLayout(new BoxLayout(bottomPanel, BoxLayout.X_AXIS));
-        fullTurretPanel.setLayout(new BoxLayout(fullTurretPanel, BoxLayout.Y_AXIS));
-
+        Box topPanel = Box.createVerticalBox();
         topPanel.add(frontPanel);
-        topPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Front", TitledBorder.TOP,
-                TitledBorder.DEFAULT_POSITION));
-        mainPanel.add(topPanel);
 
+        Box middlePanel = Box.createHorizontalBox();
         middlePanel.add(leftPanel);
-        leftPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Left Side",
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
         middlePanel.add(bodyPanel);
-        bodyPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Body", TitledBorder.TOP,
-                TitledBorder.DEFAULT_POSITION));
         middlePanel.add(rightPanel);
-        rightPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Right Side",
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-        mainPanel.add(middlePanel);
+        middlePanel.setBorder(BorderFactory.createEmptyBorder(8, 0, 0, 0));
 
         middlePanel2.add(rearLeftPanel);
-        rearLeftPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Rear Left Side",
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
         middlePanel2.add(new JPanel());
         middlePanel2.add(rearRightPanel);
-        rearRightPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Rear Right Side",
-                TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-        mainPanel.add(middlePanel2);
+        middlePanel2.setBorder(BorderFactory.createEmptyBorder(8, 0, 0, 0));
 
-        middlePanel2.setVisible(getEntity().isSuperHeavy() && !(getEntity() instanceof VTOL));
-
-        rearPanel.setBorder(BorderFactory.createTitledBorder(
-                BorderFactory.createEmptyBorder(), "Rear", TitledBorder.TOP,
-                TitledBorder.DEFAULT_POSITION));
+        Box bottomPanel = Box.createHorizontalBox();
         bottomPanel.add(rearPanel);
-        mainPanel.add(bottomPanel);
+        bottomPanel.setBorder(BorderFactory.createEmptyBorder(8, 0, 0, 0));
 
-        this.add(mainPanel);
+        Box chassisPanel = Box.createVerticalBox();
+        chassisPanel.add(topPanel);
+        chassisPanel.add(middlePanel);
+        chassisPanel.add(middlePanel2);
+        chassisPanel.add(bottomPanel);
 
+        Box fullTurretPanel = Box.createVerticalBox();
+        fullTurretPanel.add(dualTurretPanel);
+        fullTurretPanel.add(Box.createVerticalStrut(10));
+        fullTurretPanel.add(turretPanel);
+        fullTurretPanel.add(Box.createVerticalStrut(10));
+        fullTurretPanel.add(rotorPanel);
+
+        Box mainPanel = Box.createHorizontalBox();
+        mainPanel.add(chassisPanel);
+        mainPanel.add(fullTurretPanel);
+        add(mainPanel);
     }
 
     public void updateRefresh(RefreshListener refresh) {
@@ -126,208 +133,84 @@ public class SVCriticalView extends IView {
         rearPanel.removeAll();
         turretPanel.removeAll();
         dualTurretPanel.removeAll();
-        fullTurretPanel.removeAll();
         rearLeftPanel.removeAll();
         rearRightPanel.removeAll();
-        this.remove(fullTurretPanel);
+        rotorPanel.removeAll();
 
-        if (getEntity() instanceof VTOL) {
-            if (getVTOL().hasNoTurret()) {
-                turretPanel.setBorder(BorderFactory.createTitledBorder(
-                        BorderFactory.createEmptyBorder(), "Rotor",
-                        TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-                fullTurretPanel.add(turretPanel);
-                this.add(fullTurretPanel);
-            } else {
-                dualTurretPanel.setBorder(BorderFactory.createTitledBorder(
-                        BorderFactory.createEmptyBorder(), "Turret",
-                        TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-                fullTurretPanel.add(dualTurretPanel);
-                turretPanel.setBorder(BorderFactory.createTitledBorder(
-                        BorderFactory.createEmptyBorder(), "Rotor",
-                        TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-                fullTurretPanel.add(turretPanel);
-                this.add(fullTurretPanel);
-            }
-        } else if (getEntity() instanceof Tank) {
-            if (!getTank().hasNoDualTurret()) {
-                dualTurretPanel.setBorder(BorderFactory.createTitledBorder(
-                        BorderFactory.createEmptyBorder(), "Front Turret",
-                        TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-                fullTurretPanel.add(dualTurretPanel);
-                turretPanel.setBorder(BorderFactory.createTitledBorder(
-                        BorderFactory.createEmptyBorder(), "Rear Turret",
-                        TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-                fullTurretPanel.add(turretPanel);
-                this.add(fullTurretPanel);
-            } else if (!getTank().hasNoTurret()) {
-                turretPanel.setBorder(BorderFactory.createTitledBorder(
-                        BorderFactory.createEmptyBorder(), "Turret",
-                        TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
-                fullTurretPanel.add(turretPanel);
-                this.add(fullTurretPanel);
-            }
+        rotorPanel.setVisible(isVTOL());
+        turretPanel.setVisible((getEntity() instanceof Tank) && !getTank().hasNoTurret());
+        dualTurretPanel.setVisible((getEntity() instanceof Tank) && !getTank().hasNoDualTurret());
+        middlePanel2.setVisible((getEntity() instanceof Tank) && getTank().isSuperHeavy() && !isVTOL());
+        if ((getEntity() instanceof Tank) && getTank().hasNoDualTurret()) {
+            turretPanel.setBorder(CritCellUtil.locationBorderNoLine("Turret"));
+        } else {
+            turretPanel.setBorder(CritCellUtil.locationBorderNoLine("Rear Turret"));
         }
 
         synchronized (getEntity()) {
+            System.out.println(getEntity().locations());
             for (int location = 0; location < getEntity().locations(); location++) {
-                // JPanel locationPanel = new JPanel();
                 Vector<String> critNames = new Vector<>(1, 1);
 
                 for (int slot = 0; slot < getEntity().getNumberOfCriticals(location); slot++) {
                     CriticalSlot cs = getEntity().getCritical(location, slot);
                     if (cs == null) {
                         continue;
-                    } else if (cs.getType() == CriticalSlot.TYPE_SYSTEM) {
+                    }
+                    if (cs.getType() == CriticalSlot.TYPE_SYSTEM) {
                         critNames.add(getMech().getSystemName(cs.getIndex()));
                     } else if (cs.getType() == CriticalSlot.TYPE_EQUIPMENT) {
-                        try {
-                            Mounted m = cs.getMount();
-                            // Critical didn't get removed. Remove it now.
-                            if (m == null) {
-                                getEntity().setCritical(location, slot, null);
-                                continue;
-                            }
-                            StringBuilder critName = new StringBuilder(m.getName());
-                            if (critName.length() > 25) {
-                                critName.setLength(25);
-                                critName.append("...");
-                            }
-                            if (m.isRearMounted()) {
-                                critName.append(" (R)");
-                            }
-                            if (m.isSponsonTurretMounted()) {
-                                critName.append(" (ST)");
-                            }
-                            if (m.isPintleTurretMounted()) {
-                                critName.append(" (PT)");
-                            }
-                            critNames.add(critName.toString());
-
-                        } catch (Exception ex) {
-                            MegaMekLab.getLogger().error(ex);
+                        Mounted m = cs.getMount();
+                        // Critical didn't get removed. Remove it now.
+                        if (m == null) {
+                            getEntity().setCritical(location, slot, null);
+                            continue;
                         }
+                        StringBuilder critName = new StringBuilder(m.getName());
+                        if (critName.length() > 25) {
+                            critName.setLength(25);
+                            critName.append("...");
+                        }
+                        if (m.isRearMounted()) {
+                            critName.append(" (R)");
+                        }
+                        if (m.isSponsonTurretMounted()) {
+                            critName.append(" (ST)");
+                        }
+                        if (m.isPintleTurretMounted()) {
+                            critName.append(" (PT)");
+                        }
+                        critNames.add(critName.toString());
                     }
                 }
 
                 if (critNames.size() == 0) {
-                    critNames.add(MtfFile.EMPTY);
+                    critNames.add(CritCellUtil.EMPTYCELLTEXT);
                 }
-                DropTargetCriticalList<String> criticalSlotList = new DropTargetCriticalList<>(critNames, eSource, refresh, showEmpty);
+                DropTargetCriticalList<String> criticalSlotList =
+                        new DropTargetCriticalList<>(critNames, eSource, refresh, true);
                 criticalSlotList.setVisibleRowCount(critNames.size());
                 criticalSlotList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-                criticalSlotList.setFont(new Font("Arial", Font.PLAIN, 10));
-                criticalSlotList.setName(Integer.toString(location));
-                criticalSlotList.setBorder(BorderFactory.createEtchedBorder(Color.WHITE.brighter(), Color.BLACK.darker()));
-                if (getEntity().isAero()) {
-                    switch (location) {
-                        case FixedWingSupport.LOC_NOSE:
-                            frontPanel.add(criticalSlotList);
-                            break;
-                        case FixedWingSupport.LOC_LWING:
-                            leftPanel.add(criticalSlotList);
-                            break;
-                        case FixedWingSupport.LOC_RWING:
-                            rightPanel.add(criticalSlotList);
-                            break;
-                        case FixedWingSupport.LOC_BODY:
-                            bodyPanel.add(criticalSlotList);
-                            break;
-                        case FixedWingSupport.LOC_AFT:
-                            rearPanel.add(criticalSlotList);
-                            break;
-                    }
-                } else if (!(getEntity()).isSuperHeavy()) {
-                    switch (location) {
-                        case Tank.LOC_FRONT:
-                            frontPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_LEFT:
-                            leftPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_RIGHT:
-                            rightPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_BODY:
-                            bodyPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_REAR:
-                            rearPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_TURRET:
-                            turretPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_TURRET_2:
-                            dualTurretPanel.add(criticalSlotList);
-                            break;
-                    }
-                } else if (getEntity() instanceof VTOL) {
-                    switch (location) {
-                        case Tank.LOC_FRONT:
-                            frontPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_LEFT:
-                            leftPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_RIGHT:
-                            rightPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_BODY:
-                            bodyPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_REAR:
-                            rearPanel.add(criticalSlotList);
-                            break;
-                        case VTOL.LOC_ROTOR:
-                            turretPanel.add(criticalSlotList);
-                            break;
-                        case VTOL.LOC_TURRET:
-                            dualTurretPanel.add(criticalSlotList);
-                            break;
-                    }
-                } else {
-                    switch (location) {
-                        case Tank.LOC_FRONT:
-                            frontPanel.add(criticalSlotList);
-                            break;
-                        case SuperHeavyTank.LOC_FRONTLEFT:
-                            leftPanel.add(criticalSlotList);
-                            break;
-                        case SuperHeavyTank.LOC_FRONTRIGHT:
-                            rightPanel.add(criticalSlotList);
-                            break;
-                        case SuperHeavyTank.LOC_REARLEFT:
-                            rearLeftPanel.add(criticalSlotList);
-                            break;
-                        case SuperHeavyTank.LOC_REARRIGHT:
-                            rearRightPanel.add(criticalSlotList);
-                            break;
-                        case Tank.LOC_BODY:
-                            bodyPanel.add(criticalSlotList);
-                            break;
-                        case SuperHeavyTank.LOC_REAR:
-                            rearPanel.add(criticalSlotList);
-                            break;
-                        case SuperHeavyTank.LOC_TURRET:
-                            turretPanel.add(criticalSlotList);
-                            break;
-                        case SuperHeavyTank.LOC_TURRET_2:
-                            dualTurretPanel.add(criticalSlotList);
-                            break;
-                    }
+                criticalSlotList.setName(location + "");
+                criticalSlotList.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+                if (panelForLocation(location) != null) {
+                    panelForLocation(location).add(criticalSlotList);
                 }
             }
-            middlePanel2.setVisible(getEntity().isSuperHeavy() && !(getEntity() instanceof VTOL));
-            frontPanel.repaint();
-            bodyPanel.repaint();
-            leftPanel.repaint();
-            rightPanel.repaint();
-            rearLeftPanel.repaint();
-            rearRightPanel.repaint();
-            rearPanel.repaint();
-            turretPanel.repaint();
-            dualTurretPanel.repaint();
-
+            validate();
         }
     }
+
+    private @Nullable JComponent panelForLocation(int location) {
+        if (getEntity().isAero()) {
+            return aeroLocations.get(location);
+        } else if (isVTOL()) {
+            return vtolLocations.get(location);
+        } else if (getTank().isSuperHeavy()) {
+            return superHvyLocations.get(location);
+        } else {
+            return tankLocations.get(location);
+        }
+    }
+
 }

--- a/src/megameklab/com/ui/supportvehicle/SVCriticalView.java
+++ b/src/megameklab/com/ui/supportvehicle/SVCriticalView.java
@@ -185,7 +185,7 @@ public class SVCriticalView extends IView {
                 }
 
                 if (critNames.size() == 0) {
-                    critNames.add(CritCellUtil.EMPTYCELLTEXT);
+                    critNames.add(CritCellUtil.EMPTY_CRITCELL_TEXT);
                 }
                 DropTargetCriticalList<String> criticalSlotList =
                         new DropTargetCriticalList<>(critNames, eSource, refresh, true);

--- a/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
+++ b/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
@@ -742,14 +742,14 @@ public class BayWeaponCriticalTree extends JTree {
 
                 if (node.isLeaf()) {
                     if (node.getParent() != null && node != node.getParent().getChildAt(node.getParent().getChildCount() - 1)) {
-                        Border dashed = BorderFactory.createDashedBorder(CritCellUtil.CRITCELL_BORDERCOLOR, 5, 5);
+                        Border dashed = BorderFactory.createDashedBorder(CritCellUtil.CRITCELL_BORDER_COLOR, 5, 5);
                         Border empty = BorderFactory.createEmptyBorder(-1, -1, 0, -1);
                         Border compound = new CompoundBorder(empty, dashed);
                         setBorder(compound);
                     }
                 } else  {
                     if (row != 0) {
-                        setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, CritCellUtil.CRITCELL_BORDERCOLOR));
+                        setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, CritCellUtil.CRITCELL_BORDER_COLOR));
                     }
                 }
             } else {
@@ -764,7 +764,7 @@ public class BayWeaponCriticalTree extends JTree {
             // Keep a minimum height to avoid empty sections from having no height
             int width = CritCellUtil.CRITCELL_WIDTH;
             width += (!eSource.getEntity().usesWeaponBays() || ((node != null) && node.isLeaf())) ? 0 : 20;
-            int height = Math.max(CRITCELL_MINHEIGHT, super.getPreferredSize().height + CRITCELL_ADDHEIGHT);
+            int height = Math.max(CRITCELL_MIN_HEIGHT, super.getPreferredSize().height + CRITCELL_ADD_HEIGHT);
             return new Dimension(width, height);
         }
     };

--- a/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
+++ b/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
@@ -53,6 +53,7 @@ import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
 
 import static megameklab.com.ui.util.AeroBayTransferHandler.EMTPYSLOT;
+import static megameklab.com.ui.util.CritCellUtil.*;
 
 /**
  * Variant of DropTargetCriticalList for aerospace units that groups weapons into bays. Also
@@ -737,46 +738,34 @@ public class BayWeaponCriticalTree extends JTree {
             setBorder(null);
             if (value instanceof EquipmentNode) {
                 node = (EquipmentNode) value;
-                setToolTipText(node.getTooltip());
-                setHorizontalAlignment(JLabel.LEFT);
-                setForeground(node.getForegroundColor());
-                if (sel) {
-                    setBackground(new Color(UIManager.getColor("Tree.selectionBackground").getRGB()));
-                } else {
-                    setBackground(node.getBackgroundColor());
-                }
+                CritCellUtil.formatCell(this, node.getMounted(), true, eSource.getEntity(), 0);
 
                 if (node.isLeaf()) {
                     if (node.getParent() != null && node != node.getParent().getChildAt(node.getParent().getChildCount() - 1)) {
-                        Border dashed = BorderFactory.createDashedBorder(Color.BLACK, 5, 5);
+                        Border dashed = BorderFactory.createDashedBorder(CritCellUtil.CRITCELL_BORDERCOLOR, 5, 5);
                         Border empty = BorderFactory.createEmptyBorder(-1, -1, 0, -1);
                         Border compound = new CompoundBorder(empty, dashed);
                         setBorder(compound);
                     }
                 } else  {
                     if (row != 0) {
-                        setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.BLACK));
+                        setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, CritCellUtil.CRITCELL_BORDERCOLOR));
                     }
                 }
-                setText(" " + getText());
             } else {
-                node = null;
-                setText("-Empty-");
-                setToolTipText(null);
-                setHorizontalAlignment(JLabel.CENTER);
-                setForeground(CConfig.getForegroundColor(CConfig.CONFIG_EMPTY));
-                setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_EMPTY));
+                CritCellUtil.formatCell(this, null, true, eSource.getEntity(), 0);
             }
             return this;
         }
 
         @Override
         public Dimension getPreferredSize() {
-            Dimension pref = super.getPreferredSize();
             // Make the Bays wider to prevent the tree from changing size upon opening a bay
             // Keep a minimum height to avoid empty sections from having no height
-            int width = (!eSource.getEntity().usesWeaponBays() || ((node != null) && node.isLeaf())) ? 250 : 270;
-            return new Dimension(width, Math.max(25, pref.height + 5));
+            int width = CritCellUtil.CRITCELL_WIDTH;
+            width += (!eSource.getEntity().usesWeaponBays() || ((node != null) && node.isLeaf())) ? 0 : 20;
+            int height = Math.max(CRITCELL_MINHEIGHT, super.getPreferredSize().height + CRITCELL_ADDHEIGHT);
+            return new Dimension(width, height);
         }
     };
 

--- a/src/megameklab/com/ui/util/CritCellUtil.java
+++ b/src/megameklab/com/ui/util/CritCellUtil.java
@@ -1,0 +1,104 @@
+package megameklab.com.ui.util;
+
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import megameklab.com.util.CConfig;
+import megameklab.com.util.UnitUtil;
+
+import javax.swing.*;
+import javax.swing.border.Border;
+import javax.swing.border.TitledBorder;
+import java.awt.*;
+
+/** Contains constants and utils for a unified crit cell display across unit types. */
+public final class CritCellUtil {
+
+    /** The base width of Crit Cells across units with 3 columns of crit lists */
+    public static final int CRITCELL_WIDTH = 250;
+
+    /** The width of Crit Cells for Meks; their layout has 5 columns */
+    public static final int CRITCELL_MEKWIDTH = (int) (0.6 * CRITCELL_WIDTH);
+
+    /** The width of Crit Cells for Vehicles; their layout has 4 columns */
+    public static final int CRITCELL_VEHWIDTH = (int) (0.8 * CRITCELL_WIDTH);
+
+    public static final int CRITCELL_ADDHEIGHT = 5;
+    public static final int CRITCELL_MINHEIGHT = 25;
+    public static final Color CRITCELL_BORDERCOLOR = Color.BLACK;
+    public static final String EMPTYCELLTEXT = "- Empty -";
+
+    public static Border locationBorder(String title) {
+        return BorderFactory.createTitledBorder(
+                new LocationBorder(CRITCELL_BORDERCOLOR, 2f),
+                " " + title + " ",
+                TitledBorder.TOP,
+                TitledBorder.DEFAULT_POSITION);
+    }
+
+    public static Border locationBorderNoLine(String title) {
+        return BorderFactory.createTitledBorder(
+                BorderFactory.createEmptyBorder(),
+                " " + title + " ",
+                TitledBorder.TOP,
+                TitledBorder.DEFAULT_POSITION);
+    }
+
+    public static void formatCell(JLabel cell, @Nullable Mounted mounted, boolean useColor,
+                                  Entity entity, int index) {
+        if (useColor) {
+            if (mounted == null) {
+                cell.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_EMPTY));
+                cell.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_EMPTY));
+            } else if (mounted.getType() instanceof WeaponType) {
+                cell.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_WEAPONS));
+                cell.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_WEAPONS));
+            } else if (mounted.getType() instanceof AmmoType) {
+                cell.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_AMMO));
+                cell.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_AMMO));
+            } else {
+                cell.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_EQUIPMENT));
+                cell.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_EQUIPMENT));
+            }
+        }
+
+        if (mounted == null) {
+            cell.setText(" " + EMPTYCELLTEXT);
+            cell.setToolTipText(null);
+        } else {
+            String name = UnitUtil.getCritName(entity, mounted.getType());
+            name += mounted.isRearMounted() ? " (R)" : "";
+            name += mounted.isArmored() ? " (A)" : "";
+            name += mounted.isMechTurretMounted() ? " (T)" : "";
+            name += mounted.isSponsonTurretMounted() ? " (ST)" : "";
+            name += mounted.isPintleTurretMounted() ? " (PT)" : "";
+            name += mounted.isDWPMounted() ? " (DWP)" : "";
+            if (mounted.getType() instanceof AmmoType) {
+                name = mounted.getBaseShotsLeft() + " shot" + (mounted.getBaseShotsLeft() > 1 ? "s " : " ") + name;
+            }
+            if (entity.isOmni() && !mounted.getType().isOmniFixedOnly()) {
+                if (mounted.isOmniPodMounted()) {
+                    name += " (Pod)";
+                } else {
+                    name += " (Fixed)";
+                    cell.setFont(cell.getFont().deriveFont(Font.ITALIC));
+                }
+            }
+            if ((mounted.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK)
+                    || mounted.getType().hasFlag(MiscType.F_AP_MOUNT))
+                    && mounted.getLinked() != null) {
+                name += " (attached " + mounted.getLinked().getName() + ")";
+            }
+
+            cell.setText(" " + name);
+
+            String toolTipText = UnitUtil.getToolTipInfo(entity, mounted);
+            // distinguish tooltips of equal adjacent one-slot equipment (e.g. ammo) to make the tip renew itself
+            // when crossing from one such slot to the next (avoids them feeling like a single equipment)
+            if (mounted.getCriticals() == 1) {
+                toolTipText += " ".repeat(index);
+            }
+            cell.setToolTipText(toolTipText);
+        }
+    }
+
+}

--- a/src/megameklab/com/ui/util/CritCellUtil.java
+++ b/src/megameklab/com/ui/util/CritCellUtil.java
@@ -17,24 +17,37 @@ public final class CritCellUtil {
     public static final int CRITCELL_WIDTH = 250;
 
     /** The width of Crit Cells for Meks; their layout has 5 columns */
-    public static final int CRITCELL_MEKWIDTH = (int) (0.6 * CRITCELL_WIDTH);
+    public static final int CRITCELL_MEK_WIDTH = (int) (0.6 * CRITCELL_WIDTH);
 
     /** The width of Crit Cells for Vehicles; their layout has 4 columns */
-    public static final int CRITCELL_VEHWIDTH = (int) (0.8 * CRITCELL_WIDTH);
+    public static final int CRITCELL_VEH_WIDTH = (int) (0.8 * CRITCELL_WIDTH);
 
-    public static final int CRITCELL_ADDHEIGHT = 5;
-    public static final int CRITCELL_MINHEIGHT = 25;
-    public static final Color CRITCELL_BORDERCOLOR = Color.BLACK;
-    public static final String EMPTYCELLTEXT = "- Empty -";
+    /** The height added to the text height of Crit Cells (padding) */
+    public static final int CRITCELL_ADD_HEIGHT = 5;
 
+    /** The minimum height of Crit Cells (safeguard for empty blocks) */
+    public static final int CRITCELL_MIN_HEIGHT = 25;
+    public static final Color CRITCELL_BORDER_COLOR = Color.BLACK;
+    public static final String EMPTY_CRITCELL_TEXT = "- Empty -";
+
+    /**
+     * Returns a titled border using the given string as title placed centered atop the
+     * Component and using a {@link LocationBorder} as a border. To be used for crit
+     * location blocks, especially when they have additional information ("Slots: 0/2")
+     * above or below the crits to group them visually.
+     */
     public static Border locationBorder(String title) {
         return BorderFactory.createTitledBorder(
-                new LocationBorder(CRITCELL_BORDERCOLOR, 2f),
+                new LocationBorder(CRITCELL_BORDER_COLOR, 2f),
                 " " + title + " ",
                 TitledBorder.TOP,
                 TitledBorder.DEFAULT_POSITION);
     }
 
+    /**
+     * Returns a titled but otherwise empty border using the given string as title
+     * placed centered atop the Component.
+     */
     public static Border locationBorderNoLine(String title) {
         return BorderFactory.createTitledBorder(
                 BorderFactory.createEmptyBorder(),
@@ -43,6 +56,11 @@ public final class CritCellUtil {
                 TitledBorder.DEFAULT_POSITION);
     }
 
+    /**
+     * Applies crit cell formatting to the given JLabel cell, which is assumed to display
+     * the given mounted in the given entity at the given crit cell index.
+     * The JLabel cell should be a ListCellRenderer or TreeCellRenderer return value.
+     */
     public static void formatCell(JLabel cell, @Nullable Mounted mounted, boolean useColor,
                                   Entity entity, int index) {
         if (useColor) {
@@ -62,7 +80,7 @@ public final class CritCellUtil {
         }
 
         if (mounted == null) {
-            cell.setText(" " + EMPTYCELLTEXT);
+            cell.setText(" " + EMPTY_CRITCELL_TEXT);
             cell.setToolTipText(null);
         } else {
             String name = UnitUtil.getCritName(entity, mounted.getType());

--- a/src/megameklab/com/ui/util/ProtomekMountList.java
+++ b/src/megameklab/com/ui/util/ProtomekMountList.java
@@ -13,9 +13,9 @@
  */
 package megameklab.com.ui.util;
 
+import megamek.MegaMek;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
-import megamek.common.verifier.TestProtomech;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.CriticalTransferHandler;
 import megameklab.com.util.RefreshListener;
@@ -32,7 +32,7 @@ import java.util.List;
 import static megameklab.com.ui.util.CritCellUtil.*;
 
 /**
- * The location crit block for Protomeks
+ * The location crit block for ProtoMeks
  *
  * @author Neoancient
  * @author Simon (Juliez)
@@ -123,9 +123,9 @@ public class ProtomekMountList extends JList<Mounted> {
             if (SwingUtilities.isLeftMouseButton(e)) {
                 if (e.isControlDown() && (mounted.getType() instanceof AmmoType)) {
                     try {
-                        UnitUtil.addProtomechAmmo(getProtomech(), mounted.getType(), 1);
+                        UnitUtil.addProtoMechAmmo(getProtomech(), mounted.getType(), 1);
                     } catch (LocationFullException ex) {
-                        ex.printStackTrace();
+                        MegaMek.getLogger().error(ex);
                     }
                     refresh();
                     return;
@@ -139,7 +139,7 @@ public class ProtomekMountList extends JList<Mounted> {
                 }
                 if (e.isControlDown()) {
                     if ((mounted.getType() instanceof AmmoType)) {
-                        UnitUtil.reduceProtomechAmmo(getProtomech(), mounted.getType(), 1);
+                        UnitUtil.reduceProtoMechAmmo(getProtomech(), mounted.getType(), 1);
                     } else {
                         removeMount(mounted);
                     }
@@ -182,7 +182,7 @@ public class ProtomekMountList extends JList<Mounted> {
         }
     };
 
-    private class MountedListModel extends AbstractListModel<Mounted> {
+    private static class MountedListModel extends AbstractListModel<Mounted> {
 
         private final List<Mounted> list = new ArrayList<>();
 
@@ -217,7 +217,7 @@ public class ProtomekMountList extends JList<Mounted> {
 
         @Override
         public Dimension getPreferredSize() {
-            int height = Math.max(CRITCELL_MINHEIGHT, super.getPreferredSize().height + CRITCELL_ADDHEIGHT);
+            int height = Math.max(CRITCELL_MIN_HEIGHT, super.getPreferredSize().height + CRITCELL_ADD_HEIGHT);
             return new Dimension(CRITCELL_WIDTH, height);
         }
     }

--- a/src/megameklab/com/ui/util/ProtomekMountList.java
+++ b/src/megameklab/com/ui/util/ProtomekMountList.java
@@ -13,46 +13,31 @@
  */
 package megameklab.com.ui.util;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.event.InputEvent;
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import megamek.common.verifier.TestProtomech;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.CriticalTransferHandler;
+import megameklab.com.util.RefreshListener;
+import megameklab.com.util.UnitUtil;
+
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.AbstractListModel;
-import javax.swing.BorderFactory;
-import javax.swing.DefaultListCellRenderer;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.ListSelectionModel;
-
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.Protomech;
-import megamek.common.WeaponType;
-import megamek.common.annotations.Nullable;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.CConfig;
-import megameklab.com.util.CriticalTransferHandler;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.UnitUtil;
+import static megameklab.com.ui.util.CritCellUtil.*;
 
 /**
- * @author Neoancient
+ * The location crit block for Protomeks
  *
+ * @author Neoancient
+ * @author Simon (Juliez)
  */
 public class ProtomekMountList extends JList<Mounted> {
-
-    private static final long serialVersionUID = -2051124199120063905L;
 
     private final EntitySource eSource;
     private final int location;
@@ -63,14 +48,12 @@ public class ProtomekMountList extends JList<Mounted> {
         this.refresh = refresh;
         this.location = location;
         refreshContents();
-        setCellRenderer(new MountCellRenderer(true));
+        setCellRenderer(new MountCellRenderer());
         addMouseListener(mouseListener);
         setDragEnabled(true);
         setTransferHandler(new CriticalTransferHandler(eSource, refresh));
-        
         setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-        setFont(new Font("Arial", Font.PLAIN, 10));
-        setBorder(BorderFactory.createEtchedBorder(Color.WHITE.brighter(), Color.BLACK.darker()));
+        setBorder(BorderFactory.createLineBorder(Color.BLACK));
     }
     
     public Protomech getProtomech() {
@@ -95,11 +78,7 @@ public class ProtomekMountList extends JList<Mounted> {
     
     public void refreshContents() {
         MountedListModel model = new MountedListModel();
-        for (Mounted m : getProtomech().getEquipment()) {
-            if (m.getLocation() == location) {
-                model.add(m);
-            }
-        }
+        getProtomech().getEquipment().stream().filter(m -> m.getLocation() == location).forEach(model::add);
         setModel(model);
         setVisibleRowCount(model.getSize());
     }
@@ -110,8 +89,7 @@ public class ProtomekMountList extends JList<Mounted> {
     }
     
     private void deleteMount(Mounted mount) {
-        if ((mount.getType() instanceof WeaponType)
-                && (mount.getType().hasFlag(WeaponType.F_ONESHOT))) {
+        if (mount.isOneShotWeapon()) {
             Mounted ammo = mount.getLinked();
             if (null != ammo) {
                 UnitUtil.removeMounted(getProtomech(), ammo);
@@ -126,67 +104,87 @@ public class ProtomekMountList extends JList<Mounted> {
         refresh();
     }
     
-    private MouseListener mouseListener = new MouseAdapter() {
+    private final MouseListener mouseListener = new MouseAdapter() {
         @Override
         public void mousePressed(MouseEvent e) {
-            final int index = locationToIndex(e.getPoint());
-            final Mounted mount = getModel().getElementAt(index);
-            if ((null == mount) || UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
-                return;
-            }
-            if ((mount.getType() instanceof MiscType)
-                    && (UnitUtil.isArmor(mount.getType())
-                            || mount.getType().hasFlag(MiscType.F_JUMP_JET)
-                            || mount.getType().hasFlag(MiscType.F_UMU))) {
-                return;
-            }
-            
-            if (e.getButton() == MouseEvent.BUTTON2) {
-                remove(index);
-            } else if (e.getButton() == MouseEvent.BUTTON3) {
-                if ((e.getModifiersEx() & InputEvent.CTRL_DOWN_MASK) != 0) {
-                    remove(index);
-                    return;
-                }
-
-                JPopupMenu popup = new JPopupMenu();
-
-                if ((location == Protomech.LOC_TORSO)
-                        && (e.getModifiersEx() & InputEvent.ALT_DOWN_MASK) != 0) {
-                    changeFacing(mount);
-                    return;
-                }
-
-                JMenuItem info;
-
-                if (!(mount.getType() instanceof AmmoType)) {
-                    info = new JMenuItem("Remove " + mount.getName());
-                    info.addActionListener(ev -> removeMount(mount));
-                    popup.add(info);
-                }
-                info = new JMenuItem("Delete " + mount.getName());
-                info.addActionListener(ev -> deleteMount(mount));
-                popup.add(info);
-                if ((location == Protomech.LOC_TORSO)
-                        && (mount.getType() instanceof WeaponType)) {
-                    info = new JMenuItem("Change Facing");
-                    info.addActionListener(ev -> changeFacing(mount));
-                    popup.add(info);
-                }
-
-
-                if (popup.getComponentCount() > 0) {
-                    popup.show(ProtomekMountList.this, e.getX(), e.getY());
-                }
+            final Mounted mounted = getModel().getElementAt(locationToIndex(e.getPoint()));
+            if (e.isPopupTrigger() && isChangeable(mounted)) {
+                showPopup(e, mounted);
             }
         }
+
+        @Override
+        public void mouseReleased(MouseEvent e) {
+            final Mounted mounted = getModel().getElementAt(locationToIndex(e.getPoint()));
+            if (!isChangeable(mounted)) {
+                return;
+            }
+
+            if (SwingUtilities.isLeftMouseButton(e)) {
+                if (e.isControlDown() && (mounted.getType() instanceof AmmoType)) {
+                    try {
+                        UnitUtil.addProtomechAmmo(getProtomech(), mounted.getType(), 1);
+                    } catch (LocationFullException ex) {
+                        ex.printStackTrace();
+                    }
+                    refresh();
+                    return;
+                }
+            }
+
+            if (SwingUtilities.isRightMouseButton(e)) {
+                if (e.isAltDown() && isTorso()) {
+                    changeFacing(mounted);
+                    return;
+                }
+                if (e.isControlDown()) {
+                    if ((mounted.getType() instanceof AmmoType)) {
+                        UnitUtil.reduceProtomechAmmo(getProtomech(), mounted.getType(), 1);
+                    } else {
+                        removeMount(mounted);
+                    }
+                    refresh();
+                    return;
+                }
+            }
+
+            if (e.isPopupTrigger()) {
+                showPopup(e, mounted);
+            }
+        }
+
+        private boolean isChangeable(@Nullable Mounted mounted) {
+            return (mounted != null)
+                    && !UnitUtil.isFixedLocationSpreadEquipment(mounted.getType())
+                    && !UnitUtil.isArmor(mounted.getType());
+        }
+
+        private void showPopup(MouseEvent e, Mounted mounted) {
+            JPopupMenu popup = new JPopupMenu();
+            JMenuItem menuItem;
+            if (!(mounted.getType() instanceof AmmoType)) {
+                menuItem = new JMenuItem("Remove " + mounted.getName());
+                menuItem.addActionListener(ev -> removeMount(mounted));
+                popup.add(menuItem);
+            }
+
+            menuItem = new JMenuItem("Delete " + mounted.getName());
+            menuItem.addActionListener(ev -> deleteMount(mounted));
+            popup.add(menuItem);
+
+            if (isTorso() && (mounted.getType() instanceof WeaponType)) {
+                menuItem = new JMenuItem("Change Facing");
+                menuItem.addActionListener(ev -> changeFacing(mounted));
+                popup.add(menuItem);
+            }
+
+            popup.show(ProtomekMountList.this, e.getX(), e.getY());
+        }
     };
-    
-    private static class MountedListModel extends AbstractListModel<Mounted> {
 
-        private static final long serialVersionUID = 2575915653617712928L;
+    private class MountedListModel extends AbstractListModel<Mounted> {
 
-        private List<Mounted> list = new ArrayList<>();
+        private final List<Mounted> list = new ArrayList<>();
 
         @Override
         public int getSize() {
@@ -195,88 +193,41 @@ public class ProtomekMountList extends JList<Mounted> {
 
         @Override
         public Mounted getElementAt(int index) {
-            if (index >= list.size()) {
-                return null;
-            }
-            return list.get(index);
+            return (index >= list.size()) ? null : list.get(index);
         }
         
         public void add(Mounted mounted) {
             list.add(mounted);
             fireContentsChanged(this, list.size() - 1, list.size() - 1);
         }
-        
     }
     
     private static class MountCellRenderer extends DefaultListCellRenderer {
 
-        private static final long serialVersionUID = -1115364118975814321L;
-        
-        private boolean useColor = false;
-
-        public MountCellRenderer(boolean useColor) {
-            this.useColor = useColor;
+        @Override
+        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean hasFocus) {
+            final ProtomekMountList lstMount = (ProtomekMountList) list;
+            final Entity entity = lstMount.eSource.getEntity();
+            CritCellUtil.formatCell(this, (Mounted) value, true, entity, index);
+            if ((index > 0) && (index < list.getModel().getSize())) {
+                setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.black));
+            }
+            return this;
         }
 
         @Override
-        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean hasFocus) {
-            final JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, hasFocus);
-            final ProtomekMountList lstMount = (ProtomekMountList) list;
-            final Entity entity = lstMount.eSource.getEntity();
-            
-            label.setPreferredSize(new Dimension(140,15));
-            label.setMaximumSize(new Dimension(140,15));
-            label.setMinimumSize(new Dimension(140,15));
-
-            if (null == value) {
-                if (useColor) {
-                    label.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_EMPTY));
-                    label.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_EMPTY));
-                }
-                label.setText("-Empty-");
-            } else {
-                final Mounted mount = (Mounted) value;
-
-                if (useColor) {
-                    if (mount.getType() instanceof WeaponType) {
-                        label.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_WEAPONS));
-                        label.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_WEAPONS));
-                    } else if (mount.getType() instanceof AmmoType) {
-                        label.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_AMMO));
-                        label.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_AMMO));
-                    } else {
-                        label.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_EQUIPMENT));
-                        label.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_EQUIPMENT));
-                    }
-                }
-                if (UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
-                    label.setFont(label.getFont().deriveFont(Font.ITALIC));
-                }
-                
-                String name = UnitUtil.getCritName(entity, mount.getType());
-                if (mount.isRearMounted()) {
-                    name += " (R)";
-                }
-                if (mount.getType() instanceof AmmoType) {
-                    name += " (" + mount.getBaseShotsLeft() + ")";
-                }
-                String toolTipText = UnitUtil.getToolTipInfo(entity, mount);
-                label.setText(name);
-                label.setToolTipText(toolTipText);
-            }
-
-            if ((index > 0) && (index < list.getModel().getSize())) {
-                label.setBorder( BorderFactory.createMatteBorder(1, 0, 0, 0, Color.black));
-            }
-
-            return label;
+        public Dimension getPreferredSize() {
+            int height = Math.max(CRITCELL_MINHEIGHT, super.getPreferredSize().height + CRITCELL_ADDHEIGHT);
+            return new Dimension(CRITCELL_WIDTH, height);
         }
     }
 
-    /**
-     * @return The selected item, or null if nothing is selected.
-     */
+    /** Returns the selected item, or null if nothing is selected. */
     public @Nullable Mounted getMounted() {
         return getSelectedValue();
+    }
+
+    private boolean isTorso() {
+        return location == Protomech.LOC_TORSO;
     }
 }

--- a/src/megameklab/com/util/CritListCellRenderer.java
+++ b/src/megameklab/com/util/CritListCellRenderer.java
@@ -16,23 +16,13 @@
 
 package megameklab.com.util;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
+import megamek.common.*;
+import megameklab.com.ui.util.CritCellUtil;
 
-import javax.swing.BorderFactory;
-import javax.swing.DefaultListCellRenderer;
-import javax.swing.JLabel;
-import javax.swing.JList;
+import javax.swing.*;
+import java.awt.*;
 
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
+import static megameklab.com.ui.util.CritCellUtil.*;
 
 public class CritListCellRenderer extends DefaultListCellRenderer {
 
@@ -47,16 +37,12 @@ public class CritListCellRenderer extends DefaultListCellRenderer {
 
     @Override
     public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean hasFocus) {
-        JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, hasFocus);
+        super.getListCellRendererComponent(list, value, index, isSelected, hasFocus);
         this.list = list;
 
-        setPreferredSize(new Dimension(110,15));
-        setMaximumSize(new Dimension(110,15));
-        setMinimumSize(new Dimension(110,15));
-
         String[] split = ((String)value).split(":");
-        label.setText(split[0]);
-        label.setToolTipText(null);
+        setText(split[0]);
+        setToolTipText(null);
 
         CriticalSlot cs;
         if (split.length > 2) {
@@ -71,98 +57,52 @@ public class CritListCellRenderer extends DefaultListCellRenderer {
         }
 
         if (cs != null) {
-
             if (cs.getType() == CriticalSlot.TYPE_SYSTEM) {
                 if (useColor) {
-                    label.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_SYSTEMS));
-                    label.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_SYSTEMS));
+                    setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_SYSTEMS));
+                    setForeground(CConfig.getForegroundColor(CConfig.CONFIG_SYSTEMS));
                 }
                 if (cs.isArmored()) {
-                    label.setText(label.getText() + " (A)");
+                    setText(getText() + " (A)");
                 }
+                setText(" " + getText());
             } else if (cs.getMount() != null) {
-
-                Mounted mount = cs.getMount();
-
-                if (useColor) {
-                    if (mount.getType() instanceof WeaponType) {
-                        label.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_WEAPONS));
-                        label.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_WEAPONS));
-                    } else if (mount.getType() instanceof AmmoType) {
-                        label.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_AMMO));
-                        label.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_AMMO));
-                    } else {
-                        label.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_EQUIPMENT));
-                        label.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_EQUIPMENT));
-                    }
-                }
-                String name = UnitUtil.getCritName(unit, mount.getType());
-
-                if (mount.isRearMounted()) {
-                    name += " (R)";
-                }
-                if (mount.isArmored()) {
-                    name += " (A)";
-                }
-                if (mount.isMechTurretMounted()) {
-                    name += " (T)";
-                }
-                if (mount.isSponsonTurretMounted()) {
-                    name += " (ST)";
-                }
-                if (mount.isPintleTurretMounted()) {
-                    name += " (PT)";
-                }
-                if (mount.isDWPMounted()) {
-                    name += " (DWP)";
-                }
-                if (unit.isOmni() && !mount.getType().isOmniFixedOnly()) {
-                    if (mount.isOmniPodMounted()) {
-                        name += " (Pod)";
-                    } else {
-                        name += " (Fixed)";
-                        label.setFont(label.getFont().deriveFont(Font.ITALIC));
-                    }
-                }
-                if ((mount.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK)
-                        || mount.getType().hasFlag(MiscType.F_AP_MOUNT))
-                        && mount.getLinked() != null){
-                    name += " (attached " + mount.getLinked().getName() + ")";
-                }
-                // For ammo on BA, show the number of shots
-                if ((unit instanceof BattleArmor) && (mount.getType() instanceof AmmoType)) {
-                    name += " (" + mount.getBaseShotsLeft() + ")";
-                }
-                String toolTipText = UnitUtil.getToolTipInfo(unit, mount);
-                // distinguish tooltips of equal adjacent one-slot equipment (e.g. ammo) to make the tip renew itself
-                // when crossing from one such slot to the next (avoids them feeling like a single equipment)
-                if (mount.getCriticals() == 1) {
-                    toolTipText += " ".repeat(index);
-                }
+                CritCellUtil.formatCell(this, cs.getMount(), useColor, unit, index);
                 if (cs.getMount2() != null) {
-                    mount = cs.getMount2();
-                    name += " | "+ UnitUtil.getCritName(unit, mount.getType());
+                    setText(getText() + " | " + UnitUtil.getCritName(unit, cs.getMount2().getType()));
                 }
-                label.setText(name);
-                label.setToolTipText(toolTipText);
             }
-        } else if (useColor) {
-            label.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_EMPTY));
-            label.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_EMPTY));
+        } else {
+            CritCellUtil.formatCell(this, null, useColor, unit, index);
         }
 
         int loc = getCritLocation();
         if ((cs != null) 
                 && UnitUtil.isLastCrit(unit, cs, index, loc) 
                 && UnitUtil.isPreviousCritEmpty(unit, cs, index, loc)) {
-            label.setBorder(BorderFactory.createMatteBorder(1, 0, 1, 0, Color.black));
+            setBorder(BorderFactory.createMatteBorder(1, 0, 1, 0, CritCellUtil.CRITCELL_BORDERCOLOR));
         } else if ((cs != null) && UnitUtil.isLastCrit(unit, cs, index, loc)) {
-            label.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, Color.black));
+            setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, CritCellUtil.CRITCELL_BORDERCOLOR));
         } else if ((cs != null) && UnitUtil.isPreviousCritEmpty(unit, cs, index, loc)) {
-            label.setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, Color.black));
+            setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, CritCellUtil.CRITCELL_BORDERCOLOR));
         } 
 
-        return label;
+        return this;
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+        int width = CRITCELL_WIDTH;
+        width = (unit instanceof Mech) ? CRITCELL_MEKWIDTH : width;
+        width = (unit instanceof Tank) ? CRITCELL_VEHWIDTH : width;
+        int height = Math.max(CRITCELL_MINHEIGHT, super.getPreferredSize().height + CRITCELL_ADDHEIGHT);
+        return new Dimension(width, height);
+    }
+
+    @Override
+    public Dimension getMaximumSize() {
+        Dimension pref = getPreferredSize();
+        return new Dimension(pref.width * 2, pref.height);
     }
 
     private CriticalSlot getCrit(int slot) {

--- a/src/megameklab/com/util/CritListCellRenderer.java
+++ b/src/megameklab/com/util/CritListCellRenderer.java
@@ -80,11 +80,11 @@ public class CritListCellRenderer extends DefaultListCellRenderer {
         if ((cs != null) 
                 && UnitUtil.isLastCrit(unit, cs, index, loc) 
                 && UnitUtil.isPreviousCritEmpty(unit, cs, index, loc)) {
-            setBorder(BorderFactory.createMatteBorder(1, 0, 1, 0, CritCellUtil.CRITCELL_BORDERCOLOR));
+            setBorder(BorderFactory.createMatteBorder(1, 0, 1, 0, CritCellUtil.CRITCELL_BORDER_COLOR));
         } else if ((cs != null) && UnitUtil.isLastCrit(unit, cs, index, loc)) {
-            setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, CritCellUtil.CRITCELL_BORDERCOLOR));
+            setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, CritCellUtil.CRITCELL_BORDER_COLOR));
         } else if ((cs != null) && UnitUtil.isPreviousCritEmpty(unit, cs, index, loc)) {
-            setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, CritCellUtil.CRITCELL_BORDERCOLOR));
+            setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, CritCellUtil.CRITCELL_BORDER_COLOR));
         } 
 
         return this;
@@ -93,9 +93,9 @@ public class CritListCellRenderer extends DefaultListCellRenderer {
     @Override
     public Dimension getPreferredSize() {
         int width = CRITCELL_WIDTH;
-        width = (unit instanceof Mech) ? CRITCELL_MEKWIDTH : width;
-        width = (unit instanceof Tank) ? CRITCELL_VEHWIDTH : width;
-        int height = Math.max(CRITCELL_MINHEIGHT, super.getPreferredSize().height + CRITCELL_ADDHEIGHT);
+        width = (unit instanceof Mech) ? CRITCELL_MEK_WIDTH : width;
+        width = (unit instanceof Tank) ? CRITCELL_VEH_WIDTH : width;
+        int height = Math.max(CRITCELL_MIN_HEIGHT, super.getPreferredSize().height + CRITCELL_ADD_HEIGHT);
         return new Dimension(width, height);
     }
 

--- a/src/megameklab/com/util/CritListCellRenderer.java
+++ b/src/megameklab/com/util/CritListCellRenderer.java
@@ -99,12 +99,6 @@ public class CritListCellRenderer extends DefaultListCellRenderer {
         return new Dimension(width, height);
     }
 
-    @Override
-    public Dimension getMaximumSize() {
-        Dimension pref = getPreferredSize();
-        return new Dimension(pref.width * 2, pref.height);
-    }
-
     private CriticalSlot getCrit(int slot) {
         int location = getCritLocation();
         CriticalSlot crit = null;

--- a/src/megameklab/com/util/IView.java
+++ b/src/megameklab/com/util/IView.java
@@ -93,4 +93,12 @@ public class IView extends JPanel {
     public boolean isWarShip() {
         return getEntity().hasETypeFlag(Entity.ETYPE_WARSHIP);
     }
+
+    /**
+     * Returns true if the entity is a VTOL Combat Vehicle. This is an instanceof check and includes
+     * Support VTOLs but not VTOL type Infantry.
+     * */
+    public boolean isVTOL() {
+        return getEntity() instanceof VTOL;
+    }
 }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -4438,8 +4438,8 @@ public class UnitUtil {
         emptyBays.forEach(bay -> UnitUtil.removeMounted(entity, bay));
     }
 
-
-    public static void addProtomechAmmo(Protomech entity, EquipmentType ammo, int shots) throws LocationFullException {
+    /** Adds the given number of shots to the already present given ammo on the given ProtoMek. */
+    public static void addProtoMechAmmo(Protomech entity, EquipmentType ammo, int shots) throws LocationFullException {
         Mounted aMount = entity.getAmmo().stream()
                 .filter(m -> ammo.equals(m.getType())).findFirst().orElse(null);
         if (null != aMount) {
@@ -4451,7 +4451,11 @@ public class UnitUtil {
         }
     }
 
-    public static void reduceProtomechAmmo(Protomech entity, EquipmentType ammo, int shots) {
+    /**
+     * Subtracts the given number of shots from the given ammo on the given ProtoMek.
+     * May remove the entire Mounted from the ProtoMek.
+     */
+    public static void reduceProtoMechAmmo(Protomech entity, EquipmentType ammo, int shots) {
         Mounted aMount = entity.getAmmo().stream()
                 .filter(m -> ammo.equals(m.getType())).findFirst().orElse(null);
         if (aMount != null) {


### PR DESCRIPTION
+ Crit Cells on various units now use a more unified style and use a standard size font instead of a reduced size font. The width of crit cells adapts to the number of columns used by the unit (5 for meks, 3 for BA)
+ The number of shots for ammo is now displayed at the start of the cell text to (finally) always keep it in sight no matter the name of the ammo
+ Adds experimental mouse click functionality on Crit Cells (add & remove weapons & ammo on Ctrl-Click) to ProtoMeks (for now)

Adds a CritCellUtil class that combines general Crit Cell display functionality. Lots of code cleanup without much visual effect. Especially in the various CriticalView classes loads of code is removed that had little or no effect or was just (to my eye) in need of some updated organization.

![image](https://user-images.githubusercontent.com/17069663/144725617-9f05038e-288d-4a6d-9953-41d8b02a9a1e.png)
![image](https://user-images.githubusercontent.com/17069663/144725767-ea83e35b-3028-470e-88c6-58acf3ec2b4b.png)

