### PR TITLE
Log4j 2 Swapover

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,8 @@ configurations {
 
 dependencies {
     implementation "org.megamek:megamek${mmBranchTag}:${version}"
-    
+
+    implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
     implementation 'org.apache.xmlgraphics:batik-dom:1.14'
     implementation 'org.apache.xmlgraphics:batik-codec:1.14'
     implementation 'org.apache.xmlgraphics:batik-rasterizer:1.14'

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration status="info">
+    <Properties>
+        <Property name="layout">%d{ABSOLUTE} %-5p [%logger{36}] {%t}%n%l - %m%n%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="Console">
+            <PatternLayout pattern="${layout}" />
+        </Console>
+        <File name="MegaMekLog" fileName="logs/megamek.log" append="false">
+            <PatternLayout pattern="${layout}"/>
+        </File>
+        <File name="MegaMekLabLog" fileName="logs/megameklab.log" append="false">
+            <PatternLayout pattern="${layout}"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="megamek" level="info" additivity="false" >
+            <AppenderRef ref="MegaMekLabLog" />
+        </Logger>
+        <Logger name="megameklab" level="info" additivity="false" >
+            <AppenderRef ref="MegaMekLabLog" />
+        </Logger>
+
+        <Root level="info">
+            <AppenderRef ref="MegaMekLabLog" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -8,9 +8,6 @@
         <Console name="Console">
             <PatternLayout pattern="${layout}" />
         </Console>
-        <File name="MegaMekLog" fileName="logs/megamek.log" append="false">
-            <PatternLayout pattern="${layout}"/>
-        </File>
         <File name="MegaMekLabLog" fileName="logs/megameklab.log" append="false">
             <PatternLayout pattern="${layout}"/>
         </File>

--- a/src/megameklab/com/MegaMekLab.java
+++ b/src/megameklab/com/MegaMekLab.java
@@ -13,7 +13,6 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com;
 
 import megamek.MegaMek;
@@ -21,20 +20,15 @@ import megamek.common.Configuration;
 import megamek.common.EquipmentType;
 import megamek.common.MechSummaryCache;
 import megamek.common.QuirksHandler;
-import megamek.common.logging.DefaultMmLogger;
-import megamek.common.logging.MMLogger;
 import megamek.common.preference.PreferenceManager;
 import megameklab.com.ui.StartupGUI;
 import megameklab.com.util.CConfig;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
+import java.io.*;
 import java.text.NumberFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -43,8 +37,6 @@ import java.util.List;
 import java.util.Locale;
 
 public class MegaMekLab {
-    private static MMLogger logger = null;
-
     public static void main(String[] args) {
     	System.setProperty("apple.laf.useScreenMenuBar", "true");
         System.setProperty("com.apple.mrj.application.apple.menu.about.name","MegaMekLab");
@@ -76,7 +68,7 @@ public class MegaMekLab {
             System.setOut(ps);
             System.setErr(ps);
         } catch (Exception e) {
-            getLogger().error("Unable to redirect output to megameklablog.txt", e);
+            LogManager.getLogger().error("Unable to redirect output to megameklablog.txt", e);
         }
     }
 
@@ -97,47 +89,33 @@ public class MegaMekLab {
                     try {
                         list.add(Font.createFont(Font.TRUETYPE_FONT, f));
                     } catch (IOException | FontFormatException ex) {
-                        getLogger().error("Error creating font from " + f, ex);
+                        LogManager.getLogger().error("Error creating font from " + f, ex);
                     }
                 }
             }
         }
     }
 
-    public static MMLogger getLogger() {
-        if (null == logger) {
-            logger = DefaultMmLogger.getInstance();
-        }
-        return logger;
-    }
-    
     /**
      * Prints some information about MegaMekLab. Used in logfiles to figure out the
      * JVM and version of MegaMekLab.
      */
-    private static void showInfo() {
-        final long TIMESTAMP = new File(PreferenceManager
-                .getClientPreferences().getLogDirectory()
-                + File.separator
-                + "timestamp").lastModified();
+    public static void showInfo() {
+        final long TIMESTAMP = new File(PreferenceManager.getClientPreferences().getLogDirectory()
+                + File.separator + "timestamp").lastModified();
         // echo some useful stuff
-        String msg = "Starting MegaMekLab v" + MMLConstants.VERSION + " ..."; //$NON-NLS-1$ //$NON-NLS-2$
+        String msg = "Starting MegaMekLab v" + MMLConstants.VERSION;
         if (TIMESTAMP > 0) {
-            msg += "\n\tCompiled on " + new Date(TIMESTAMP).toString(); //$NON-NLS-1$
+            msg += "\n\tCompiled on " + new Date(TIMESTAMP);
         }
-        msg += "\n\tToday is " + LocalDate.now().toString();
-        msg += "\n\tJava vendor " + System.getProperty("java.vendor"); //$NON-NLS-1$ //$NON-NLS-2$
-        msg += "\n\tJava version " + System.getProperty("java.version"); //$NON-NLS-1$ //$NON-NLS-2$
-        msg += "\n\tPlatform " //$NON-NLS-1$
-               + System.getProperty("os.name") //$NON-NLS-1$
-               + " " //$NON-NLS-1$
-               + System.getProperty("os.version") //$NON-NLS-1$
-               + " (" //$NON-NLS-1$
-               + System.getProperty("os.arch") //$NON-NLS-1$
-               + ")"; //$NON-NLS-1$
-        long maxMemory = Runtime.getRuntime().maxMemory() / 1024;
-        msg += "\n\tTotal memory available to MegaMek: " + NumberFormat.getInstance().format(maxMemory) + " kB"; //$NON-NLS-1$ //$NON-NLS-2$
-        getLogger().info(msg);
+        msg += "\n\tToday is " + LocalDate.now()
+                + "\n\tJava Vendor: " + System.getProperty("java.vendor")
+                + "\n\tJava Version: " + System.getProperty("java.version")
+                + "\n\tPlatform: " + System.getProperty("os.name") + " " + System.getProperty("os.version")
+                + " (" + System.getProperty("os.arch") + ")"
+                + "\n\tTotal memory available to MegaMek: "
+                + NumberFormat.getInstance().format(Runtime.getRuntime().maxMemory()) + " GB";
+        LogManager.getLogger().info(msg);
     }
     
     private static void startup() {
@@ -148,7 +126,7 @@ public class MegaMekLab {
         try {
             QuirksHandler.initQuirksList();
         } catch (Exception e) {
-            MegaMekLab.getLogger().warning("Could not load quirks");
+            LogManager.getLogger().warn("Could not load quirks");
         }
         CConfig.load();
         UnitUtil.loadFonts();
@@ -170,7 +148,7 @@ public class MegaMekLab {
             String plaf = CConfig.getParam(CConfig.CONFIG_PLAF, UIManager.getSystemLookAndFeelClassName());
             UIManager.setLookAndFeel(plaf);
         } catch (Exception e) {
-            getLogger().error(e);
+            LogManager.getLogger().error(e);
        }
     }
     

--- a/src/megameklab/com/printing/ArmorPipLayout.java
+++ b/src/megameklab/com/printing/ArmorPipLayout.java
@@ -14,8 +14,8 @@
 package megameklab.com.printing;
 
 import megamek.common.annotations.Nullable;
-import megameklab.com.MegaMekLab;
 import org.apache.batik.util.SVGConstants;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.svg.SVGGElement;
@@ -244,15 +244,15 @@ class ArmorPipLayout {
                             && right <= bbox.right + PRECISION) {
                         return new Bounds(left, bbox.top, right, bbox.bottom);
                     } else {
-                        MegaMekLab.getLogger().error("Gap is not contained within bounding rectangle in "
+                        LogManager.getLogger().error("Gap is not contained within bounding rectangle in "
                                 + rect.getAttributeNS(null, SVGConstants.SVG_ID_ATTRIBUTE));
                     }
                 } else {
-                    MegaMekLab.getLogger().error("Incorrect number of parameters to " + IdConstants.MML_GAP
+                    LogManager.getLogger().error("Incorrect number of parameters to " + IdConstants.MML_GAP
                             + " in " + rect.getAttributeNS(null, SVGConstants.SVG_ID_ATTRIBUTE));
                 }
             } catch (NumberFormatException ex) {
-                MegaMekLab.getLogger().error("NumberFormatException parsing gap parameters in "
+                LogManager.getLogger().error("NumberFormatException parsing gap parameters in "
                         + rect.getAttributeNS(null, SVGConstants.SVG_ID_ATTRIBUTE));
             }
         }

--- a/src/megameklab/com/printing/PrintCapitalShip.java
+++ b/src/megameklab/com/printing/PrintCapitalShip.java
@@ -13,23 +13,24 @@
  */
 package megameklab.com.printing;
 
-import java.awt.geom.Rectangle2D;
-
-import megamek.common.*;
+import megamek.common.Jumpship;
+import megamek.common.SpaceStation;
+import megamek.common.UnitType;
+import megamek.common.Warship;
+import megameklab.com.util.ImageHelper;
 import org.apache.batik.util.SVGConstants;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Element;
 import org.w3c.dom.svg.SVGElement;
 import org.w3c.dom.svg.SVGRectElement;
 
-import megameklab.com.MegaMekLab;
-import megameklab.com.util.ImageHelper;
+import java.awt.geom.Rectangle2D;
 
 /**
- * Generates a record sheet image for jumpships, warships, and space stations.
+ * Generates a record sheet image for JumpShips, WarShips, and space stations.
  *
  * @author arlith
  * @author Neoancient
- *
  */
 public class PrintCapitalShip extends PrintDropship {
 
@@ -173,7 +174,7 @@ public class PrintCapitalShip extends PrintDropship {
             if (element instanceof SVGRectElement) {
                 printArmorRegion((SVGRectElement) element, ship.getOArmor(loc));
             } else {
-                MegaMekLab.getLogger().error("No SVGRectElement found with id " + id);
+                LogManager.getLogger().error("No SVGRectElement found with id " + id);
             }
         }
     }

--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -13,6 +13,20 @@
  */
 package megameklab.com.printing;
 
+import megamek.common.Entity;
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import megameklab.com.printing.reference.*;
+import megameklab.com.util.ImageHelper;
+import megameklab.com.util.UnitUtil;
+import org.apache.batik.anim.dom.SVGDOMImplementation;
+import org.apache.batik.dom.util.SAXDocumentFactory;
+import org.apache.batik.util.SVGConstants;
+import org.apache.batik.util.XMLResourceDescriptor;
+import org.apache.logging.log4j.LogManager;
+import org.w3c.dom.*;
+import org.w3c.dom.svg.SVGRectElement;
+
 import java.awt.geom.Rectangle2D;
 import java.awt.print.PageFormat;
 import java.io.File;
@@ -22,34 +36,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import megamek.common.*;
-import megameklab.com.printing.reference.*;
-import org.apache.batik.anim.dom.SVGDOMImplementation;
-import org.apache.batik.dom.util.SAXDocumentFactory;
-import org.apache.batik.util.SVGConstants;
-import org.apache.batik.util.XMLResourceDescriptor;
-import org.w3c.dom.DOMImplementation;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.svg.SVGRectElement;
-
-import megamek.common.annotations.Nullable;
-import megameklab.com.MegaMekLab;
-import megameklab.com.util.ImageHelper;
-import megameklab.com.util.UnitUtil;
-
 /**
- * Lays out a record sheet for a mech
+ * Lays out a record sheet for a Mek
  * 
  * @author Neoancient
- *
  */
 public class PrintMech extends PrintEntity {
 
     /**
-     * The current mech being printed.
+     * The current Mek being printed.
      */
     private final Mech mech;
     
@@ -165,7 +160,7 @@ public class PrintMech extends PrintEntity {
             if (si instanceof SVGRectElement) {
                 drawSIPips((SVGRectElement) si);
             } else {
-                MegaMekLab.getLogger().error("Region siPips does not exist in template or is not a <rect>");
+                LogManager.getLogger().error("Region siPips does not exist in template or is not a <rect>");
             }
         }
         
@@ -334,11 +329,11 @@ public class PrintMech extends PrintEntity {
             SAXDocumentFactory df = new SAXDocumentFactory(impl, parser);
             doc = df.createDocument(f.toURI().toASCIIString(), is);
         } catch (Exception e) {
-            MegaMekLab.getLogger().error("Failed to open pip SVG file! Path: " + f.getName());
+            LogManager.getLogger().error("Failed to open pip SVG file! Path: " + f.getName());
             return null;
         }
         if (null == doc) {
-            MegaMekLab.getLogger().error("Failed to open pip SVG file! Path: " + f.getName());
+            LogManager.getLogger().error("Failed to open pip SVG file! Path: " + f.getName());
             return null;
         }
         return doc.getElementsByTagName(SVGConstants.SVG_PATH_TAG);

--- a/src/megameklab/com/printing/PrintProtomech.java
+++ b/src/megameklab/com/printing/PrintProtomech.java
@@ -14,13 +14,13 @@
 package megameklab.com.printing;
 
 import megamek.common.*;
-import megameklab.com.MegaMekLab;
 import org.apache.batik.anim.dom.SVGLocatableSupport;
 import org.apache.batik.util.SVGConstants;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.Element;
 
 /**
- * Lays out a record sheet block for a single protomech
+ * Lays out a record sheet block for a single ProtoMek
  */
 public class PrintProtomech extends PrintEntity {
 
@@ -123,7 +123,7 @@ public class PrintProtomech extends PrintEntity {
                         }
                     }
                 } catch (NumberFormatException ex) {
-                    MegaMekLab.getLogger().warning("Could not parse fieldWidth: " + fieldWidth);
+                    LogManager.getLogger().warn("Could not parse fieldWidth: " + fieldWidth);
                 }
             }
         }

--- a/src/megameklab/com/printing/PrintRecordSheet.java
+++ b/src/megameklab/com/printing/PrintRecordSheet.java
@@ -15,12 +15,8 @@ package megameklab.com.printing;
 
 import megamek.common.EquipmentType;
 import megamek.common.annotations.Nullable;
-import megameklab.com.MegaMekLab;
 import megameklab.com.printing.reference.ReferenceTable;
 import megameklab.com.util.CConfig;
-import org.apache.fop.configuration.Configuration;
-import org.apache.fop.configuration.ConfigurationException;
-import org.apache.fop.configuration.DefaultConfigurationBuilder;
 import org.apache.batik.anim.dom.SVGDOMImplementation;
 import org.apache.batik.anim.dom.SVGLocatableSupport;
 import org.apache.batik.bridge.BridgeContext;
@@ -35,7 +31,11 @@ import org.apache.batik.transcoder.TranscoderInput;
 import org.apache.batik.transcoder.TranscoderOutput;
 import org.apache.batik.util.SVGConstants;
 import org.apache.batik.util.XMLResourceDescriptor;
+import org.apache.fop.configuration.Configuration;
+import org.apache.fop.configuration.ConfigurationException;
+import org.apache.fop.configuration.DefaultConfigurationBuilder;
 import org.apache.fop.svg.PDFTranscoder;
+import org.apache.logging.log4j.LogManager;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -55,7 +55,8 @@ import java.awt.print.Printable;
 import java.io.*;
 import java.net.URLConnection;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -235,10 +236,10 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
             SAXDocumentFactory df = new SAXDocumentFactory(impl, parser);
             svgDocument = df.createDocument(f.toURI().toASCIIString(), is);
         } catch (Exception e) {
-            MegaMekLab.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         if (null == svgDocument) {
-            MegaMekLab.getLogger().error("Failed to open SVG file! Path: data/images/recordsheets/" + filename);
+            LogManager.getLogger().error("Failed to open SVG file! Path: data/images/recordsheets/" + filename);
         }
         return svgDocument;
     }
@@ -360,7 +361,7 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
             // If an image can't be rendered we'll log it and return an empty document in its place
             // rather than throwing an exception.
             public SVGDocument getBrokenLinkDocument(Element e, String url, String message) {
-                MegaMekLab.getLogger().warning("Cannot render image: " + message);
+                LogManager.getLogger().warn("Cannot render image: " + message);
                 DOMImplementation impl = SVGDOMImplementation.getDOMImplementation();
                 SVGDocument doc = (SVGDocument) impl.createDocument(svgNS, SVGConstants.SVG_SVG_TAG, null);
                 Element text = doc.createElementNS(svgNS, SVGConstants.SVG_TEXT_TAG);
@@ -459,7 +460,7 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
                                     SVGConstants.SVG_SPACING_AND_GLYPHS_VALUE);
                         }
                     } catch (NumberFormatException ex) {
-                        MegaMekLab.getLogger().warning("Could not parse fieldWidth: " + fieldWidth);
+                        LogManager.getLogger().warn("Could not parse fieldWidth: " + fieldWidth);
                     }
                 }
             }
@@ -839,9 +840,9 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
                     "data:" + mimeType + ";base64," + Base64.getEncoder().encodeToString(bytes.toByteArray()));
             canvas.appendChild(img);
         } catch (FileNotFoundException e) {
-            MegaMekLab.getLogger().error("Fluff image file not found: " + imageFile.getPath());
+            LogManager.getLogger().error("Fluff image file not found: " + imageFile.getPath());
         } catch (IOException e) {
-            MegaMekLab.getLogger().error("Error reading fluff image file: " + imageFile.getPath());
+            LogManager.getLogger().error("Error reading fluff image file: " + imageFile.getPath());
         }
     }
 

--- a/src/megameklab/com/printing/RecordSheetTask.java
+++ b/src/megameklab/com/printing/RecordSheetTask.java
@@ -13,21 +13,23 @@
  */
 package megameklab.com.printing;
 
-import java.awt.print.*;
-import java.io.File;
-import java.util.*;
-import java.util.concurrent.ExecutionException;
-
-import javax.print.attribute.PrintRequestAttributeSet;
-import javax.swing.*;
-
 import megamek.common.util.EncodeControl;
-import megameklab.com.MegaMekLab;
+import org.apache.logging.log4j.LogManager;
 import org.apache.pdfbox.io.MemoryUsageSetting;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
 import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
+
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.swing.*;
+import java.awt.print.PageFormat;
+import java.awt.print.Pageable;
+import java.awt.print.Printable;
+import java.awt.print.PrinterJob;
+import java.io.File;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Renders one or more record sheets as a background task. The task is created using
@@ -103,7 +105,7 @@ public abstract class RecordSheetTask extends SwingWorker<Void, Integer> {
         try {
             get();
         } catch (ExecutionException e) {
-            MegaMekLab.getLogger().error(e.getCause());
+            LogManager.getLogger().error(e.getCause());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } finally {

--- a/src/megameklab/com/ui/Aero/MainUI.java
+++ b/src/megameklab/com/ui/Aero/MainUI.java
@@ -13,31 +13,20 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.ui.Aero;
 
-import java.awt.BorderLayout;
-
-import javax.swing.JPanel;
-import javax.swing.JTabbedPane;
-import javax.swing.SwingConstants;
-
-import megamek.common.Aero;
-import megamek.common.ConvFighter;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TechConstants;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.MegaMekLabMainUI;
+import megamek.common.*;
 import megameklab.com.ui.Aero.tabs.BuildTab;
 import megameklab.com.ui.Aero.tabs.EquipmentTab;
 import megameklab.com.ui.Aero.tabs.StructureTab;
+import megameklab.com.ui.MegaMekLabMainUI;
 import megameklab.com.ui.tabs.FluffTab;
 import megameklab.com.ui.tabs.PreviewTab;
 import megameklab.com.ui.util.TabScrollPane;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
 
 public class MainUI extends MegaMekLabMainUI {
 
@@ -98,7 +87,7 @@ public class MainUI extends MegaMekLabMainUI {
             setEntity(new ConvFighter());
             getEntity().setTechLevel(TechConstants.T_IS_TW_NON_BOX);
         } else {
-            MegaMekLab.getLogger().error("Received incorrect entityType!");
+            LogManager.getLogger().error("Received incorrect entityType!");
             return;
         }
 

--- a/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Aero/tabs/EquipmentTab.java
@@ -13,78 +13,29 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.ui.Aero.tabs;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.stream.Collectors;
+import megamek.common.*;
+import megamek.common.weapons.artillery.ArtilleryWeapon;
+import megamek.common.weapons.bayweapons.BayWeapon;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
 
-import javax.swing.AbstractAction;
-import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JSpinner;
-import javax.swing.JSplitPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.KeyStroke;
-import javax.swing.ListSelectionModel;
-import javax.swing.RowFilter;
-import javax.swing.RowSorter;
-import javax.swing.SortOrder;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
-
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.LocationFullException;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
-import megamek.common.weapons.artillery.ArtilleryWeapon;
-import megamek.common.weapons.bayweapons.BayWeapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.EquipmentTableModel;
-import megameklab.com.util.ITab;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.UnitUtil;
-import megameklab.com.util.XTableColumnModel;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 
 public class EquipmentTab extends ITab implements ActionListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 3978675469713289404L;
 
     private static final int T_ENERGY    =  0;
@@ -451,7 +402,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                 } catch (IndexOutOfBoundsException ignored) {
                     return;
                 } catch (Exception e) {
-                    MegaMekLab.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     return;
                 }
             } else {

--- a/src/megameklab/com/ui/Aero/views/BuildView.java
+++ b/src/megameklab/com/ui/Aero/views/BuildView.java
@@ -13,11 +13,20 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.ui.Aero.views;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
+import megamek.common.*;
+import megamek.common.verifier.TestAero;
+import megamek.common.weapons.Weapon;
+import megameklab.com.ui.Aero.tabs.BuildTab;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import javax.swing.table.TableColumn;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -26,44 +35,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Vector;
 
-import javax.swing.BorderFactory;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-import javax.swing.border.TitledBorder;
-import javax.swing.table.TableColumn;
-
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
-import megamek.common.verifier.TestAero;
-import megamek.common.weapons.Weapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.ui.Aero.tabs.BuildTab;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.CriticalTransferHandler;
-import megameklab.com.util.IView;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.StringUtils;
-import megameklab.com.util.UnitUtil;
-
 /**
  * This IView shows all the equipment that's not yet been assigned a location
  * @author beerockxs
  * @author arlith
- *
  */
 public class BuildView extends IView implements ActionListener, MouseListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 799195356642563937L;
 
     private CriticalTableModel equipmentList;
@@ -361,7 +338,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
         try {
             getAero().addEquipment(eq, location, false);
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
         UnitUtil.changeMountStatus(getAero(), eq, location, -1, false);
 

--- a/src/megameklab/com/ui/Aero/views/CriticalView.java
+++ b/src/megameklab/com/ui/Aero/views/CriticalView.java
@@ -12,26 +12,24 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
-
 package megameklab.com.ui.Aero.views;
 
 import megamek.common.*;
 import megamek.common.verifier.TestAero;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.util.CritCellUtil;
 import megameklab.com.util.IView;
 import megameklab.com.util.Mech.DropTargetCriticalList;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
 import java.util.Vector;
 
 /**
- * The Crit Slots view for a Fighter (Aerospacce and Conventional)
+ * The Crit Slots view for a Fighter (Aerospace and Conventional)
  *
  * Original author - jtighe (torren@users.sourceforge.net)
  * @author arlith
@@ -108,7 +106,7 @@ public class CriticalView extends IView {
 
         if (availSpace == null) {
             // Shouldn't happen, since we only allow valid armor types to be selected...
-            MegaMekLab.getLogger().error("Invalid armour type!");
+            LogManager.getLogger().error("Invalid armour type!");
             return;
         }
 

--- a/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/EquipmentTab.java
@@ -13,72 +13,28 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.ui.BattleArmor.tabs;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
+import megamek.common.*;
+import megamek.common.weapons.artillery.ArtilleryWeapon;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
 
-import javax.swing.AbstractAction;
-import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.KeyStroke;
-import javax.swing.ListSelectionModel;
-import javax.swing.RowFilter;
-import javax.swing.RowSorter;
-import javax.swing.SortOrder;
+import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
-
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.EquipmentType;
-import megamek.common.LocationFullException;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
-import megamek.common.weapons.artillery.ArtilleryWeapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.EquipmentTableModel;
-import megameklab.com.util.ITab;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.UnitUtil;
-import megameklab.com.util.XTableColumnModel;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 
 public class EquipmentTab extends ITab implements ActionListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 3978675469713289404L;
 
     private static final int T_ENERGY    =  0;
@@ -423,7 +379,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                 } catch (IndexOutOfBoundsException ignored) {
                     return;
                 } catch (Exception e) {
-                    MegaMekLab.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     return;
                 }
             } else {

--- a/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/BattleArmor/tabs/StructureTab.java
@@ -13,53 +13,32 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.ui.BattleArmor.tabs;
-
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTabbedPane;
-import javax.swing.SwingConstants;
 
 import megamek.client.ui.swing.MechViewPanel;
 import megamek.common.*;
 import megamek.common.templates.TROView;
-import megamek.common.verifier.TestEntity;
 import megamek.common.verifier.TestBattleArmor;
 import megamek.common.verifier.TestBattleArmor.BAManipulator;
-import megameklab.com.MegaMekLab;
+import megamek.common.verifier.TestEntity;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.util.CustomComboBox;
-import megameklab.com.ui.view.BAChassisView;
-import megameklab.com.ui.view.BAEnhancementView;
-import megameklab.com.ui.view.BAProtoArmorView;
-import megameklab.com.ui.view.BasicInfoView;
-import megameklab.com.ui.view.MovementView;
+import megameklab.com.ui.view.*;
 import megameklab.com.ui.view.listeners.ArmorAllocationListener;
 import megameklab.com.ui.view.listeners.BABuildListener;
 import megameklab.com.util.ITab;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class StructureTab extends ITab implements ActionListener, BABuildListener, ArmorAllocationListener {
-
-	/**
-	 *
-	 */
 	private static final long serialVersionUID = -7985608549543235815L;
 
     private RefreshListener refresh;
@@ -312,7 +291,7 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
                         }
                     } catch (LocationFullException ex) {
                         // This shouldn't happen
-                        MegaMekLab.getLogger().error(ex);
+                        LogManager.getLogger().error(ex);
                     }
                 }
             } else if (combo.equals(rightManipSelect)) {
@@ -362,7 +341,7 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
                         }
                     } catch (LocationFullException ex) {
                         // This shouldn't happen
-                        MegaMekLab.getLogger().error(ex);
+                        LogManager.getLogger().error(ex);
                     }
                 }
             }
@@ -393,7 +372,7 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
             mechView = new MechView(getBattleArmor(), false);
             troView = TROView.createView(getBattleArmor(), true);
         } catch (Exception e) {
-            MegaMekLab.getLogger().error(e);
+            LogManager.getLogger().error(e);
             // error unit didn't load right. this is bad news.
             populateTextFields = false;
         }
@@ -651,7 +630,7 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
                 }
             } catch (LocationFullException e) {
                 // Shouldn't happen with BA
-                MegaMekLab.getLogger().error(e);
+                LogManager.getLogger().error(e);
             }
         } else {
             List<Mounted> mounts = getBattleArmor().getMisc().stream()
@@ -690,7 +669,7 @@ public class StructureTab extends ITab implements ActionListener, BABuildListene
                 getBattleArmor().addEquipment(new Mounted(getBattleArmor(), armor),
                         BattleArmor.LOC_SQUAD, false);
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         }
         refresh.refreshBuild();

--- a/src/megameklab/com/ui/BattleArmor/views/BuildView.java
+++ b/src/megameklab/com/ui/BattleArmor/views/BuildView.java
@@ -13,9 +13,20 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.ui.BattleArmor.views;
 
+import megamek.common.*;
+import megamek.common.verifier.TestBattleArmor;
+import megamek.common.weapons.Weapon;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import megameklab.com.ui.BattleArmor.tabs.BuildTab;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import javax.swing.table.TableColumn;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -24,55 +35,20 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Vector;
 
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.JMenuItem;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-import javax.swing.border.TitledBorder;
-import javax.swing.table.TableColumn;
-
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.EquipmentType;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
-import megamek.common.verifier.TestBattleArmor;
-import megamek.common.weapons.Weapon;
-import megamek.common.weapons.infantry.InfantryWeapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.ui.BattleArmor.tabs.BuildTab;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.CriticalTransferHandler;
-import megameklab.com.util.IView;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.StringUtils;
-import megameklab.com.util.UnitUtil;
-
 /**
- * A component that display a table listing all of the unallocated equipment
+ * A component that display a table listing all the unallocated equipment
  * for the squad and allows dragging of the equipment to criticals to mount it.
  * 
  * @author Taharqa
  * @author arlith
- *
  */
 public class BuildView extends IView implements ActionListener, MouseListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 799195356642563937L;
 
     private JPanel mainPanel = new JPanel();
 
     private CriticalTableModel equipmentList;
-    private Vector<Mounted> masterEquipmentList = new Vector<Mounted>(10, 1);
+    private Vector<Mounted> masterEquipmentList = new Vector<>(10, 1);
     private JTable equipmentTable = new JTable();
     private JScrollPane equipmentScroll = new JScrollPane();
 
@@ -620,7 +596,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
         try {
             eq.setBaMountLoc(location);
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
         
         UnitUtil.changeMountStatus(getBattleArmor(), eq, BattleArmor.LOC_SQUAD, -1, false);

--- a/src/megameklab/com/ui/Mek/tabs/BuildTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/BuildTab.java
@@ -15,31 +15,23 @@
  */
 package megameklab.com.ui.Mek.tabs;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JPanel;
-
 import megamek.common.Entity;
 import megamek.common.Mech;
 import megamek.common.Mounted;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.Mek.views.BuildView;
 import megameklab.com.ui.Mek.views.CriticalView;
 import megameklab.com.util.ITab;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 public class BuildTab extends ITab implements ActionListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -6756011847500605874L;
 
     private RefreshListener refresh = null;
@@ -143,7 +135,7 @@ public class BuildTab extends ITab implements ActionListener {
                     UnitUtil.changeMountStatus(getMech(), mount, location, Entity.LOC_NONE, false);
                     break;
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             }
         }

--- a/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/EquipmentTab.java
@@ -13,75 +13,28 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.ui.Mek.tabs;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
+import megamek.common.*;
+import megamek.common.weapons.artillery.ArtilleryWeapon;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
 
-import javax.swing.AbstractAction;
-import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.KeyStroke;
-import javax.swing.ListSelectionModel;
-import javax.swing.RowFilter;
-import javax.swing.RowSorter;
-import javax.swing.SortOrder;
+import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
-
-import megamek.MegaMek;
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.LocationFullException;
-import megamek.common.Mech;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.QuadVee;
-import megamek.common.WeaponType;
-import megamek.common.weapons.artillery.ArtilleryWeapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.EquipmentTableModel;
-import megameklab.com.util.ITab;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.UnitUtil;
-import megameklab.com.util.XTableColumnModel;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 
 public class EquipmentTab extends ITab implements ActionListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 3978675469713289404L;
 
     private static final int T_ENERGY    =  0;
@@ -418,7 +371,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                 } catch (IndexOutOfBoundsException ignored) {
                     return;
                 } catch (Exception e) {
-                    MegaMekLab.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     return;
                 }
             } else {

--- a/src/megameklab/com/ui/Mek/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Mek/tabs/StructureTab.java
@@ -13,50 +13,29 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.ui.Mek.tabs;
-
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.SwingConstants;
 
 import megamek.common.*;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.verifier.TestEntity;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.Mek.views.SummaryView;
-import megameklab.com.ui.view.ArmorAllocationView;
-import megameklab.com.ui.view.BasicInfoView;
-import megameklab.com.ui.view.HeatSinkView;
-import megameklab.com.ui.view.MVFArmorView;
-import megameklab.com.ui.view.MekChassisView;
-import megameklab.com.ui.view.MovementView;
-import megameklab.com.ui.view.PatchworkArmorView;
+import megameklab.com.ui.view.*;
 import megameklab.com.ui.view.listeners.ArmorAllocationListener;
 import megameklab.com.ui.view.listeners.MekBuildListener;
 import megameklab.com.util.ITab;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class StructureTab extends ITab implements MekBuildListener, ArmorAllocationListener {
-    /**
-     *
-     */
     private static final long serialVersionUID = -6756011847500605874L;
 
     private BasicInfoView panBasicInfo;
@@ -392,7 +371,7 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
         } catch (EntityLoadingException ele) {
             // do nothing.
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         if ((crit != null) && (crit.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
@@ -477,7 +456,7 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
                         new Mounted(getMech(), structure),
                         Entity.LOC_NONE, false);
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         }
     }
@@ -967,7 +946,7 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
                 // Since we're not changing the total count, there should always be enough prototype
                 // doubles to switch over.
                 if (i >= doubles.size()) {
-                    MegaMekLab.getLogger().warning("Not enough prototype double heat sinks to switch to single");
+                    LogManager.getLogger().warn("Not enough prototype double heat sinks to switch to single");
                 }
                 UnitUtil.removeMounted(getMech(), doubles.get(i));
             }
@@ -981,7 +960,7 @@ public class StructureTab extends ITab implements MekBuildListener, ArmorAllocat
                     .collect(Collectors.toList());
             for (int i = 0; i < netChange; i++) {
                 if (i >= singles.size()) {
-                    MegaMekLab.getLogger().warning("Not enough single heat sinks to switch to prototype double");
+                    LogManager.getLogger().warn("Not enough single heat sinks to switch to prototype double");
                 }
                 UnitUtil.removeMounted(getMech(), singles.get(i));
             }

--- a/src/megameklab/com/ui/Mek/views/BuildView.java
+++ b/src/megameklab/com/ui/Mek/views/BuildView.java
@@ -13,11 +13,19 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.ui.Mek.views;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
+import megamek.common.*;
+import megamek.common.weapons.Weapon;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.ui.Mek.tabs.BuildTab;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.border.TitledBorder;
+import javax.swing.table.TableColumn;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -25,49 +33,15 @@ import java.awt.event.MouseListener;
 import java.util.Collections;
 import java.util.Vector;
 
-import javax.swing.BorderFactory;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-import javax.swing.border.TitledBorder;
-import javax.swing.table.TableColumn;
-
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.LandAirMech;
-import megamek.common.Mech;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
-import megamek.common.weapons.Weapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.ui.Mek.tabs.BuildTab;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.CriticalTransferHandler;
-import megameklab.com.util.IView;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.StringUtils;
-import megameklab.com.util.UnitUtil;
-
 /**
  * This IView shows all the equipment that's not yet been assigned a location
  * @author beerockxs
- *
  */
 public class BuildView extends IView implements ActionListener, MouseListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 799195356642563937L;
 
     private CriticalTableModel equipmentList;
-    private Vector<Mounted> masterEquipmentList = new Vector<Mounted>(10, 1);
+    private Vector<Mounted> masterEquipmentList = new Vector<>(10, 1);
     private JTable equipmentTable = new JTable();
     private JScrollPane equipmentScroll = new JScrollPane();
     private int engineHeatSinkCount = 0;
@@ -410,7 +384,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
             try {
                 UnitUtil.addMounted(getMech(), eq, location, false);
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         }
 
@@ -419,7 +393,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
             try {
                 UnitUtil.addMounted(getMech(), eq, secondaryLocation, false);
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         }
 
@@ -492,7 +466,7 @@ public class BuildView extends IView implements ActionListener, MouseListener {
                 UnitUtil.addMounted(getMech(), eq, location, false);
             }
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
         UnitUtil.changeMountStatus(getMech(), eq, location, -1, false);
 

--- a/src/megameklab/com/ui/StartupGUI.java
+++ b/src/megameklab/com/ui/StartupGUI.java
@@ -13,45 +13,11 @@
  */
 package megameklab.com.ui;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.DisplayMode;
-import java.awt.FontMetrics;
-import java.awt.Graphics;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Image;
-import java.awt.Insets;
-import java.awt.MediaTracker;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.util.ResourceBundle;
-import java.util.TreeMap;
-
-import javax.swing.ImageIcon;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.UIManager;
-
-import megamek.MegaMek;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.widget.MegamekButton;
 import megamek.client.ui.swing.widget.SkinSpecification;
 import megamek.client.ui.swing.widget.SkinXMLHandler;
-import megamek.common.Aero;
-import megamek.common.BattleArmor;
-import megamek.common.Configuration;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.FixedWingSupport;
-import megamek.common.GunEmplacement;
-import megamek.common.Infantry;
-import megamek.common.Mech;
-import megamek.common.Protomech;
-import megamek.common.Tank;
+import megamek.common.*;
 import megamek.common.util.EncodeControl;
 import megamek.common.util.ImageUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
@@ -60,14 +26,22 @@ import megameklab.com.MegaMekLab;
 import megameklab.com.ui.dialog.LoadingDialog;
 import megameklab.com.ui.dialog.MegaMekLabUnitSelectorDialog;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.ResourceBundle;
+import java.util.TreeMap;
 
 /**
  * A startup splash screen for MegaMekLab
  * @author Taharqa
  */
 public class StartupGUI extends javax.swing.JPanel {
-
-    
     private static final long serialVersionUID = 8376874926997734492L;
     JFrame frame;
     Image imgSplash;
@@ -114,7 +88,7 @@ public class StartupGUI extends javax.swing.JPanel {
                 File file = new MegaMekFile(Configuration.widgetsDir(),
                         skinSpec.backgrounds.get(1)).getFile();
                 if (!file.exists()) {
-                    MegaMek.getLogger().error("Background icon doesn't exist: " + file.getAbsolutePath());
+                    LogManager.getLogger().error("Background icon doesn't exist: " + file.getAbsolutePath());
                 } else {
                     backgroundIcon = (BufferedImage) ImageUtil.loadImageFromFile(file.toString());
                 }

--- a/src/megameklab/com/ui/Vehicle/tabs/BuildTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/BuildTab.java
@@ -15,34 +15,25 @@
  */
 package megameklab.com.ui.Vehicle.tabs;
 
-import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.SwingConstants;
-
 import megamek.common.Entity;
 import megamek.common.MechFileParser;
 import megamek.common.Mounted;
 import megamek.common.loaders.EntityLoadingException;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
-import megameklab.com.ui.view.UnallocatedView;
 import megameklab.com.ui.Vehicle.views.CriticalView;
+import megameklab.com.ui.view.UnallocatedView;
 import megameklab.com.util.CriticalTableModel;
 import megameklab.com.util.ITab;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 public class BuildTab extends ITab implements ActionListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -6756011847500605874L;
 
     private RefreshListener refresh = null;
@@ -119,7 +110,7 @@ public class BuildTab extends ITab implements ActionListener {
                     UnitUtil.changeMountStatus(getTank(), mount, location, Entity.LOC_NONE, false);
                     break;
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             }
         }
@@ -142,7 +133,7 @@ public class BuildTab extends ITab implements ActionListener {
         } catch (EntityLoadingException ele) {
             // do nothing.
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         refresh.refreshAll();

--- a/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/EquipmentTab.java
@@ -13,75 +13,29 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.ui.Vehicle.tabs;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
+import megamek.common.*;
+import megamek.common.verifier.TestTank;
+import megamek.common.weapons.artillery.ArtilleryWeapon;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
 
-import javax.swing.AbstractAction;
-import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.KeyStroke;
-import javax.swing.ListSelectionModel;
-import javax.swing.RowFilter;
-import javax.swing.RowSorter;
-import javax.swing.SortOrder;
+import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
-
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.LocationFullException;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.Tank;
-import megamek.common.VTOL;
-import megamek.common.WeaponType;
-import megamek.common.verifier.TestTank;
-import megamek.common.weapons.artillery.ArtilleryWeapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.EquipmentTableModel;
-import megameklab.com.util.ITab;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.UnitUtil;
-import megameklab.com.util.XTableColumnModel;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 
 public class EquipmentTab extends ITab implements ActionListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 3978675469713289404L;
 
     private static final int T_ENERGY    =  0;
@@ -409,7 +363,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                 } catch (IndexOutOfBoundsException ignored) {
                     return;
                 } catch (Exception e) {
-                    MegaMekLab.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     return;
                 }
             } else {

--- a/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
+++ b/src/megameklab/com/ui/Vehicle/tabs/StructureTab.java
@@ -13,55 +13,26 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.ui.Vehicle.tabs;
 
-import java.awt.BorderLayout;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-
-import megamek.common.Bay;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.LocationFullException;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.SimpleTechLevel;
-import megamek.common.SuperHeavyTank;
-import megamek.common.Tank;
-import megamek.common.TechConstants;
-import megamek.common.Transporter;
-import megamek.common.TroopSpace;
-import megamek.common.VTOL;
-import megamek.common.verifier.TestEntity;
+import megamek.common.*;
 import megamek.common.verifier.BayData;
+import megamek.common.verifier.TestEntity;
 import megamek.common.verifier.TestTank;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.Vehicle.views.SummaryView;
-import megameklab.com.ui.view.ArmorAllocationView;
-import megameklab.com.ui.view.BasicInfoView;
-import megameklab.com.ui.view.CVChassisView;
-import megameklab.com.ui.view.CVTransportView;
-import megameklab.com.ui.view.MVFArmorView;
-import megameklab.com.ui.view.MovementView;
-import megameklab.com.ui.view.PatchworkArmorView;
+import megameklab.com.ui.view.*;
 import megameklab.com.ui.view.listeners.ArmorAllocationListener;
 import megameklab.com.ui.view.listeners.CVBuildListener;
 import megameklab.com.util.ITab;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class StructureTab extends ITab implements CVBuildListener, ArmorAllocationListener {
 
@@ -393,7 +364,7 @@ public class StructureTab extends ITab implements CVBuildListener, ArmorAllocati
                 try {
                     getTank().addEquipment(jumpJet, Tank.LOC_BODY);
                 } catch (LocationFullException e) {
-                    MegaMekLab.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             }
             panSummary.refresh();

--- a/src/megameklab/com/ui/Vehicle/views/EquipmentView.java
+++ b/src/megameklab/com/ui/Vehicle/views/EquipmentView.java
@@ -13,45 +13,25 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.ui.Vehicle.views;
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Dimension;
+import megamek.common.Entity;
+import megamek.common.EquipmentType;
+import megamek.common.MiscType;
+import megamek.common.Mounted;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Vector;
 
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.EquipmentListCellKeySelectionManager;
-import megameklab.com.util.EquipmentListCellRenderer;
-import megameklab.com.util.IView;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.StringUtils;
-import megameklab.com.util.UnitUtil;
-
 public class EquipmentView extends IView implements ActionListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 799195356642563937L;
 
     private RefreshListener refresh;
@@ -177,7 +157,7 @@ public class EquipmentView extends IView implements ActionListener {
                 } catch (ArrayIndexOutOfBoundsException aioobe) {
                     return;
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             } else {
                 location++;
@@ -234,7 +214,7 @@ public class EquipmentView extends IView implements ActionListener {
                 try {
                     mount = getTank().addEquipment(equip, Entity.LOC_NONE, false);
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             }
             equipmentList.addCrit(mount);

--- a/src/megameklab/com/ui/Vehicle/views/WeaponView.java
+++ b/src/megameklab/com/ui/Vehicle/views/WeaponView.java
@@ -13,60 +13,21 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.ui.Vehicle.views;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Vector;
-
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTabbedPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-import javax.swing.ScrollPaneConstants;
-import javax.swing.SpringLayout;
-import javax.swing.SwingConstants;
-import javax.swing.UIManager;
-
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.IView;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.SpringLayoutHelper;
-import megameklab.com.util.StringUtils;
-import megameklab.com.util.UnitUtil;
-import megameklab.com.util.WeaponListCellRenderer;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.List;
+import java.util.*;
 
 public class WeaponView extends IView implements ActionListener, MouseListener, KeyListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 799195356642563937L;
     private RefreshListener refresh;
 
@@ -489,7 +450,7 @@ public class WeaponView extends IView implements ActionListener, MouseListener, 
                     }
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         } else if (e.getActionCommand().equals(LASERAMMOADD_COMMAND) && (subLaserAmmoList.size() > 0)) {
             try {
@@ -500,7 +461,7 @@ public class WeaponView extends IView implements ActionListener, MouseListener, 
                     }
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         } else if (e.getActionCommand().equals(MISSILEWEAPONADD_COMMAND)) {
             try {
@@ -518,7 +479,7 @@ public class WeaponView extends IView implements ActionListener, MouseListener, 
                     }
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         } else if (e.getActionCommand().equals(MISSILEAMMOADD_COMMAND)) {
             try {
@@ -529,7 +490,7 @@ public class WeaponView extends IView implements ActionListener, MouseListener, 
                     }
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         } else if (e.getActionCommand().equals(BALLISTICWEAPONADD_COMMAND)) {
             try {
@@ -546,7 +507,7 @@ public class WeaponView extends IView implements ActionListener, MouseListener, 
                     }
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         } else if (e.getActionCommand().equals(BALLISTICAMMOADD_COMMAND)) {
             try {
@@ -557,7 +518,7 @@ public class WeaponView extends IView implements ActionListener, MouseListener, 
                     }
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         } else if (e.getActionCommand().equals(ARTILLERYWEAPONADD_COMMAND)) {
             try {
@@ -568,7 +529,7 @@ public class WeaponView extends IView implements ActionListener, MouseListener, 
                     }
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         } else if (e.getActionCommand().equals(ARTILLERYAMMOADD_COMMAND)) {
             try {
@@ -579,7 +540,7 @@ public class WeaponView extends IView implements ActionListener, MouseListener, 
                     }
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         } else if (e.getActionCommand().equals(REMOVE_COMMAND)) {
 

--- a/src/megameklab/com/ui/aerospace/AdvancedAeroUI.java
+++ b/src/megameklab/com/ui/aerospace/AdvancedAeroUI.java
@@ -13,34 +13,21 @@
  */
 package megameklab.com.ui.aerospace;
 
-import java.awt.BorderLayout;
-
-import javax.swing.JPanel;
-import javax.swing.JTabbedPane;
-import javax.swing.SwingConstants;
-
-import megamek.common.Aero;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.IArmorState;
-import megamek.common.ITechManager;
-import megamek.common.Jumpship;
-import megamek.common.MechSummaryCache;
-import megamek.common.SimpleTechLevel;
-import megamek.common.SpaceStation;
-import megamek.common.TechConstants;
-import megamek.common.Warship;
+import megamek.common.*;
 import megamek.common.verifier.TestAdvancedAerospace;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.MegaMekLabMainUI;
 import megameklab.com.ui.Aero.tabs.EquipmentTab;
-import megameklab.com.ui.tabs.PreviewTab;
+import megameklab.com.ui.MegaMekLabMainUI;
 import megameklab.com.ui.tabs.FluffTab;
+import megameklab.com.ui.tabs.PreviewTab;
 import megameklab.com.ui.tabs.TransportTab;
 import megameklab.com.ui.util.TabScrollPane;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
 
 /**
- * MainUI for Jumpships, Warship, and Space Stations
+ * MainUI for JumpShips, WarShips, and Space Stations
  * 
  * @author Neoancient
  */
@@ -96,7 +83,7 @@ public class AdvancedAeroUI extends MegaMekLabMainUI {
         } else if (entitytype == Entity.ETYPE_SPACE_STATION) {
             setEntity(new SpaceStation());
         } else {
-            MegaMekLab.getLogger().error("Received incorrect entityType!");
+            LogManager.getLogger().error("Received incorrect entityType!");
             return;
         }
         getEntity().setTechLevel(TechConstants.T_IS_ADVANCED);

--- a/src/megameklab/com/ui/aerospace/DropshipMainUI.java
+++ b/src/megameklab/com/ui/aerospace/DropshipMainUI.java
@@ -13,35 +13,22 @@
  */
 package megameklab.com.ui.aerospace;
 
-import java.awt.BorderLayout;
-
-import javax.swing.JTabbedPane;
-import javax.swing.SwingConstants;
-
-import megamek.common.Aero;
-import megamek.common.Dropship;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EquipmentType;
-import megamek.common.IArmorState;
-import megamek.common.ITechManager;
-import megamek.common.MechSummaryCache;
-import megamek.common.SimpleTechLevel;
-import megamek.common.SmallCraft;
-import megamek.common.TechConstants;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.MegaMekLabMainUI;
+import megamek.common.*;
 import megameklab.com.ui.Aero.tabs.EquipmentTab;
-import megameklab.com.ui.tabs.PreviewTab;
+import megameklab.com.ui.MegaMekLabMainUI;
 import megameklab.com.ui.tabs.FluffTab;
+import megameklab.com.ui.tabs.PreviewTab;
 import megameklab.com.ui.tabs.TransportTab;
 import megameklab.com.ui.util.TabScrollPane;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
 
 /**
- * Main UI for Dropships and Small Craft
+ * Main UI for DropShips and Small Craft
  * 
  * @author Neoancient
- *
  */
 public class DropshipMainUI extends MegaMekLabMainUI {
 
@@ -85,7 +72,7 @@ public class DropshipMainUI extends MegaMekLabMainUI {
             setEntity(new Dropship());
             getEntity().setTechLevel(TechConstants.T_IS_TW_NON_BOX);
         } else {
-            MegaMekLab.getLogger().error("Received incorrect entityType!");
+            LogManager.getLogger().error("Received incorrect entityType!");
             return;
         }
 

--- a/src/megameklab/com/ui/dialog/LoadingDialog.java
+++ b/src/megameklab/com/ui/dialog/LoadingDialog.java
@@ -13,32 +13,22 @@
  */
 package megameklab.com.ui.dialog;
 
-import java.awt.BorderLayout;
-import java.awt.Image;
-import java.awt.MediaTracker;
-import java.util.TreeMap;
-import java.util.concurrent.ExecutionException;
-
-import javax.swing.ImageIcon;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.SwingWorker;
-
 import megamek.common.Entity;
 import megameklab.com.MegaMekLab;
 import megameklab.com.ui.MegaMekLabMainUI;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
 
 /**
  * A loading dialog to display until the mainUI has loaded.
  * @author Taharqa
  */
 public class LoadingDialog extends JDialog {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -3454307876761238915L;
     
     Task task;
@@ -146,7 +136,7 @@ public class LoadingDialog extends JDialog {
             try {
                 get();
             } catch (ExecutionException ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             } catch (InterruptedException ex) {
                 interrupted = true;
             } finally {

--- a/src/megameklab/com/ui/dialog/UnitPrintQueueDialog.java
+++ b/src/megameklab/com/ui/dialog/UnitPrintQueueDialog.java
@@ -13,10 +13,17 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.ui.dialog;
 
-import java.awt.Dimension;
+import megamek.client.ui.swing.UnitLoadingDialog;
+import megamek.common.Entity;
+import megamek.common.MechFileParser;
+import megameklab.com.util.UnitPrintManager;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
@@ -26,34 +33,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JDialog;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.ScrollPaneConstants;
-import javax.swing.WindowConstants;
-import javax.swing.filechooser.FileNameExtensionFilter;
-
-import megamek.client.ui.swing.UnitLoadingDialog;
-import megamek.common.Entity;
-import megamek.common.MechFileParser;
-import megameklab.com.MegaMekLab;
-import megameklab.com.util.UnitPrintManager;
-
-/*
+/**
  * Allows a user to Select Multiple units to print
  */
 public class UnitPrintQueueDialog extends JDialog implements ActionListener, KeyListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 4812586858732825464L;
 
     JList<String> unitList = new JList<>();
@@ -199,7 +182,7 @@ public class UnitPrintQueueDialog extends JDialog implements ActionListener, Key
                     Entity tempEntity = new MechFileParser(entityFile).getEntity();
                     units.add(tempEntity);
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             }
             refresh();

--- a/src/megameklab/com/ui/supportvehicle/SVBuildTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVBuildTab.java
@@ -22,11 +22,14 @@ import megamek.common.Entity;
 import megamek.common.MechFileParser;
 import megamek.common.Mounted;
 import megamek.common.loaders.EntityLoadingException;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.tabs.EquipmentTab;
 import megameklab.com.ui.view.UnallocatedView;
-import megameklab.com.util.*;
+import megameklab.com.util.CriticalTableModel;
+import megameklab.com.util.ITab;
+import megameklab.com.util.RefreshListener;
+import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -112,7 +115,7 @@ public class SVBuildTab extends ITab implements ActionListener {
                     UnitUtil.changeMountStatus(getTank(), mount, location, Entity.LOC_NONE, false);
                     break;
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             }
         }
@@ -135,7 +138,7 @@ public class SVBuildTab extends ITab implements ActionListener {
         } catch (EntityLoadingException ele) {
             // do nothing.
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         refresh.refreshAll();

--- a/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
+++ b/src/megameklab/com/ui/supportvehicle/SVStructureTab.java
@@ -21,13 +21,13 @@ package megameklab.com.ui.supportvehicle;
 import megamek.common.*;
 import megamek.common.verifier.TestEntity;
 import megamek.common.verifier.TestSupportVehicle;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.view.*;
 import megameklab.com.ui.view.listeners.SVBuildListener;
 import megameklab.com.util.ITab;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -272,7 +272,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
                 try {
                     getSV().addEquipment(jumpJet, Tank.LOC_BODY);
                 } catch (LocationFullException e) {
-                    MegaMekLab.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                 }
             }
             panSummary.refresh();
@@ -425,7 +425,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
                 getSV().addEquipment(mod, getSV().isAero() ? FixedWingSupport.LOC_BODY : Tank.LOC_BODY);
             } catch (LocationFullException e) {
                 // This should not be possible since chassis mods don't occupy slots
-                MegaMekLab.getLogger().error("LocationFullException when adding chassis mod " + mod.getName());
+                LogManager.getLogger().error("LocationFullException when adding chassis mod " + mod.getName());
             }
         } else if (!installed && (null != current)) {
             getSV().getMisc().remove(current);
@@ -513,7 +513,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
                 getSV().addEquipment(EquipmentType.get(EquipmentTypeLookup.SPONSON_TURRET), Tank.LOC_RIGHT);
             } catch (LocationFullException e) {
                 // This should not be possible since sponson turrets mods don't occupy slots
-                MegaMekLab.getLogger().error("LocationFullException when adding sponson turret");
+                LogManager.getLogger().error("LocationFullException when adding sponson turret");
             }
         } else if (!installed) {
             for (Mounted m : getEntity().getEquipment()) {
@@ -544,7 +544,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
                 getSV().addEquipment(EquipmentType.get(EquipmentTypeLookup.PINTLE_TURRET), loc);
             } catch (LocationFullException e) {
                 // This should not be possible since sponson turrets mods don't occupy slots
-                MegaMekLab.getLogger().error("LocationFullException when adding sponson turret");
+                LogManager.getLogger().error("LocationFullException when adding sponson turret");
             }
         } else if (!installed && (null != current)) {
             for (Mounted m : getEntity().getEquipment()) {
@@ -622,7 +622,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
                 getSV().addEquipment(eq, getSV().isAero() ? FixedWingSupport.LOC_BODY : Tank.LOC_BODY);
             } catch (LocationFullException e) {
                 // This should not be possible since fire control doesn't occupy slots
-                MegaMekLab.getLogger().error("LocationFullException when adding fire control " + eq.getName());
+                LogManager.getLogger().error("LocationFullException when adding fire control " + eq.getName());
             }
         }
         panChassis.setFromEntity(getSV());

--- a/src/megameklab/com/ui/tabs/EquipmentTab.java
+++ b/src/megameklab/com/ui/tabs/EquipmentTab.java
@@ -13,72 +13,31 @@
  */
 package megameklab.com.ui.tabs;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
+import megamek.common.*;
+import megamek.common.verifier.TestEntity;
+import megamek.common.weapons.tag.TAGWeapon;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+import java.awt.*;
+import java.awt.event.*;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import javax.swing.AbstractAction;
-import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
-import javax.swing.DefaultComboBoxModel;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
-import javax.swing.JSpinner;
-import javax.swing.JSplitPane;
-import javax.swing.JTable;
-import javax.swing.JTextField;
-import javax.swing.KeyStroke;
-import javax.swing.ListCellRenderer;
-import javax.swing.ListSelectionModel;
-import javax.swing.RowFilter;
-import javax.swing.RowSorter;
-import javax.swing.SortOrder;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import javax.swing.event.ListSelectionListener;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-
-import megamek.common.*;
-import megamek.common.verifier.TestEntity;
-import megamek.common.weapons.tag.TAGWeapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.EquipmentTableModel;
-import megameklab.com.util.ITab;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.UnitUtil;
-import megameklab.com.util.XTableColumnModel;
-
 /**
  * General purpose equipment tab
  * 
  * @author Neoancient
- *
  */
 public class EquipmentTab extends ITab implements ActionListener {
     
@@ -487,7 +446,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                 } catch (IndexOutOfBoundsException ignored) {
                     return;
                 } catch (Exception e) {
-                    MegaMekLab.getLogger().error(e);
+                    LogManager.getLogger().error(e);
                     return;
                 }
             } else {
@@ -578,7 +537,7 @@ public class EquipmentTab extends ITab implements ActionListener {
                 }
             }
         } catch (LocationFullException ex) {
-            MegaMekLab.getLogger().error("Location full while trying to add " + equip.getName());
+            LogManager.getLogger().error("Location full while trying to add " + equip.getName());
             JOptionPane.showMessageDialog(
                     this,"Could not add " + equip.getName(),
                     "Location Full", JOptionPane.ERROR_MESSAGE);

--- a/src/megameklab/com/ui/tabs/PreviewTab.java
+++ b/src/megameklab/com/ui/tabs/PreviewTab.java
@@ -13,27 +13,20 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.ui.tabs;
-
-import java.awt.BorderLayout;
-
-import javax.swing.JTabbedPane;
-import javax.swing.UIManager;
 
 import megamek.client.ui.swing.MechViewPanel;
 import megamek.common.Entity;
 import megamek.common.MechView;
 import megamek.common.templates.TROView;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.ITab;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.*;
 
 public class PreviewTab extends ITab {
-
-	/**
-	 * 
-	 */
 	private static final long serialVersionUID = -7410436201331568734L;
 
     private MechViewPanel panelMekView;
@@ -67,7 +60,7 @@ public class PreviewTab extends ITab {
             mechView = new MechView(selectedUnit, false);
             troView = TROView.createView(selectedUnit, true);
         } catch (Exception e) {
-            MegaMekLab.getLogger().error(e);
+            LogManager.getLogger().error(e);
             // error unit didn't load right. this is bad news.
             populateTextFields = false;
         }

--- a/src/megameklab/com/ui/tabs/TransportTab.java
+++ b/src/megameklab/com/ui/tabs/TransportTab.java
@@ -13,53 +13,36 @@
  */
 package megameklab.com.ui.tabs;
 
-import java.awt.*;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.StringSelection;
-import java.awt.datatransfer.Transferable;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.*;
-import java.util.List;
-import java.util.stream.Collectors;
+import megamek.common.*;
+import megamek.common.util.EncodeControl;
+import megamek.common.verifier.*;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.IView;
+import megameklab.com.util.RefreshListener;
+import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
 
-import javax.swing.AbstractCellEditor;
-import javax.swing.DefaultCellEditor;
-import javax.swing.DefaultListCellRenderer;
-import javax.swing.DropMode;
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JList;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSpinner;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.TransferHandler;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableCellEditor;
 import javax.swing.table.TableColumn;
-
-import megamek.common.*;
-import megamek.common.util.EncodeControl;
-import megamek.common.verifier.*;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.IView;
-import megameklab.com.util.RefreshListener;
-import megameklab.com.util.UnitUtil;
+import java.awt.*;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Tab for adding and modifying aerospace and support vee transport bays.
  * 
  * @author Neoancient
- *
  */
 public class TransportTab extends IView implements ActionListener, ChangeListener {
     
@@ -933,7 +916,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                   return true;
                }
             } catch (Exception e) {
-               MegaMekLab.getLogger().error(e);
+               LogManager.getLogger().error(e);
             }
             return false;
         }

--- a/src/megameklab/com/ui/util/AeroBayTransferHandler.java
+++ b/src/megameklab/com/ui/util/AeroBayTransferHandler.java
@@ -13,6 +13,14 @@
  */
 package megameklab.com.ui.util;
 
+import megamek.common.*;
+import megamek.common.weapons.bayweapons.BayWeapon;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.CriticalTableModel;
+import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
@@ -23,22 +31,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 
-import javax.swing.JComponent;
-import javax.swing.JTable;
-import javax.swing.JTree;
-import javax.swing.TransferHandler;
-
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.LocationFullException;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
-import megamek.common.weapons.bayweapons.BayWeapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.CriticalTableModel;
-import megameklab.com.util.UnitUtil;
-
 /**
  * Handles drag-and-drop for aerospace units that use weapon bays. Most of the work of adding, removing,
  * and changing equipment locations is done by the JTree for the weapon arc.
@@ -46,10 +38,6 @@ import megameklab.com.util.UnitUtil;
  * @author Neoancient
  */
 public class AeroBayTransferHandler extends TransferHandler {
-    
-    /**
-     * 
-     */
     private static final long serialVersionUID = 2534394664060762469L;
     
     private EntitySource eSource;
@@ -87,7 +75,7 @@ public class AeroBayTransferHandler extends TransferHandler {
                 }
             }
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return false;
         }
         if (eqList.isEmpty()) {
@@ -139,7 +127,7 @@ public class AeroBayTransferHandler extends TransferHandler {
                                 m.setShotsLeft(mount.getUsableShotsLeft());
                             }
                         } catch (LocationFullException e) {
-                            MegaMekLab.getLogger().error(e);
+                            LogManager.getLogger().error(e);
                         }
                     }
                 } else {
@@ -206,7 +194,7 @@ public class AeroBayTransferHandler extends TransferHandler {
                 mounted.add(eSource.getEntity().getEquipment(Integer.parseInt(field)));
             }
         } catch (NumberFormatException | UnsupportedFlavorException | IOException e) {
-            MegaMekLab.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
 
         // not actually dragged a Mounted? not transferable
@@ -254,7 +242,7 @@ public class AeroBayTransferHandler extends TransferHandler {
                 ((BayWeaponCriticalTree)source).removeExported((String)data.getTransferData(DataFlavor.stringFlavor),
                         action);
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         }
     }

--- a/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
+++ b/src/megameklab/com/ui/util/BayWeaponCriticalTree.java
@@ -13,31 +13,7 @@
  */
 package megameklab.com.ui.util;
 
-import java.awt.*;
-import java.awt.event.*;
-import java.util.*;
-import java.util.List;
-
-import javax.swing.*;
-import javax.swing.border.Border;
-import javax.swing.border.CompoundBorder;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeCellRenderer;
-import javax.swing.tree.DefaultTreeModel;
-import javax.swing.tree.MutableTreeNode;
-import javax.swing.tree.TreeNode;
-import javax.swing.tree.TreePath;
-import javax.swing.tree.TreeSelectionModel;
-
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.LocationFullException;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.SmallCraft;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestEntity;
@@ -46,14 +22,24 @@ import megamek.common.weapons.bayweapons.PPCBayWeapon;
 import megamek.common.weapons.lrms.LRMWeapon;
 import megamek.common.weapons.ppc.PPCWeapon;
 import megamek.common.weapons.srms.SRMWeapon;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.CConfig;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.border.Border;
+import javax.swing.border.CompoundBorder;
+import javax.swing.tree.*;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.List;
+import java.util.*;
 
 import static megameklab.com.ui.util.AeroBayTransferHandler.EMTPYSLOT;
-import static megameklab.com.ui.util.CritCellUtil.*;
+import static megameklab.com.ui.util.CritCellUtil.CRITCELL_ADD_HEIGHT;
+import static megameklab.com.ui.util.CritCellUtil.CRITCELL_MIN_HEIGHT;
 
 /**
  * Variant of DropTargetCriticalList for aerospace units that groups weapons into bays. Also
@@ -674,7 +660,7 @@ public class BayWeaponCriticalTree extends JTree {
                         msg.append(i).append(": ").append(eSource.getEntity().getEquipment().get(i).getName());
                         msg.append("\n");
                     }
-                    MegaMekLab.getLogger().info(msg.toString());
+                    LogManager.getLogger().info(msg.toString());
                 }
             }
             for (Integer aNum : getMounted().getBayAmmo()) {
@@ -1065,7 +1051,7 @@ public class BayWeaponCriticalTree extends JTree {
                     bay.addAmmoToBay(eSource.getEntity().getEquipmentNum(eq));
                 }
             } else {
-                MegaMekLab.getLogger().debug(bay.getName() + "[" + eSource.getEntity().getEquipmentNum(bay)
+                LogManager.getLogger().debug(bay.getName() + "[" + eSource.getEntity().getEquipmentNum(bay)
                         + "] not found in " + getLocationName());
             }
         }
@@ -1255,7 +1241,7 @@ public class BayWeaponCriticalTree extends JTree {
             eSource.getEntity().addEquipment(eq, location, false);
         } catch (LocationFullException e) {
             // We shouldn't be hitting any limits
-            MegaMekLab.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         UnitUtil.changeMountStatus(eSource.getEntity(), eq, location,
                 Entity.LOC_NONE, (facing == AFT) || ((facing == BOTH) && eq.isRearMounted()));

--- a/src/megameklab/com/ui/util/ProtomekMountList.java
+++ b/src/megameklab/com/ui/util/ProtomekMountList.java
@@ -20,6 +20,7 @@ import megameklab.com.ui.EntitySource;
 import megameklab.com.util.CriticalTransferHandler;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -125,7 +126,7 @@ public class ProtomekMountList extends JList<Mounted> {
                     try {
                         UnitUtil.addProtoMechAmmo(getProtomech(), mounted.getType(), 1);
                     } catch (LocationFullException ex) {
-                        MegaMek.getLogger().error(ex);
+                        LogManager.getLogger().error(ex);
                     }
                     refresh();
                     return;

--- a/src/megameklab/com/ui/view/UnallocatedView.java
+++ b/src/megameklab/com/ui/view/UnallocatedView.java
@@ -14,9 +14,18 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.ui.view;
 
+import megamek.common.AmmoType;
+import megamek.common.Entity;
+import megamek.common.MiscType;
+import megamek.common.Mounted;
+import megamek.common.weapons.Weapon;
+import megameklab.com.ui.EntitySource;
+import megameklab.com.util.*;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -24,27 +33,9 @@ import java.awt.event.MouseListener;
 import java.util.Vector;
 import java.util.function.Supplier;
 
-import javax.swing.BoxLayout;
-import javax.swing.JMenuItem;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-
-import megamek.common.AmmoType;
-import megamek.common.Entity;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.weapons.Weapon;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.EntitySource;
-import megameklab.com.util.*;
-
 /**
  * View that displays unallocated equipment on the build tab.
  */
-
 public class UnallocatedView extends IView implements ActionListener, MouseListener {
 
     private static final long serialVersionUID = 799195356642563937L;
@@ -264,7 +255,7 @@ public class UnallocatedView extends IView implements ActionListener, MouseListe
         try {
             getEntity().addEquipment(eq, location, false);
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         if (refresh.get() != null) {

--- a/src/megameklab/com/util/CConfig.java
+++ b/src/megameklab/com/util/CConfig.java
@@ -13,18 +13,12 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.util;
 
-import megameklab.com.MegaMekLab;
+import org.apache.logging.log4j.LogManager;
 
-import java.awt.Color;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
+import java.awt.*;
+import java.io.*;
 import java.util.Properties;
 
 /**
@@ -178,7 +172,7 @@ public class CConfig {
                         config.load(backupStream);
                         backupStream.close();
                     } catch (Exception ex) {
-                        MegaMekLab.getLogger().error(ex);
+                        LogManager.getLogger().error(ex);
                     }
 
                 } else {
@@ -195,10 +189,10 @@ public class CConfig {
                 config.load(fis);
                 fis.close();
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
     
@@ -316,7 +310,7 @@ public class CConfig {
         } catch (FileNotFoundException ignored) {
 
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return;
         }
         try {
@@ -328,7 +322,7 @@ public class CConfig {
         } catch (FileNotFoundException ignored) {
 
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 

--- a/src/megameklab/com/util/CriticalTransferHandler.java
+++ b/src/megameklab/com/util/CriticalTransferHandler.java
@@ -13,17 +13,12 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.util;
 
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.Mounted;
-import megameklab.com.MegaMekLab;
+import megamek.common.*;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.ui.util.ProtomekMountList;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.datatransfer.DataFlavor;
@@ -33,10 +28,6 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 
 public class CriticalTransferHandler extends TransferHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -5215375829853683877L;
     private EntitySource eSource;
     private int location;
@@ -77,7 +68,7 @@ public class CriticalTransferHandler extends TransferHandler {
                     changeMountStatus(mount, location, false);
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
 
             return true;
@@ -105,7 +96,7 @@ public class CriticalTransferHandler extends TransferHandler {
                     changeMountStatus(mount, location, false);
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
 
             return true;
@@ -123,7 +114,7 @@ public class CriticalTransferHandler extends TransferHandler {
                     changeMountStatus(mount, Entity.LOC_NONE, false);
                 }
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
             return true;
         }
@@ -143,7 +134,7 @@ public class CriticalTransferHandler extends TransferHandler {
                     .parseInt((String) info.getTransferable().getTransferData(
                             DataFlavor.stringFlavor)));
         } catch (NumberFormatException | UnsupportedFlavorException | IOException e) {
-            MegaMekLab.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         // not actually dragged a Mounted? not transferable
         if (mounted == null) {

--- a/src/megameklab/com/util/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/DropTargetCriticalList.java
@@ -13,32 +13,20 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.util;
-
-import java.awt.dnd.DropTargetDragEvent;
-import java.awt.dnd.DropTargetEvent;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.util.Vector;
-
-import javax.swing.JList;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
 
 import megamek.common.*;
 import megamek.common.loaders.EntityLoadingException;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.dnd.DropTargetDragEvent;
+import java.awt.dnd.DropTargetEvent;
+import java.awt.event.*;
+import java.util.Vector;
 
 public class DropTargetCriticalList<E> extends JList<E> implements MouseListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 6847511182922982125L;
     private EntitySource eSource;
     private RefreshListener refresh;
@@ -237,7 +225,7 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
                 return crit.getMount();
             }
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return mount;
@@ -352,7 +340,7 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
         } catch (EntityLoadingException ele) {
             // do nothing.
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
         if (refresh != null) {
             refresh.refreshAll();

--- a/src/megameklab/com/util/Mech/CriticalTransferHandler.java
+++ b/src/megameklab/com/util/Mech/CriticalTransferHandler.java
@@ -13,29 +13,17 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.util.Mech;
 
-import megamek.common.Aero;
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.LandAirMech;
-import megamek.common.LocationFullException;
-import megamek.common.Mech;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestBattleArmor;
 import megamek.common.weapons.infantry.InfantryWeapon;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.CriticalTableModel;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.datatransfer.DataFlavor;
@@ -45,10 +33,6 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.io.IOException;
 
 public class CriticalTransferHandler extends TransferHandler {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = -5215375829853683877L;
     private EntitySource eSource;
     private int location = -1;
@@ -68,7 +52,7 @@ public class CriticalTransferHandler extends TransferHandler {
         try {
             mounted = getUnit().getEquipment(Integer.parseInt((String) data.getTransferData(DataFlavor.stringFlavor)));
         } catch (NumberFormatException | UnsupportedFlavorException | IOException e) {
-            MegaMekLab.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         if ((source instanceof DropTargetCriticalList)
                 && (mounted.getLocation() != Entity.LOC_NONE)) {
@@ -466,7 +450,7 @@ public class CriticalTransferHandler extends TransferHandler {
                         "Location Full", JOptionPane.INFORMATION_MESSAGE);
                 return false;
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
             return true;
         }
@@ -492,7 +476,7 @@ public class CriticalTransferHandler extends TransferHandler {
                     .parseInt((String) info.getTransferable().getTransferData(
                             DataFlavor.stringFlavor)));
         } catch (NumberFormatException | UnsupportedFlavorException | IOException e) {
-            MegaMekLab.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
         // not actually dragged a Mounted? not transferable
         if (mounted == null) {

--- a/src/megameklab/com/util/Mech/DropTargetCriticalList.java
+++ b/src/megameklab/com/util/Mech/DropTargetCriticalList.java
@@ -13,31 +13,9 @@
  * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
-
 package megameklab.com.util.Mech;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.util.Vector;
-
-import javax.swing.JList;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-
-import megamek.common.AmmoType;
-import megamek.common.BattleArmor;
-import megamek.common.BipedMech;
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.Mech;
-import megamek.common.MechFileParser;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.TripodMech;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.verifier.TestBattleArmor;
 import megamek.common.weapons.autocannons.ACWeapon;
@@ -45,17 +23,17 @@ import megamek.common.weapons.autocannons.LBXACWeapon;
 import megamek.common.weapons.autocannons.UACWeapon;
 import megamek.common.weapons.gaussrifles.GaussWeapon;
 import megamek.common.weapons.ppc.PPCWeapon;
-import megameklab.com.MegaMekLab;
 import megameklab.com.ui.EntitySource;
 import megameklab.com.util.CritListCellRenderer;
 import megameklab.com.util.RefreshListener;
 import megameklab.com.util.UnitUtil;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import java.awt.event.*;
+import java.util.Vector;
 
 public class DropTargetCriticalList<E> extends JList<E> implements MouseListener {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 6847511182922982125L;
     private EntitySource eSource;
     private RefreshListener refresh;
@@ -501,7 +479,7 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
                 return crit.getMount();
             }
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         return mount;
@@ -543,7 +521,7 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
         } catch (EntityLoadingException ele) {
             // do nothing.
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         if (refresh != null) {
@@ -575,7 +553,7 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
         } catch (EntityLoadingException ele) {
             // do nothing.
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         if ((crit != null) && (crit.getType() == CriticalSlot.TYPE_EQUIPMENT)) {

--- a/src/megameklab/com/util/MenuBarCreator.java
+++ b/src/megameklab/com/util/MenuBarCreator.java
@@ -13,12 +13,23 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.util;
 
-import java.awt.Component;
-import java.awt.FileDialog;
-import java.awt.Toolkit;
+import megamek.client.ui.swing.UnitLoadingDialog;
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import megamek.common.loaders.BLKFile;
+import megamek.common.templates.TROView;
+import megamek.common.util.EncodeControl;
+import megameklab.com.MMLConstants;
+import megameklab.com.ui.MegaMekLabMainUI;
+import megameklab.com.ui.dialog.LoadingDialog;
+import megameklab.com.ui.dialog.MegaMekLabUnitSelectorDialog;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.UIManager.LookAndFeelInfo;
+import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.ClipboardOwner;
 import java.awt.datatransfer.StringSelection;
@@ -30,32 +41,6 @@ import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.PrintStream;
 import java.util.ResourceBundle;
-
-import javax.swing.BoxLayout;
-import javax.swing.JCheckBoxMenuItem;
-import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JTextArea;
-import javax.swing.KeyStroke;
-import javax.swing.UIManager;
-import javax.swing.UIManager.LookAndFeelInfo;
-
-import megamek.client.ui.swing.UnitLoadingDialog;
-import megamek.common.*;
-import megamek.common.annotations.Nullable;
-import megamek.common.loaders.BLKFile;
-import megamek.common.templates.TROView;
-import megamek.common.util.EncodeControl;
-import megameklab.com.MMLConstants;
-import megameklab.com.MegaMekLab;
-import megameklab.com.ui.MegaMekLabMainUI;
-import megameklab.com.ui.dialog.LoadingDialog;
-import megameklab.com.ui.dialog.MegaMekLabUnitSelectorDialog;
 
 public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
 
@@ -715,7 +700,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
                 BLKFile.encode(unitFile.getAbsolutePath(), tempEntity);
             }
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 
@@ -916,7 +901,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
         } else if (parentFrame.getEntity() instanceof Protomech) {
             parentFrame.createNewUnit(Entity.ETYPE_PROTOMECH);
         } else {
-            MegaMekLab.getLogger().warning("Received unknown entityType!");
+            LogManager.getLogger().warn("Received unknown entityType!");
         }
         setVisible(true);
         reload();
@@ -988,7 +973,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             }
             CConfig.updateSaveFiles(filePathName);
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         JOptionPane.showMessageDialog(parentFrame,
@@ -1037,7 +1022,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             }
             CConfig.updateSaveFiles(filePathName);
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
 
         JOptionPane.showMessageDialog(parentFrame,
@@ -1085,7 +1070,7 @@ public class MenuBarCreator extends JMenuBar implements ClipboardOwner {
             p.close();
             out.close();
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 

--- a/src/megameklab/com/util/UnitPrintManager.java
+++ b/src/megameklab/com/util/UnitPrintManager.java
@@ -13,49 +13,31 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.util;
 
+import megamek.client.ui.swing.UnitLoadingDialog;
+import megamek.common.*;
+import megamek.common.util.EncodeControl;
+import megameklab.com.printing.*;
+import megameklab.com.ui.MegaMekLabMainUI;
+import megameklab.com.ui.dialog.MegaMekLabUnitSelectorDialog;
+import megameklab.com.ui.dialog.UnitPrintQueueDialog;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.logging.log4j.LogManager;
+
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.standard.DialogTypeSelection;
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import java.awt.*;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.print.PageFormat;
 import java.awt.print.PrinterJob;
 import java.io.File;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
-
-import javax.print.attribute.HashPrintRequestAttributeSet;
-import javax.print.attribute.standard.DialogTypeSelection;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.KeyStroke;
-import javax.swing.filechooser.FileNameExtensionFilter;
-
-import megamek.client.ui.swing.UnitLoadingDialog;
-import megamek.common.Aero;
-import megamek.common.BattleArmor;
-import megamek.common.Dropship;
-import megamek.common.Entity;
-import megamek.common.EntityListFile;
-import megamek.common.EntityMovementMode;
-import megamek.common.Infantry;
-import megamek.common.Jumpship;
-import megamek.common.Mech;
-import megamek.common.MechFileParser;
-import megamek.common.Protomech;
-import megamek.common.Tank;
-import megamek.common.util.EncodeControl;
-import megameklab.com.MegaMekLab;
-import megameklab.com.printing.*;
-import megameklab.com.ui.dialog.MegaMekLabUnitSelectorDialog;
-import megameklab.com.ui.MegaMekLabMainUI;
-import megameklab.com.ui.dialog.UnitPrintQueueDialog;
-import org.apache.commons.io.FilenameUtils;
 
 public class UnitPrintManager {
 
@@ -94,7 +76,7 @@ public class UnitPrintManager {
             loadedUnits = EntityListFile.loadFrom(f.getSelectedFile());
             loadedUnits.trimToSize();
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return;
         }
 
@@ -123,7 +105,7 @@ public class UnitPrintManager {
             loadedUnits = EntityListFile.loadFrom(mulFile);
             loadedUnits.trimToSize();
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
             return;
         }
 
@@ -445,7 +427,7 @@ public class UnitPrintManager {
                 printAllUnits(unitList, singleUnit);
             }
         } catch (Exception ex) {
-            MegaMekLab.getLogger().error(ex);
+            LogManager.getLogger().error(ex);
         }
     }
 }

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -13,49 +13,14 @@
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
  * details.
  */
-
 package megameklab.com.util;
-
-import java.awt.Dimension;
-import java.awt.Font;
-import java.io.File;
-import java.math.BigInteger;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.*;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.stream.Collectors;
-
-import javax.swing.JDialog;
-import javax.swing.JEditorPane;
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
-import javax.swing.JScrollPane;
-import javax.swing.JTextPane;
-import javax.swing.ScrollPaneConstants;
-import javax.swing.text.DefaultCaret;
-import javax.swing.text.html.HTMLEditorKit;
 
 import megamek.client.ui.dialogs.BVDisplayDialog;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.loaders.EntityLoadingException;
-import megamek.common.verifier.EntityVerifier;
-import megamek.common.verifier.TestAdvancedAerospace;
-import megamek.common.verifier.TestAero;
-import megamek.common.verifier.TestBattleArmor;
-import megamek.common.verifier.TestEntity;
-import megamek.common.verifier.TestInfantry;
-import megamek.common.verifier.TestMech;
-import megamek.common.verifier.TestProtomech;
-import megamek.common.verifier.TestSmallCraft;
-import megamek.common.verifier.TestSupportVehicle;
-import megamek.common.verifier.TestTank;
-import megamek.common.weapons.AmmoWeapon;
-import megamek.common.weapons.LegAttack;
-import megamek.common.weapons.StopSwarmAttack;
-import megamek.common.weapons.SwarmAttack;
-import megamek.common.weapons.SwarmWeaponAttack;
+import megamek.common.verifier.*;
+import megamek.common.weapons.*;
 import megamek.common.weapons.autocannons.ACWeapon;
 import megamek.common.weapons.autocannons.HVACWeapon;
 import megamek.common.weapons.autocannons.LBXACWeapon;
@@ -80,13 +45,7 @@ import megamek.common.weapons.missiles.MMLWeapon;
 import megamek.common.weapons.missiles.MRMWeapon;
 import megamek.common.weapons.missiles.RLWeapon;
 import megamek.common.weapons.missiles.ThunderBoltWeapon;
-import megamek.common.weapons.other.CLAMS;
-import megamek.common.weapons.other.CLLaserAMS;
-import megamek.common.weapons.other.ISAMS;
-import megamek.common.weapons.other.ISAPDS;
-import megamek.common.weapons.other.ISC3M;
-import megamek.common.weapons.other.ISC3MBS;
-import megamek.common.weapons.other.ISLaserAMS;
+import megamek.common.weapons.other.*;
 import megamek.common.weapons.ppc.CLPlasmaCannon;
 import megamek.common.weapons.ppc.ISPlasmaRifle;
 import megamek.common.weapons.ppc.PPCWeapon;
@@ -96,7 +55,20 @@ import megamek.common.weapons.srms.StreakSRMWeapon;
 import megamek.common.weapons.tag.CLLightTAG;
 import megamek.common.weapons.tag.CLTAG;
 import megamek.common.weapons.tag.ISTAG;
-import megameklab.com.MegaMekLab;
+import org.apache.logging.log4j.LogManager;
+
+import javax.swing.*;
+import javax.swing.text.DefaultCaret;
+import javax.swing.text.html.HTMLEditorKit;
+import java.awt.*;
+import java.io.File;
+import java.math.BigInteger;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.List;
+import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
 
 public class UnitUtil {
 
@@ -713,7 +685,7 @@ public class UnitUtil {
                             new Mounted(unit, EquipmentType
                                     .get("IS1 Compact Heat Sink")), loc, false);
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             }
 
@@ -747,7 +719,7 @@ public class UnitUtil {
                     unit.addEquipment(new Mounted(unit, sinkType),
                             Entity.LOC_NONE, false);
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             }
         }
@@ -770,7 +742,7 @@ public class UnitUtil {
                     unit.addEquipment(new Mounted(unit, EquipmentType.get(EquipmentTypeLookup.COMPACT_HS_1)),
                         Entity.LOC_NONE, false);
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             } else {
                 int loc = singleCompact.getLocation();
@@ -780,7 +752,7 @@ public class UnitUtil {
                     addMounted(unit,new Mounted(unit, EquipmentType.get(EquipmentTypeLookup.COMPACT_HS_2)),
                         loc, false);
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             }
             restHS -= 1;
@@ -790,7 +762,7 @@ public class UnitUtil {
                 unit.addEquipment(new Mounted(unit, EquipmentType.get(EquipmentTypeLookup.COMPACT_HS_2)),
                     Entity.LOC_NONE, false);
             } catch (Exception ex) {
-                MegaMekLab.getLogger().error(ex);
+                LogManager.getLogger().error(ex);
             }
         }
     }
@@ -1129,7 +1101,7 @@ public class UnitUtil {
                                     .getJumpJetType(jjType))),
                             Entity.LOC_NONE, false);
                 } catch (Exception ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
                 jjAmount--;
             }
@@ -2122,7 +2094,7 @@ public class UnitUtil {
                         }
                     }
                 } catch (LocationFullException lfe) {
-                    MegaMekLab.getLogger().error(lfe);
+                    LogManager.getLogger().error(lfe);
                     JOptionPane.showMessageDialog(
                             null,
                             lfe.getMessage(),
@@ -3303,7 +3275,7 @@ public class UnitUtil {
             Mounted m = cs.getMount();
 
             if (m == null) {
-                MegaMekLab.getLogger().error("Null Mount index: " + cs.getIndex());
+                LogManager.getLogger().error("Null Mount index: " + cs.getIndex());
                 m = cs.getMount();
             }
 
@@ -3331,7 +3303,7 @@ public class UnitUtil {
             Mounted m = cs.getMount();
 
             if (m == null) {
-                MegaMekLab.getLogger().error("Null Mount index: " + cs.getIndex());
+                LogManager.getLogger().error("Null Mount index: " + cs.getIndex());
                 m = cs.getMount();
             }
 
@@ -3780,7 +3752,7 @@ public class UnitUtil {
         try {
             MechFileParser.postLoadInit(entity);
         } catch (EntityLoadingException e) {
-            MegaMekLab.getLogger().error(e);
+            LogManager.getLogger().error(e);
         }
     }
     
@@ -4254,10 +4226,10 @@ public class UnitUtil {
                     if (ammo.isPresent()) {
                         unit.addEquipment(ammo.get(), Infantry.LOC_FIELD_GUNS);
                     } else {
-                        MegaMekLab.getLogger().error("Could not find ammo for field gun " + fieldGun.getName());
+                        LogManager.getLogger().error("Could not find ammo for field gun " + fieldGun.getName());
                     }
                 } catch (LocationFullException ex) {
-                    MegaMekLab.getLogger().error(ex);
+                    LogManager.getLogger().error(ex);
                 }
             }                
         }


### PR DESCRIPTION
This swaps MegaMekLab to Log4j 2 and by doing so improves our logging implementation in MegaMekLab.

The MegaMekLab::showInfo method has been standardized with MegaMek and MekHQ, and made public so that MekHQ can call it.

I chose to isolate all logging in MegaMekLab to the MegaMekLab.log file outside of legacy exceptions, as this makes it easier to bugfix.