### PR TITLE
Updating to Log4j2 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ configurations {
 dependencies {
     implementation "org.megamek:megamek${mmBranchTag}:${version}"
 
-    implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.16.0'
     implementation 'org.apache.xmlgraphics:batik-dom:1.14'
     implementation 'org.apache.xmlgraphics:batik-codec:1.14'
     implementation 'org.apache.xmlgraphics:batik-rasterizer:1.14'


### PR DESCRIPTION
There was a major bugfix release to further improve security when using Log4j. This updates MML to that release, while MM and MHQ have it as part of their individual update PRs.