### PR TITLE
Add a color config for unhittables (Endo etc.)

### DIFF
--- a/src/megameklab/com/ui/dialog/ConfigurationDialog.java
+++ b/src/megameklab/com/ui/dialog/ConfigurationDialog.java
@@ -118,6 +118,7 @@ public final class ConfigurationDialog extends JDialog implements ActionListener
         addFields(CConfig.CONFIG_EQUIPMENT);
         addFields(CConfig.CONFIG_AMMO);
         addFields(CConfig.CONFIG_SYSTEMS);
+        addFields(CConfig.CONFIG_NONHITTABLE);
         addFields(CConfig.CONFIG_EMPTY);
         SpringLayoutHelper.setupSpringGrid(panColors, 3);
     }

--- a/src/megameklab/com/ui/util/CritCellUtil.java
+++ b/src/megameklab/com/ui/util/CritCellUtil.java
@@ -67,6 +67,9 @@ public final class CritCellUtil {
             if (mounted == null) {
                 cell.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_EMPTY));
                 cell.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_EMPTY));
+            } else if (!mounted.getType().isHittable()) {
+                cell.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_NONHITTABLE));
+                cell.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_NONHITTABLE));
             } else if (mounted.getType() instanceof WeaponType) {
                 cell.setBackground(CConfig.getBackgroundColor(CConfig.CONFIG_WEAPONS));
                 cell.setForeground(CConfig.getForegroundColor(CConfig.CONFIG_WEAPONS));

--- a/src/megameklab/com/ui/util/CritListCellRenderer.java
+++ b/src/megameklab/com/ui/util/CritListCellRenderer.java
@@ -21,6 +21,7 @@ import megameklab.com.util.CConfig;
 import megameklab.com.util.UnitUtil;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import java.awt.*;
 
 import static megameklab.com.ui.util.CritCellUtil.*;
@@ -86,7 +87,9 @@ public class CritListCellRenderer extends DefaultListCellRenderer {
             setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, CritCellUtil.CRITCELL_BORDER_COLOR));
         } else if ((cs != null) && UnitUtil.isPreviousCritEmpty(unit, cs, index, loc)) {
             setBorder(BorderFactory.createMatteBorder(1, 0, 0, 0, CritCellUtil.CRITCELL_BORDER_COLOR));
-        } 
+        } else {
+            setBorder(new EmptyBorder(0, 0, 0, 0));
+        }
 
         return this;
     }

--- a/src/megameklab/com/ui/util/CriticalTableModel.java
+++ b/src/megameklab/com/ui/util/CriticalTableModel.java
@@ -316,11 +316,14 @@ public class CriticalTableModel extends AbstractTableModel {
 
             String equipmentType = CConfig.CONFIG_EQUIPMENT;
 
-            if (mount.getType() instanceof WeaponType) {
+            if (!mount.getType().isHittable()) {
+                equipmentType = CConfig.CONFIG_NONHITTABLE;
+            } else if (mount.getType() instanceof WeaponType) {
                 equipmentType = CConfig.CONFIG_WEAPONS;
             } else if (mount.getType() instanceof AmmoType) {
                 equipmentType = CConfig.CONFIG_AMMO;
             }
+
             c.setBackground(CConfig.getBackgroundColor(equipmentType));
             c.setForeground(CConfig.getForegroundColor(equipmentType));
             return c;

--- a/src/megameklab/com/util/CConfig.java
+++ b/src/megameklab/com/util/CConfig.java
@@ -66,6 +66,7 @@ public class CConfig {
     public static final String CONFIG_EQUIPMENT = "Equipment";
     public static final String CONFIG_SYSTEMS = "Systems";
     public static final String CONFIG_EMPTY = "Empty";
+    public static final String CONFIG_NONHITTABLE = "Nonhittable";
 
     public static final String CONFIG_SAVE_FILE_1 = "Save_File_One";
     public static final String CONFIG_SAVE_FILE_2 = "Save_File_Two";
@@ -75,17 +76,6 @@ public class CConfig {
     public static final String CONFIG_FOREGROUND = "-Foreground";
     public static final String CONFIG_BACKGROUND = "-Background";
 
-    public static final String CONFIG_WEAPONS_FOREGROUND = "Weapons-Foreground";
-    public static final String CONFIG_WEAPONS_BACKGROUND = "Weapons-Background";
-    public static final String CONFIG_AMMO_FOREGROUND = "Ammo-Foreground";
-    public static final String CONFIG_AMMO_BACKGROUND = "Ammo-Background";
-    public static final String CONFIG_EQUIPMENT_FOREGROUND = "Equipment-Foreground";
-    public static final String CONFIG_EQUIPMENT_BACKGROUND = "Equipment-Background";
-    public static final String CONFIG_SYSTEMS_FOREGROUND = "Systems-Foreground";
-    public static final String CONFIG_SYSTEMS_BACKGROUND = "Systems-Background";
-    public static final String CONFIG_EMPTY_FOREGROUND = "Empty-Foreground";
-    public static final String CONFIG_EMPTY_BACKGROUND = "Empty-Background";
-    
     public static final String TECH_PROGRESSION = "techProgression";
     public static final String TECH_USE_YEAR = "techUseYear";
     public static final String TECH_YEAR = "techYear";


### PR DESCRIPTION
Makes a new color config available for unhittable crit slots such as Endo Steel or Ferro Armor and I think a handful of systems that are unhittable. Since most unit types don't use unhittable crit slots this will almost exclusively affect Meks.

Also corrects an indentation issue in the crit slots that was caused by a missing border.

![image](https://user-images.githubusercontent.com/17069663/148533432-e19cb76d-41f5-4351-b757-9a5c11975219.png)
