### PR TITLE
SuiteOptions: Naming standardization and finishing initial setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ timestamp
 /properties_local.gradle
 .idea/
 .vscode/
+/mmconf/*.preferences
 
 # Data Files
 data/fonts/

--- a/src/megameklab/com/MMLOptions.java
+++ b/src/megameklab/com/MMLOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -18,21 +18,12 @@
  */
 package megameklab.com;
 
-import megamek.SuiteConstants;
+import megamek.SuiteOptions;
 
-/**
- * These are constants that hold across MegaMekLab.
- */
-public final class MMLConstants extends SuiteConstants {
-    //region General Constants
-    //endregion General Constants
-
-    //region GUI Constants
-    //endregion GUI Constants
-
-    //region MMLOptions
-    //endregion MMLOptions
-
-    //region File Paths
-    //endregion File Paths
+public class MMLOptions extends SuiteOptions {
+    //region Constructors
+    public MMLOptions() {
+        super();
+    }
+    //endregion Constructors
 }

--- a/src/megameklab/com/MegaMekLab.java
+++ b/src/megameklab/com/MegaMekLab.java
@@ -40,9 +40,8 @@ import java.util.List;
 import java.util.Locale;
 
 public class MegaMekLab {
-
-    public static final String PREFERENCES_FILE = "mmconf/mml.preferences";
-    private static MMPreferences preferences = null;
+    private static final MMPreferences mmlPreferences = new MMPreferences();
+    private static final MMLOptions mmlOptions = new MMLOptions();
 
     public static void main(String... args) {
         // First, create a global default exception handler
@@ -122,7 +121,6 @@ public class MegaMekLab {
     }
     
     private static void startup() {
-        Locale.setDefault(Locale.US);
         EquipmentType.initializeTypes();
         MechSummaryCache.getInstance();
         try {
@@ -133,8 +131,11 @@ public class MegaMekLab {
         CConfig.load();
         UnitUtil.loadFonts();
 
-        MegaMek.getPreferences().loadFromFile(MegaMek.PREFERENCES_FILE);
-        getPreferences().loadFromFile(PREFERENCES_FILE);
+        MegaMek.getMMPreferences().loadFromFile(MMLConstants.MM_PREFERENCES_FILE);
+        getMMLPreferences().loadFromFile(MMLConstants.MML_PREFERENCES_FILE);
+
+        // TODO : Individual localizations
+        Locale.setDefault(getMMLOptions().getLocale());
 
         // Add additional themes
         UIManager.installLookAndFeel("Flat Light", "com.formdev.flatlaf.FlatLightLaf");
@@ -143,7 +144,8 @@ public class MegaMekLab {
         UIManager.installLookAndFeel("Flat Darcula", "com.formdev.flatlaf.FlatDarculaLaf");
 
         setLookAndFeel();
-        //create a start up frame and display it
+
+        // Create a startup frame and display it
         StartupGUI sud = new StartupGUI();
         sud.setVisible(true);
     }
@@ -167,7 +169,7 @@ public class MegaMekLab {
         double maxWidth = 0;
         for (GraphicsDevice g : gs) {
             Rectangle b = g.getDefaultConfiguration().getBounds();
-            if (b.getWidth() > maxWidth) {   // Update the max size found on this monitor
+            if (b.getWidth() > maxWidth) { // Update the max size found on this monitor
                 maxWidth = b.getWidth();
             }
         }
@@ -175,10 +177,11 @@ public class MegaMekLab {
         return maxWidth;
     }
 
-    public static MMPreferences getPreferences() {
-        if (preferences == null) {
-            preferences = new MMPreferences();
-        }
-        return preferences;
+    public static MMPreferences getMMLPreferences() {
+        return mmlPreferences;
+    }
+
+    public static MMLOptions getMMLOptions() {
+        return mmlOptions;
     }
 }

--- a/src/megameklab/com/MegaMekLab.java
+++ b/src/megameklab/com/MegaMekLab.java
@@ -17,7 +17,7 @@
 package megameklab.com;
 
 import megamek.MegaMek;
-import megamek.client.ui.preferences.MMPreferences;
+import megamek.client.ui.preferences.SuitePreferences;
 import megamek.common.Configuration;
 import megamek.common.EquipmentType;
 import megamek.common.MechSummaryCache;
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Locale;
 
 public class MegaMekLab {
-    private static final MMPreferences mmlPreferences = new MMPreferences();
+    private static final SuitePreferences mmlPreferences = new SuitePreferences();
     private static final MMLOptions mmlOptions = new MMLOptions();
 
     public static void main(String... args) {
@@ -177,7 +177,7 @@ public class MegaMekLab {
         return maxWidth;
     }
 
-    public static MMPreferences getMMLPreferences() {
+    public static SuitePreferences getMMLPreferences() {
         return mmlPreferences;
     }
 

--- a/src/megameklab/com/ui/MegaMekLabMainUI.java
+++ b/src/megameklab/com/ui/MegaMekLabMainUI.java
@@ -109,8 +109,8 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
             CConfig.saveConfig();
             PreferenceManager.getInstance().save();
 
-            MegaMek.getPreferences().saveToFile(MegaMek.PREFERENCES_FILE);
-            MegaMekLab.getPreferences().saveToFile(MegaMekLab.PREFERENCES_FILE);
+            MegaMek.getMMPreferences().saveToFile(MegaMek.PREFERENCES_FILE);
+            MegaMekLab.getMMLPreferences().saveToFile(MegaMekLab.PREFERENCES_FILE);
             System.exit(0);
         }
     }

--- a/src/megameklab/com/ui/MegaMekLabMainUI.java
+++ b/src/megameklab/com/ui/MegaMekLabMainUI.java
@@ -19,6 +19,7 @@ package megameklab.com.ui;
 import megamek.MegaMek;
 import megamek.common.Entity;
 import megamek.common.preference.PreferenceManager;
+import megameklab.com.MMLConstants;
 import megameklab.com.MegaMekLab;
 import megameklab.com.util.CConfig;
 import megameklab.com.ui.util.RefreshListener;
@@ -109,8 +110,8 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
             CConfig.saveConfig();
             PreferenceManager.getInstance().save();
 
-            MegaMek.getMMPreferences().saveToFile(MegaMek.PREFERENCES_FILE);
-            MegaMekLab.getMMLPreferences().saveToFile(MegaMekLab.PREFERENCES_FILE);
+            MegaMek.getMMPreferences().saveToFile(MMLConstants.MM_PREFERENCES_FILE);
+            MegaMekLab.getMMLPreferences().saveToFile(MMLConstants.MML_PREFERENCES_FILE);
             System.exit(0);
         }
     }

--- a/src/megameklab/com/ui/dialog/AbstractMMLDialog.java
+++ b/src/megameklab/com/ui/dialog/AbstractMMLDialog.java
@@ -59,6 +59,6 @@ public abstract class AbstractMMLDialog extends AbstractDialog {
      */
     @Override
     protected void setPreferences() {
-        setPreferences(MegaMekLab.getPreferences().forClass(getClass()));
+        setPreferences(MegaMekLab.getMMLPreferences().forClass(getClass()));
     }
 }


### PR DESCRIPTION
This is part of a suite-wide PR to create a standardized SuiteOptions, SuiteConstants, and SuitePreferences setup. This requires https://github.com/MegaMek/megamek/pull/3391 and https://github.com/MegaMek/mekhq/pull/3087.

For Review: The changes are in MegaMekLab and MMLOptions. Everything else is just renames.