### PR TITLE
Fixes for 1016, 1012, 1008

### DIFF
--- a/src/megameklab/com/printing/PrintMech.java
+++ b/src/megameklab/com/printing/PrintMech.java
@@ -426,8 +426,10 @@ public class PrintMech extends PrintEntity {
         double x = viewX + viewWidth * 0.075;
         x += addTextElement(canvas, x, viewY - 1, mech.getLocationName(loc),
                 fontSize * 1.25f, SVGConstants.SVG_START_VALUE, SVGConstants.SVG_BOLD_VALUE);
-        if (mech.isClan() && UnitUtil.hasAmmo(mech, loc) && !mech.hasCASEII(loc)) {
-            addTextElement(canvas, x + fontSize / 2, viewY - 1, "(CASE)", fontSize,
+        if ((mech.isClan() && UnitUtil.hasAmmo(mech, loc))
+                || (!mech.isClan() && (mech.hasCASEII(loc) || mech.locationHasCase(loc)))) {
+            String text = "(CASE" + (mech.hasCASEII(loc) ? " II)" : ")");
+            addTextElement(canvas, x + fontSize / 2, viewY - 1, text, fontSize,
                     SVGConstants.SVG_START_VALUE, SVGConstants.SVG_NORMAL_VALUE);
         }
         

--- a/src/megameklab/com/ui/combatVeh/CVEquipmentDatabaseView.java
+++ b/src/megameklab/com/ui/combatVeh/CVEquipmentDatabaseView.java
@@ -51,6 +51,7 @@ class CVEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
         } else {
             try {
                 mount = new Mounted(getTank(), equip);
+                UnitUtil.setVariableSizeMiscTypeMinimumSize(mount);
                 int loc = Entity.LOC_NONE;
                 if (isMisc && equip.hasFlag(MiscType.F_MAST_MOUNT)) {
                     loc = VTOL.LOC_ROTOR;

--- a/src/megameklab/com/ui/fighterAero/ASChassisView.java
+++ b/src/megameklab/com/ui/fighterAero/ASChassisView.java
@@ -312,8 +312,7 @@ public class ASChassisView extends BuildView implements ActionListener, ChangeLi
 
     private boolean validCFEngine(Engine engine) {
         return conventional && ((engine.getEngineType() == Engine.NORMAL_ENGINE)
-                || (engine.getEngineType() == Engine.COMBUSTION_ENGINE)
-                || (engine.getEngineType() == Engine.XXL_ENGINE));
+                || (engine.getEngineType() == Engine.COMBUSTION_ENGINE));
     }
 
     private boolean validASFEngine(Engine engine) {

--- a/src/megameklab/com/ui/fighterAero/ASChassisView.java
+++ b/src/megameklab/com/ui/fighterAero/ASChassisView.java
@@ -294,23 +294,30 @@ public class ASChassisView extends BuildView implements ActionListener, ChangeLi
             flags |= Engine.LARGE_ENGINE;
         }
         int altFlags = flags ^ Engine.CLAN_ENGINE;
-        // Non-superheavies can use non-fusion engines under experimental rules
         for (int i : ENGINE_TYPES) {
             Engine e = new Engine(getEngineRating(), i, flags);
-            if (e.engineValid && (e.isFusion() || conventional)
-                    && techManager.isLegal(e)) {
+            if (e.engineValid && techManager.isLegal(e) && (validCFEngine(e) || validASFEngine(e))) {
                 retVal.add(e);
             }
             // Only add the opposite tech base if the engine is different.
             if (isMixed && e.getSideTorsoCriticalSlots().length > 0) {
                 e = new Engine(getEngineRating(), i, altFlags);
-                if (e.engineValid && (e.isFusion() || conventional)
-                        && techManager.isLegal(e)) {
+                if (e.engineValid && techManager.isLegal(e) && (validCFEngine(e) || validASFEngine(e))) {
                     retVal.add(e);
                 }
             }
         }
         return retVal;
+    }
+
+    private boolean validCFEngine(Engine engine) {
+        return conventional && ((engine.getEngineType() == Engine.NORMAL_ENGINE)
+                || (engine.getEngineType() == Engine.COMBUSTION_ENGINE)
+                || (engine.getEngineType() == Engine.XXL_ENGINE));
+    }
+
+    private boolean validASFEngine(Engine engine) {
+        return !conventional && engine.isFusion();
     }
     
     private void refreshCockpit() {

--- a/src/megameklab/com/ui/fighterAero/ASEquipmentDatabaseView.java
+++ b/src/megameklab/com/ui/fighterAero/ASEquipmentDatabaseView.java
@@ -49,6 +49,7 @@ class ASEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
         } else {
             try {
                 Mounted mount = new Mounted(getAero(), equip);
+                UnitUtil.setVariableSizeMiscTypeMinimumSize(mount);
                 int location = (equip instanceof AmmoType) ? Aero.LOC_FUSELAGE : Aero.LOC_NONE;
                 getAero().addEquipment(mount, location, false);
                 if ((equip instanceof WeaponType) && equip.hasFlag(WeaponType.F_ONESHOT)) {

--- a/src/megameklab/com/ui/largeAero/LAEquipmentDatabaseView.java
+++ b/src/megameklab/com/ui/largeAero/LAEquipmentDatabaseView.java
@@ -72,6 +72,7 @@ class LAEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
                 try {
                     for (int i = 0; i < count; i++) {
                         mount = new Mounted(getAero(), equip);
+                        UnitUtil.setVariableSizeMiscTypeMinimumSize(mount);
                         getAero().addEquipment(mount, Entity.LOC_NONE, false);
                         if ((equip instanceof WeaponType) && equip.hasFlag(WeaponType.F_ONESHOT)) {
                             UnitUtil.removeOneShotAmmo(eSource.getEntity());

--- a/src/megameklab/com/ui/mek/BMEquipmentDatabaseView.java
+++ b/src/megameklab/com/ui/mek/BMEquipmentDatabaseView.java
@@ -52,6 +52,7 @@ class BMEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
         } else {
             try {
                 mount = new Mounted(getMech(), equip);
+                UnitUtil.setVariableSizeMiscTypeMinimumSize(mount);
                 getMech().addEquipment(mount, Entity.LOC_NONE, false);
                 if ((equip instanceof WeaponType) && equip.hasFlag(WeaponType.F_ONESHOT)) {
                     UnitUtil.removeOneShotAmmo(eSource.getEntity());

--- a/src/megameklab/com/ui/supportVeh/SVEquipmentDatabaseView.java
+++ b/src/megameklab/com/ui/supportVeh/SVEquipmentDatabaseView.java
@@ -71,6 +71,7 @@ class SVEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
                 }
                 for (int i = 0; i < count; i++) {
                     mount = new Mounted(eSource.getEntity(), equip);
+                    UnitUtil.setVariableSizeMiscTypeMinimumSize(mount);
                     if ((eSource.getEntity().isFighter()
                             && (equip instanceof MiscType)) && equip.hasFlag(MiscType.F_BLUE_SHIELD)) {
                         getAero().addEquipment(mount, Aero.LOC_FUSELAGE, false);

--- a/src/megameklab/com/util/UnitUtil.java
+++ b/src/megameklab/com/util/UnitUtil.java
@@ -4464,5 +4464,15 @@ public class UnitUtil {
         entity.setUseManualBV(manualBV > 0);
     }
 
+    /**
+     * For MiscTypes of variable size such as Ladders this sets the size to the minimum
+     * size which is equal to the step size (20m for Ladders, 0.5t for Cargo space and the like).
+     */
+    public static void setVariableSizeMiscTypeMinimumSize(Mounted mounted) {
+        if ((mounted.getType() instanceof MiscType) && mounted.getType().isVariableSize()) {
+            mounted.setSize(mounted.getType().variableStepSize());
+        }
+    }
+
 
 }


### PR DESCRIPTION
Fixes #1016 (as per request, the CASE / CASE II note is now printed with the header of all locations that have either system, as equipment or automatically for both Clan and IS)
Fixes #1012 (only allows Std Fusion and ICE engines on CF, not TO Large Engines as we don't seem to have them nor XXL engines which will receive errata to not be available for CF)
Fixes #1008 (now sets the correct minimum size value for all variable size equipment)

1016 and 1008 are in their own commits. But it's not that much code either way.