### PR TITLE
Issue 1042: Print the exact type of TSM to RS

### DIFF
--- a/megameklab/src/megameklab/printing/PrintMech.java
+++ b/megameklab/src/megameklab/printing/PrintMech.java
@@ -711,7 +711,7 @@ public class PrintMech extends PrintEntity {
 
             if (UnitUtil.isTSM(m.getType())) {
                 critName.setLength(0);
-                critName.append("Triple-Strength Myomer");
+                critName.append(m.getType().getName());
             }
 
             if (m.isRearMounted()) {


### PR DESCRIPTION
Writes the exact type of TSM to record sheet crit slots (Triple Strength Myomer / Industrial Triple Strength Myomer / Prototype Triple Strength Myomer).

Fixes #1042 