### PR TITLE
Issue #1045: Equipment filters

### DIFF
--- a/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
@@ -90,7 +90,7 @@ public enum EquipmentDatabaseCategory {
                     && !eq.hasFlag(F_PINTLE_TURRET))
                     || (eq instanceof TAGWeapon)
                     || ((eq instanceof AmmoType) && (((AmmoType) eq).getAmmoType() == AmmoType.T_COOLANT_POD))
-                    || (eq.hasFlag(F_AMS))),
+                    || eq.hasFlag(F_AMS)),
 
     AP ("Anti-Personnel",
             (eq, en) -> UnitUtil.isBattleArmorAPWeapon(eq),


### PR DESCRIPTION
Fixes #1045 
Requires MM #3474

Generally speaking, this adapts the equipment filtering somewhat to restore some missing equipment after the more extensive equipment table changes.
- Adds an "Industrial" filter toggle to CV and SV (since they have no "Physical" filter). Industrial will show Backhoe, Dumper etc. Industrial eqp no longer appears in "Other"
- Aero dont have access to industrial equipment except for the refueling drogue, which now appears in "Other"
- On Meks, industrial eqp is shown under "Physical" to relieve the "Other" category a bit and since the game effects are often similar
- Sponson turrets will appear again in "Other" for CV (SV handle them in the Structure tab)
- CV chassis mods again appear as they should in "Other"
- AMS and Laser AMS will now appear in "Other" in addition to "Energy" (Laser AMS) and "Ballistic" (AMS) since that doesnt hurt