### PR TITLE
Issue 1022: Add RS ammo display to Mine/Sensor dispensers

### DIFF
--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -218,8 +218,7 @@ public class InventoryWriter {
             if (m.isWeaponGroup()) {
                 continue;
             }
-            if ((m.getType() instanceof AmmoType)
-                    && (((AmmoType) m.getType()).getAmmoType() != AmmoType.T_COOLANT_POD)) {
+            if ((m.getType() instanceof AmmoType) && (((AmmoType) m.getType()).getAmmoType() != AmmoType.T_COOLANT_POD)) {
                 if (m.getLocation() != Entity.LOC_NONE) {
                     String shortName = m.getType().getShortName().replace("Ammo", "");
                     shortName = shortName.replace("(Clan)", "");
@@ -231,6 +230,10 @@ public class InventoryWriter {
                     ammo.merge("Fusillade", m.getBaseShotsLeft(), Integer::sum);
                 }
                 continue;
+            }
+            if (m.getType().hasFlag(MiscType.F_VEHICLE_MINE_DISPENSER)
+                    || m.getType().hasFlag(MiscType.F_SENSOR_DISPENSER)) {
+                ammo.merge(m.getShortName(), m.getBaseShotsLeft(), Integer::sum);
             }
             if ((m.getType() instanceof AmmoType)
                     || (m.getLocation() == Entity.LOC_NONE)

--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -231,8 +231,7 @@ public class InventoryWriter {
                 }
                 continue;
             }
-            if (m.getType().hasFlag(MiscType.F_VEHICLE_MINE_DISPENSER)
-                    || m.getType().hasFlag(MiscType.F_SENSOR_DISPENSER)) {
+            if (UnitUtil.isMineDispenser(m.getType()) || UnitUtil.isRemoteSensorDispenser(m.getType())) {
                 ammo.merge(m.getShortName(), m.getBaseShotsLeft(), Integer::sum);
             }
             if ((m.getType() instanceof AmmoType)

--- a/megameklab/src/megameklab/printing/PrintMech.java
+++ b/megameklab/src/megameklab/printing/PrintMech.java
@@ -758,6 +758,10 @@ public class PrintMech extends PrintEntity {
                     critName.trimToSize();
                 }
             }
+            if (m.getType().hasFlag(MiscType.F_VEHICLE_MINE_DISPENSER)
+                    || m.getType().hasFlag(MiscType.F_SENSOR_DISPENSER)) {
+                critName.append(" (").append(m.getBaseShotsLeft()).append(")");
+            }
             return critName.toString();
         }
     }

--- a/megameklab/src/megameklab/printing/PrintMech.java
+++ b/megameklab/src/megameklab/printing/PrintMech.java
@@ -758,8 +758,7 @@ public class PrintMech extends PrintEntity {
                     critName.trimToSize();
                 }
             }
-            if (m.getType().hasFlag(MiscType.F_VEHICLE_MINE_DISPENSER)
-                    || m.getType().hasFlag(MiscType.F_SENSOR_DISPENSER)) {
+            if (UnitUtil.isMineDispenser(m.getType()) || UnitUtil.isRemoteSensorDispenser(m.getType())) {
                 critName.append(" (").append(m.getBaseShotsLeft()).append(")");
             }
             return critName.toString();

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -151,6 +151,22 @@ public class UnitUtil {
     }
 
     /**
+     * @param eq The equipmentType to check
+     * @return true if this is a Remote Sensor Dispenser (BA or vehicular)
+     */
+    public static boolean isRemoteSensorDispenser(EquipmentType eq) {
+        return (eq instanceof MiscType) && eq.hasFlag(MiscType.F_SENSOR_DISPENSER);
+    }
+
+    /**
+     * @param eq The equipmentType to check
+     * @return true if this is a Mine Dispenser (BA or vehicular)
+     */
+    public static boolean isMineDispenser(EquipmentType eq) {
+        return (eq instanceof MiscType) && eq.hasFlag(MiscType.F_VEHICLE_MINE_DISPENSER);
+    }
+
+    /**
      * tells if EquipmentType is MASC
      *
      * @param eq


### PR DESCRIPTION
As the title says...
Fixes #1022 
Also works on BA. BA have a bit of a formatting problem in that the equipment list often collides with the ammo list but that's not directly related to this issue.

![image](https://user-images.githubusercontent.com/17069663/156740555-6677c457-05d1-4fcc-bb5e-b5fbf9accbb9.png)
![image](https://user-images.githubusercontent.com/17069663/156740597-2b0a13f1-c5d0-45dd-9348-d30d2d7255d7.png)
![image](https://user-images.githubusercontent.com/17069663/156740665-58820985-7160-47ab-a036-86713213baff.png)
![image](https://user-images.githubusercontent.com/17069663/156740711-6f0a17a7-9c56-483e-ac2c-5037556e583d.png)
