### PR TITLE
MML Issue 927: Add LAM FuelTank input

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -269,6 +269,10 @@ FuelView.FuelType.PETROCHEMICALS=Petrochemicals
 FuelView.FuelType.ALCOHOL=Alcohol
 FuelView.FuelType.NATURAL_GAS=Natural Gas
 
+BMLAMFuelView.spnFuel.text=Fuel Mass:\u0020
+BMLAMFuelView.lblFuelPoints.tooltip=The amount of additional fuel allocated to the LAM.
+BMLAMFuelView.totalFuelLabel.text=Total Available Fuel Points:\u0020
+
 PlatoonTypeView.cbMotiveType.values=Foot,Jump,Motorized,Mechanized (Hover),Mechanized (Tracked),Mechanized (Wheeled),VTOL (Micro-copter),VTOL (Microlite),SCUBA (Foot),SCUBA (Motorized),SCUBA (Mechanized)
 PlatoonTypeView.cbMotiveType.text=Motive Type:
 PlatoonTypeView.cbMotiveType.tooltip=Determines MP, movement mode, and maximum platoon and squad size.

--- a/megameklab/src/megameklab/ui/mek/BMEquipmentTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMEquipmentTab.java
@@ -14,19 +14,11 @@
  */
 package megameklab.ui.mek;
 
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
+import megamek.common.*;
 import megameklab.ui.EntitySource;
 import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.util.AbstractEquipmentDatabaseView;
 import megameklab.util.UnitUtil;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * The Equipment Tab for Mek units showing the equipment database and the current loadout list.
@@ -51,15 +43,16 @@ public class BMEquipmentTab extends AbstractEquipmentTab {
         EquipmentType etype = mount.getType();
         return !(etype instanceof MiscType) ||
                 !(UnitUtil.isHeatSink(mount)
-                || etype.hasFlag(MiscType.F_JUMP_JET)
-                || etype.hasFlag(MiscType.F_JUMP_BOOSTER)
-                || etype.hasFlag(MiscType.F_TSM)
-                || etype.hasFlag(MiscType.F_INDUSTRIAL_TSM)
-                || (etype.hasFlag(MiscType.F_MASC) && !etype.hasSubType(MiscType.S_SUPERCHARGER))
-                || ((getMech().getEntityType() & Entity.ETYPE_QUADVEE) == Entity.ETYPE_QUADVEE
-                && etype.hasFlag(MiscType.F_TRACKS))
-                || UnitUtil.isArmorOrStructure(etype)
-                || (etype.hasFlag(MiscType.F_CASE) && etype.isClan()));
+                        || etype.isAnyOf(EquipmentTypeLookup.LAM_FUEL_TANK)
+                        || etype.hasFlag(MiscType.F_JUMP_JET)
+                        || etype.hasFlag(MiscType.F_JUMP_BOOSTER)
+                        || etype.hasFlag(MiscType.F_TSM)
+                        || etype.hasFlag(MiscType.F_INDUSTRIAL_TSM)
+                        || (etype.hasFlag(MiscType.F_MASC) && !etype.hasSubType(MiscType.S_SUPERCHARGER))
+                        || ((getMech().getEntityType() & Entity.ETYPE_QUADVEE) == Entity.ETYPE_QUADVEE
+                        && etype.hasFlag(MiscType.F_TRACKS))
+                        || UnitUtil.isArmorOrStructure(etype)
+                        || (etype.hasFlag(MiscType.F_CASE) && etype.isClan()));
     }
 
 }

--- a/megameklab/src/megameklab/ui/mek/BMLAMFuelView.java
+++ b/megameklab/src/megameklab/ui/mek/BMLAMFuelView.java
@@ -34,6 +34,8 @@ import java.util.ResourceBundle;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
+import static megamek.common.EquipmentTypeLookup.LAM_FUEL_TANK;
+
 /**
  * This view block allows entering additional fuel tanks for LandAirMeks
  *
@@ -41,15 +43,9 @@ import java.util.stream.Collectors;
  */
 public class BMLAMFuelView extends IView implements ChangeListener {
 
-    private static final EquipmentType FUEL_TANK = MiscType.get(EquipmentTypeLookup.LAM_FUEL_TANK);
+    private static final EquipmentType FUEL_TANK = MiscType.get(LAM_FUEL_TANK);
 
     private final List<MekBuildListener> listeners = new CopyOnWriteArrayList<>();
-    public void addListener(MekBuildListener l) {
-        listeners.add(l);
-    }
-    public void removeListener(MekBuildListener l) {
-        listeners.remove(l);
-    }
 
     private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
     private final SpinnerNumberModel fuelTonsSpnModel = new SpinnerNumberModel(0, 0, 84, 1);
@@ -88,9 +84,15 @@ public class BMLAMFuelView extends IView implements ChangeListener {
         updateFuelPointsLabel();
     }
 
-    /** Returns the current number of LAM Fuel Tanks on the Mek, including unallocated. Returns 0 for non-LAM. */
+    /**
+     * Returns the current number of LAM Fuel Tanks on the Mek, including unallocated.
+     * Always returns 0 for non-LAM.
+     *
+     * @param mek The Mek unit
+     * @return The Mek's current LAM Fuel Tank count
+     */
     private int fuelTanks(Mech mek) {
-        return (mek instanceof LandAirMech) ? mek.countWorkingMisc(EquipmentTypeLookup.LAM_FUEL_TANK, -1) : 0;
+        return (mek instanceof LandAirMech) ? mek.countWorkingMisc(LAM_FUEL_TANK, -1) : 0;
     }
 
     private void updateFuelPointsLabel() {
@@ -152,4 +154,11 @@ public class BMLAMFuelView extends IView implements ChangeListener {
         }
     }
 
+    public void addListener(MekBuildListener l) {
+        listeners.add(l);
+    }
+
+    public void removeListener(MekBuildListener l) {
+        listeners.remove(l);
+    }
 }

--- a/megameklab/src/megameklab/ui/mek/BMLAMFuelView.java
+++ b/megameklab/src/megameklab/ui/mek/BMLAMFuelView.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megameklab.ui.mek;
+
+import megamek.common.*;
+import megamek.common.util.EncodeControl;
+import megameklab.ui.EntitySource;
+import megameklab.ui.listeners.MekBuildListener;
+import megameklab.ui.util.IView;
+import megameklab.util.UnitUtil;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+/**
+ * This view block allows entering additional fuel tanks for LandAirMeks
+ *
+ * @author Simon (Juliez)
+ */
+public class BMLAMFuelView extends IView implements ChangeListener {
+
+    private static final EquipmentType FUEL_TANK = MiscType.get(EquipmentTypeLookup.LAM_FUEL_TANK);
+
+    private final List<MekBuildListener> listeners = new CopyOnWriteArrayList<>();
+    public void addListener(MekBuildListener l) {
+        listeners.add(l);
+    }
+    public void removeListener(MekBuildListener l) {
+        listeners.remove(l);
+    }
+
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+    private final SpinnerNumberModel fuelTonsSpnModel = new SpinnerNumberModel(0, 0, 84, 1);
+    private final JSpinner fuelTonsSpn = new JSpinner(fuelTonsSpnModel);
+    private final JLabel totalFuelPointsLabel = new JLabel();
+
+    public BMLAMFuelView(EntitySource entitySource) {
+        super(entitySource);
+        initUI();
+    }
+
+    private void initUI() {
+        setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
+
+        fuelTonsSpn.setToolTipText(resourceMap.getString("BMLAMFuelView.lblFuelPoints.tooltip"));
+        fuelTonsSpn.addChangeListener(this);
+
+        Box fuelRangePanel = Box.createHorizontalBox();
+        fuelRangePanel.add(Box.createHorizontalStrut(10));
+        fuelRangePanel.add(new JLabel(resourceMap.getString("BMLAMFuelView.spnFuel.text")));
+        fuelRangePanel.add(Box.createHorizontalStrut(10));
+        fuelRangePanel.add(fuelTonsSpn);
+        fuelRangePanel.add(new JLabel(" tons"));
+        fuelRangePanel.add(Box.createHorizontalStrut(10));
+        fuelRangePanel.setBorder(new EmptyBorder(0, 0, 10, 0));
+        JPanel totalPointsPanel = new JPanel();
+        totalPointsPanel.add(totalFuelPointsLabel);
+
+        add(fuelRangePanel);
+        add(totalPointsPanel);
+        add(Box.createVerticalStrut(5));
+    }
+
+    public void setFromEntity(Mech mek) {
+        fuelTonsSpnModel.setValue(fuelTanks(mek));
+        updateFuelPointsLabel();
+    }
+
+    /** Returns the current number of LAM Fuel Tanks on the Mek, including unallocated. Returns 0 for non-LAM. */
+    private int fuelTanks(Mech mek) {
+        return (mek instanceof LandAirMech) ? mek.countWorkingMisc(EquipmentTypeLookup.LAM_FUEL_TANK, -1) : 0;
+    }
+
+    private void updateFuelPointsLabel() {
+        totalFuelPointsLabel.setText(resourceMap.getString("BMLAMFuelView.totalFuelLabel.text")
+                + (80 * (1 + fuelTanks(getMech()))));
+    }
+
+    @Override
+    public void stateChanged(ChangeEvent e) {
+        if (e.getSource() == fuelTonsSpn) {
+            int currentTanks = fuelTanks(getMech());
+            int newTanks = (int) fuelTonsSpn.getValue();
+            if (newTanks > currentTanks) {
+                addTanks(newTanks - currentTanks);
+            } else {
+                deleteTanks(currentTanks - newTanks);
+            }
+            updateFuelPointsLabel();
+            listeners.forEach(l -> l.engineChanged(getMech().getEngine()));
+        }
+    }
+
+    private void deleteTanks(int number) {
+        // Remove unallocated fuel tanks first
+        List<Mounted> fuelTanks = getMech().getMisc().stream()
+                .filter(mounted -> mounted.getType().equals(FUEL_TANK))
+                .filter(mounted -> mounted.getLocation() == Entity.LOC_NONE)
+                .collect(Collectors.toList());
+        for (Mounted fuelTank : fuelTanks) {
+            if (number > 0) {
+                UnitUtil.removeMounted(getMech(), fuelTank);
+                number--;
+            } else {
+                return;
+            }
+        }
+        // Must remove more, so take allocated fuel tanks
+        fuelTanks = getMech().getMisc().stream()
+                .filter(mounted -> mounted.getType().equals(FUEL_TANK))
+                .collect(Collectors.toList());
+        for (Mounted fuelTank : fuelTanks) {
+            if (number > 0) {
+                UnitUtil.removeMounted(getMech(), fuelTank);
+                number--;
+            } else {
+                return;
+            }
+        }
+    }
+
+    private void addTanks(int number) {
+        for (int i = 0; i < number; i++) {
+            try {
+                Mounted mount = new Mounted(getMech(), FUEL_TANK);
+                getMech().addEquipment(mount, Entity.LOC_NONE, false);
+            } catch (LocationFullException ignored) {
+                // this can't happen, we add to Entity.LOC_NONE
+            }
+        }
+    }
+
+}

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 public class BMStructureTab extends ITab implements MekBuildListener, ArmorAllocationListener {
     private BasicInfoView panBasicInfo;
     private BMChassisView panChassis;
+    private BMLAMFuelView panLAMFuel;
     private MVFArmorView panArmor;
     private MovementView panMovement;
     private HeatSinkView panHeat;
@@ -62,6 +63,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         panArmor = new MVFArmorView(panBasicInfo);
         panMovement = new MovementView(panBasicInfo);
         panHeat = new HeatSinkView(panBasicInfo);
+        panLAMFuel = new BMLAMFuelView(eSource);
         panArmorAllocation = new ArmorAllocationView(panBasicInfo, Entity.ETYPE_MECH);
         panPatchwork = new PatchworkArmorView(panBasicInfo);
         panSummary = new BMSummaryView(eSource);
@@ -95,12 +97,17 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         leftPanel.add(panHeat);
         leftPanel.add(Box.createGlue());
 
-        centerPanel.add(panArmor);
-        centerPanel.add(panMovement);       
+        centerPanel.add(panMovement);
+        leftPanel.add(Box.createVerticalStrut(11));
+        centerPanel.add(panLAMFuel);
+        leftPanel.add(Box.createVerticalStrut(11));
         centerPanel.add(panSummary);
         centerPanel.add(Box.createVerticalGlue());
 
+        rightPanel.add(panArmor);
+        leftPanel.add(Box.createVerticalStrut(11));
         rightPanel.add(panArmorAllocation);
+        leftPanel.add(Box.createVerticalStrut(11));
         rightPanel.add(panPatchwork);
         rightPanel.add(Box.createVerticalGlue());
 
@@ -121,6 +128,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         panChassis.setBorder(BorderFactory.createTitledBorder("Chassis"));
         panMovement.setBorder(BorderFactory.createTitledBorder("Movement"));
         panHeat.setBorder(BorderFactory.createTitledBorder("Heat Sinks"));
+        panLAMFuel.setBorder(BorderFactory.createTitledBorder("Fuel"));
         panArmor.setBorder(BorderFactory.createTitledBorder("Armor"));
         panSummary.setBorder(BorderFactory.createTitledBorder("Summary"));
         panArmorAllocation.setBorder(BorderFactory.createTitledBorder("Armor Allocation"));
@@ -136,7 +144,8 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         panMovement.setFromEntity(getMech());
         panArmorAllocation.setFromEntity(getMech());
         panPatchwork.setFromEntity(getMech());
-
+        panLAMFuel.setFromEntity(getMech());
+        panLAMFuel.setVisible(getMech() instanceof LandAirMech);
         panSummary.refresh();
         addAllListeners();
     }
@@ -401,6 +410,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         panMovement.removeListener(this);
         panArmorAllocation.removeListener(this);
         panPatchwork.removeListener(this);
+        panLAMFuel.removeListener(this);
     }
 
     public void addAllListeners() {
@@ -411,6 +421,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         panMovement.addListener(this);
         panArmorAllocation.addListener(this);
         panPatchwork.addListener(this);
+        panLAMFuel.addListener(this);
     }
 
     public void addRefreshedListener(RefreshListener l) {

--- a/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
@@ -75,6 +75,7 @@ public enum EquipmentDatabaseCategory {
                     && !UnitUtil.isJumpJet(eq)
                     && !UnitUtil.isHeatSink(eq)
                     && !(isIndustrialEquipment(eq) && ((en instanceof Tank) || en.isSupportVehicle() || en instanceof Mech))
+                    && !eq.isAnyOf(LAM_FUEL_TANK)
                     && !eq.hasFlag(F_TSM)
                     && !eq.hasFlag(F_INDUSTRIAL_TSM)
                     && !(eq.hasFlag(F_MASC)

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -2804,17 +2804,15 @@ public class UnitUtil {
         if ((eq instanceof CLTAG) || (eq instanceof ISC3MBS)
                 || (eq instanceof ISC3M) || (eq instanceof ISTAG)
                 || (eq instanceof AmmoType && ((AmmoType) eq).getAmmoType() == AmmoType.T_COOLANT_POD)
-                || (eq instanceof CLLightTAG)
-                || (eq instanceof ISAMS)
-                || (eq instanceof CLAMS)
-                || (eq instanceof ISLaserAMS)
-                || (eq instanceof CLLaserAMS)
-                || (eq instanceof ISAPDS )) {
+                || (eq instanceof CLLightTAG) || (eq instanceof ISAMS)
+                || (eq instanceof CLAMS) || (eq instanceof ISLaserAMS)
+                || (eq instanceof CLLaserAMS) || (eq instanceof ISAPDS)) {
             return true;
         }
 
         if ((eq instanceof MiscType)) {
-            if (eq.hasFlag(MiscType.F_BOMB_BAY) && !(unit instanceof LandAirMech)) {
+            if (eq.isAnyOf(EquipmentTypeLookup.LAM_FUEL_TANK, EquipmentTypeLookup.LAM_BOMB_BAY)
+                    && !(unit instanceof LandAirMech)) {
                 return false;
             }
             if ((eq.hasFlag(MiscType.F_QUAD_TURRET) || eq.hasFlag(MiscType.F_RAM_PLATE))


### PR DESCRIPTION
Fixes #927 
Requires MM 3492

Adds an entry box for the amount of additional fuel a LAM carries. Changing the amount adds or removes 1 crit/1 ton Fuel equipment entries in the Equipment view that have to be placed in crit slots.
![image](https://user-images.githubusercontent.com/17069663/156937243-eb84274b-0d32-4065-b901-752d98de05b2.png)
