### PR TITLE
Issue 1062: Reenable BA clamps in equipment DB

### DIFF
--- a/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
@@ -84,7 +84,7 @@ public enum EquipmentDatabaseCategory {
                     && !UnitUtil.isArmorOrStructure(eq)
                     && !(eq.hasFlag(F_CHASSIS_MODIFICATION) && en.isSupportVehicle())
                     && !(en.isSupportVehicle() && (eq.hasFlag(F_BASIC_FIRECONTROL) || (eq.hasFlag(F_ADVANCED_FIRECONTROL))))
-                    && !eq.hasFlag(F_MAGNETIC_CLAMP)
+                    && !(eq.hasFlag(F_MAGNETIC_CLAMP) && en.hasETypeFlag(Entity.ETYPE_PROTOMECH))
                     && !(eq.hasFlag(F_PARTIAL_WING) && en.hasETypeFlag(Entity.ETYPE_PROTOMECH))
                     && !(eq.hasFlag(F_SPONSON_TURRET) && en.isSupportVehicle())
                     && !eq.hasFlag(F_PINTLE_TURRET))


### PR DESCRIPTION
Fixes #1062 
PM allow adding clamps in their Structure tab and don't need them in the Equipment DB.