### PR TITLE
Show dry cost in Status bar and full cost in tooltip

### DIFF
--- a/megameklab/src/megameklab/ui/battleArmor/BAStatusBar.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAStatusBar.java
@@ -103,7 +103,6 @@ public class BAStatusBar extends ITab {
         final double maxKilos = getBattleArmor().getTrooperWeight() * 1000;
         double currentKilos;
         final int bv = getBattleArmor().calculateBattleValue();
-        final long currentCost = Math.round(getBattleArmor().getCost(false));
 
         TestBattleArmor testBA = new TestBattleArmor(getBattleArmor(), entityVerifier.baOption,
                 null);
@@ -126,7 +125,10 @@ public class BAStatusBar extends ITab {
         move.setText("Movement: " + walk + "/" + jump);
         move.setToolTipText("Walk/Jump MP");
 
-        cost.setText("Squad Cost: " + formatter.format(currentCost) + " C-bills");
+        cost.setText("Dry Cost: " + formatter.format(Math.round(getEntity().getCost(true))) + " C-bills");
+        cost.setToolTipText("The dry cost of the unit (without ammo). The unit's full cost is "
+                + formatter.format(Math.round(getEntity().getCost(false))) + " C-bills.");
+
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testBA.correctEntity(sb));
         invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");

--- a/megameklab/src/megameklab/ui/combatVehicle/CVStatusBar.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVStatusBar.java
@@ -134,7 +134,6 @@ public class CVStatusBar extends ITab {
         currentTonnage = testEntity.calculateWeight();
 
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getTank());
-        long currentCost = Math.round(getTank().getCost(false));
 
         tons.setText(String.format("Tonnage: %.1f/%.1f (%.1f Remaining)", currentTonnage, tonnage, tonnage - currentTonnage));
         tons.setToolTipText("Current Tonnage/Max Tonnage");
@@ -155,7 +154,9 @@ public class CVStatusBar extends ITab {
         bvLabel.setText("BV: " + bv);
         bvLabel.setToolTipText("BV 2.0");
 
-        cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        cost.setText("Dry Cost: " + formatter.format(Math.round(getEntity().getCost(true))) + " C-bills");
+        cost.setToolTipText("The dry cost of the unit (without ammo). The unit's full cost is "
+                + formatter.format(Math.round(getEntity().getCost(false))) + " C-bills.");
 
         move.setText("Movement: " + walk + "/" + run + "/" + jump);
         move.setToolTipText("Walk/Run/Jump MP");

--- a/megameklab/src/megameklab/ui/fighterAero/ASStatusBar.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASStatusBar.java
@@ -78,7 +78,6 @@ public class ASStatusBar extends ITab {
         double tonnage = getAero().getWeight();
         double currentTonnage;
         int bv = getAero().calculateBattleValue();
-        long currentCost = Math.round(getAero().getCost(false));
 
         TestAero testAero = new TestAero(getAero(), entityVerifier.aeroOption, null);
 
@@ -107,7 +106,10 @@ public class ASStatusBar extends ITab {
         bvLabel.setText("BV: " + bv);
         bvLabel.setToolTipText("BV 2.0");
 
-        cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        cost.setText("Dry Cost: " + formatter.format(Math.round(getEntity().getCost(true))) + " C-bills");
+        cost.setToolTipText("The dry cost of the unit (without ammo). The unit's full cost is "
+                + formatter.format(Math.round(getEntity().getCost(false))) + " C-bills.");
+
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testAero.correctEntity(sb));
         invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");

--- a/megameklab/src/megameklab/ui/infantry/CIStatusBar.java
+++ b/megameklab/src/megameklab/ui/infantry/CIStatusBar.java
@@ -83,7 +83,6 @@ public class CIStatusBar extends ITab {
         DecimalFormat roundFormat = new DecimalFormat("#.##");
         double currentTonnage;
         int bv = getInfantry().calculateBattleValue();
-        long currentCost = Math.round(getInfantry().getCost(false));
 
         currentTonnage = getInfantry().getWeight();
 
@@ -96,7 +95,10 @@ public class CIStatusBar extends ITab {
         bvLabel.setText("BV: " + bv);
         bvLabel.setToolTipText("BV 2.0");
 
-        cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        cost.setText("Dry Cost: " + formatter.format(Math.round(getEntity().getCost(true))) + " C-bills");
+        cost.setToolTipText("The dry cost of the unit (without ammo). The unit's full cost is "
+                + formatter.format(Math.round(getEntity().getCost(false))) + " C-bills.");
+
         String str = UnitUtil.validateUnit(getInfantry());
         invalid.setVisible(!str.isEmpty());
         invalid.setToolTipText("<html>" + str.replaceAll("\n", "<br/>") + "</html>");

--- a/megameklab/src/megameklab/ui/largeAero/DSStatusBar.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSStatusBar.java
@@ -82,7 +82,6 @@ public class DSStatusBar extends ITab {
         double tonnage = getSmallCraft().getWeight();
         double currentTonnage;
         int bv = getSmallCraft().calculateBattleValue();
-        long currentCost = Math.round(getSmallCraft().getCost(false));
 
         TestSmallCraft testSmallCraft = new TestSmallCraft(getSmallCraft(), entityVerifier.aeroOption, null);
 
@@ -111,7 +110,10 @@ public class DSStatusBar extends ITab {
         bvLabel.setText("BV: " + bv);
         bvLabel.setToolTipText("BV 2.0");
 
-        cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        cost.setText("Dry Cost: " + formatter.format(Math.round(getEntity().getCost(true))) + " C-bills");
+        cost.setToolTipText("The dry cost of the unit (without ammo). The unit's full cost is "
+                + formatter.format(Math.round(getEntity().getCost(false))) + " C-bills.");
+
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testSmallCraft.correctEntity(sb));
         invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");

--- a/megameklab/src/megameklab/ui/largeAero/WSStatusBar.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSStatusBar.java
@@ -84,8 +84,7 @@ public class WSStatusBar extends ITab {
         double tonnage = getJumpship().getWeight();
         double currentTonnage;
         int bv = getJumpship().calculateBattleValue();
-        long currentCost = Math.round(getJumpship().getCost(false));
-        
+
         TestAdvancedAerospace testAdvAero = new TestAdvancedAerospace(getJumpship(), entityVerifier.aeroOption, null);
         currentTonnage = testAdvAero.calculateWeight();
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getJumpship());
@@ -116,7 +115,10 @@ public class WSStatusBar extends ITab {
         bvLabel.setText("BV: " + bv);
         bvLabel.setToolTipText("BV 2.0");
 
-        cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        cost.setText("Dry Cost: " + formatter.format(Math.round(getEntity().getCost(true))) + " C-bills");
+        cost.setToolTipText("The dry cost of the unit (without ammo). The unit's full cost is "
+                + formatter.format(Math.round(getEntity().getCost(false))) + " C-bills.");
+
         StringBuffer sb = new StringBuffer();
         invalid.setVisible(!testAdvAero.correctEntity(sb));
         invalid.setToolTipText("<html>" + sb.toString().replaceAll("\n", "<br/>") + "</html>");

--- a/megameklab/src/megameklab/ui/mek/BMStatusBar.java
+++ b/megameklab/src/megameklab/ui/mek/BMStatusBar.java
@@ -88,7 +88,6 @@ public class BMStatusBar extends ITab {
             maxCrits = 78;
         }
         int currentCrits = UnitUtil.countUsedCriticals(getMech());
-        long currentCost = Math.round(getMech().getCost(false));
 
         testEntity = new TestMech(getMech(), entityVerifier.mechOption, null);
 
@@ -106,7 +105,9 @@ public class BMStatusBar extends ITab {
         bvLabel.setText("BV: " + bv);
         bvLabel.setToolTipText("BV 2.0");
 
-        cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        cost.setText("Dry Cost: " + formatter.format(Math.round(getEntity().getCost(true))) + " C-bills");
+        cost.setToolTipText("The dry cost of the unit (without ammo). The unit's full cost is "
+                + formatter.format(Math.round(getEntity().getCost(false))) + " C-bills.");
 
         crits.setText("Criticals: " +  currentCrits + " / " + maxCrits);
         crits.setForeground(currentCrits > maxCrits ? GUIPreferences.getInstance().getWarningColor() : null);

--- a/megameklab/src/megameklab/ui/protoMek/PMStatusBar.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMStatusBar.java
@@ -84,7 +84,6 @@ public class PMStatusBar extends ITab {
         }
         long currentCrits = getProtomech().getEquipment().stream()
                 .filter(m -> TestProtomech.requiresSlot(m.getType())).count();
-        long currentCost = Math.round(getProtomech().getCost(false));
 
         currentTonnage = testEntity.calculateWeight() * 1000;
 
@@ -99,7 +98,9 @@ public class PMStatusBar extends ITab {
         bvLabel.setText("BV: " + bv);
         bvLabel.setToolTipText("BV 2.0");
 
-        cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        cost.setText("Dry Cost: " + formatter.format(Math.round(getEntity().getCost(true))) + " C-bills");
+        cost.setToolTipText("The dry cost of the unit (without ammo). The unit's full cost is "
+                + formatter.format(Math.round(getEntity().getCost(false))) + " C-bills.");
 
         crits.setText("Criticals: " +  currentCrits + "/" + maxCrits);
         if(currentCrits > maxCrits) {

--- a/megameklab/src/megameklab/ui/supportVehicle/SVStatusBar.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVStatusBar.java
@@ -131,7 +131,6 @@ class SVStatusBar extends ITab {
         currentTonnage = testEntity.calculateWeight();
 
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(eSource.getEntity());
-        long currentCost = Math.round(eSource.getEntity().getCost(false));
 
         if (eSource.getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
             tons.setText(String.format("Tonnage: %.0f/%.0f (%.0f Remaining)",
@@ -158,7 +157,9 @@ class SVStatusBar extends ITab {
         bvLabel.setText("BV: " + bv);
         bvLabel.setToolTipText("BV 2.0");
 
-        cost.setText("Cost: " + formatter.format(currentCost) + " C-bills");
+        cost.setText("Dry Cost: " + formatter.format(Math.round(getEntity().getCost(true))) + " C-bills");
+        cost.setToolTipText("The dry cost of the unit (without ammo). The unit's full cost is "
+                + formatter.format(Math.round(getEntity().getCost(false))) + " C-bills.");
 
         move.setText("Movement: " + walk + "/" + run + "/" + jump);
         move.setToolTipText("Walk/Run/Jump MP");


### PR DESCRIPTION
Updates MML's status bars to display the dry unit cost (without ammo) instead of the full cost as "Dry cost: 123,346 C-bills". The full cost is now shown in the tooltip. The dry cost is already shown in the cost breakdown.

![image](https://user-images.githubusercontent.com/17069663/159132606-7b0e3055-eb0c-4a07-ae22-4911cb0a6608.png)

Im not sure if there can be a difference between dry and full for conventional infantry and there's a bug with BA costs (or at least the cost breakdown text). So I've just made that change for all unit types. The worst that can happen is that there's no difference.