### PR TITLE
Fixing BuildView createLabel Missing Tooltips

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -391,7 +391,7 @@ SVChassisView.spnFireConWt.tooltip=The weight of the fire control systems must b
 SVChassisView.btnResetChassis.text=Reset Chassis
 SVChassisView.btnResetChassis.tooltip=Remove all pod-mounted equipment to strip unit down to base omni chassis.
 
-SVCrewView.lbMinimumCrew.text=Minimum Crew
+SVCrewView.lblMinimumCrew.text=Minimum Crew
 SVCrewView.txtReqBaseCrew.text=Base Crew:
 SVCrewView.txtReqBaseCrew.tooltip=Minimum base crew is determined by vehicle type and weight class.
 SVCrewView.txtReqGunners.text=Gunners:

--- a/megameklab/src/megameklab/ui/battleArmor/BAChassisView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAChassisView.java
@@ -80,12 +80,13 @@ public class BAChassisView extends BuildView implements ActionListener, ChangeLi
         setLayout(new GridBagLayout());
         
         GridBagConstraints gbc = new GridBagConstraints();
-        gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.anchor = GridBagConstraints.WEST;
 
         gbc.gridx = 0;
         gbc.gridy = 0;
-        add(createLabel(resourceMap.getString("BAChassisView.cbChassisType.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblChassisType", "BAChassisView.cbChassisType.text",
+                "BAChassisView.cbChassisType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(cbChassisType, controlSize);
         cbChassisType.setToolTipText(resourceMap.getString("BAChassisView.cbChassisType.tooltip"));
@@ -94,7 +95,8 @@ public class BAChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("BAChassisView.cbWeightClass.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblWeightClass", "BAChassisView.cbWeightClass.text",
+                "BAChassisView.cbWeightClass.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(cbWeightClass, controlSize);
         cbWeightClass.setToolTipText(resourceMap.getString("BAChassisView.cbWeightClass.tooltip"));
@@ -103,7 +105,8 @@ public class BAChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("BAChassisView.spnSquadSize.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblSquadSize", "BAChassisView.spnSquadSize.text",
+                "BAChassisView.spnSquadSize.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(spnSquadSize, controlSize);
         spnSquadSize.setToolTipText(resourceMap.getString("BAChassisView.spnSquadSize.tooltip"));
@@ -112,7 +115,8 @@ public class BAChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("BAChassisView.cbTurretType.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTurretType", "BAChassisView.cbTurretType.text",
+                "BAChassisView.cbTurretType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(cbTurretType, controlSize);
         cbTurretType.setToolTipText(resourceMap.getString("BAChassisView.cbTurretType.tooltip"));
@@ -121,7 +125,8 @@ public class BAChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("BAChassisView.spnTurretSize.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTurretSize", "BAChassisView.spnTurretSize.text",
+                "BAChassisView.spnTurretSize.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(spnTurretSize, controlSize);
         spnTurretSize.setToolTipText(resourceMap.getString("BAChassisView.spnTurretSize.tooltip"));
@@ -142,7 +147,6 @@ public class BAChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridy++;
         gbc.gridwidth = 2;
         add(chassisOptions, gbc);
-                
     }
     
     public void setFromEntity(BattleArmor ba) {

--- a/megameklab/src/megameklab/ui/combatVehicle/CVChassisView.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVChassisView.java
@@ -118,9 +118,10 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridy = 0;
-        gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("CVChassisView.spnTonnage.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTonnage", "CVChassisView.spnTonnage.text",
+                "CVChassisView.spnTonnage.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 0;
         setFieldSize(spnTonnage, spinnerSize);
@@ -158,7 +159,8 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
 
         cbMotiveType.setModel(new DefaultComboBoxModel<>(MOTIVE_TYPES));
         gbc.gridx = 0;
-        add(createLabel(resourceMap.getString("CVChassisView.cbMotiveType.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblMotiveType", "CVChassisView.cbMotiveType.text",
+                "CVChassisView.cbMotiveType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 3;
         setFieldSize(cbMotiveType, controlSize);
@@ -169,7 +171,8 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("CVChassisView.cbEngine.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblEngine", "CVChassisView.cbEngine.text",
+                "CVChassisView.cbEngine.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 3;
         setFieldSize(cbEngine, controlSize);
@@ -180,7 +183,8 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridwidth = 2;
-        add(createLabel(resourceMap.getString("CVChassisView.spnExtraSeats.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblExtraSeats", "CVChassisView.spnExtraSeats.text",
+                "CVChassisView.spnExtraSeats.tooltip", labelSize), gbc);
         gbc.gridx = 2;
         gbc.gridwidth = 2;
         setFieldSize(spnExtraSeats, spinnerSize);
@@ -191,7 +195,8 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("CVChassisView.cbTurrets.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTurrets", "CVChassisView.cbTurrets.text",
+                "CVChassisView.cbTurrets.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 3;
         setFieldSize(cbTurrets, controlSize);
@@ -202,7 +207,8 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridwidth = 3;
-        JLabel lbl = createLabel(resourceMap.getString("CVChassisView.spnTurretWt.text"), labelSize);
+        JLabel lbl = createLabel(resourceMap, "lblTurretWt", "CVChassisView.spnTurretWt.text",
+                "CVChassisView.spnTurretWt.tooltip", labelSize);
         add(lbl, gbc);
         gbc.gridx = 3;
         setFieldSize(spnChassisTurretWt, spinnerSize);
@@ -215,7 +221,8 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridwidth = 3;
-        lbl = createLabel(resourceMap.getString("CVChassisView.spnTurret2Wt.text"), labelSize);
+        lbl = createLabel(resourceMap, "lblTurret2Wt", "CVChassisView.spnTurret2Wt.text",
+                "CVChassisView.spnTurret2Wt.tooltip", labelSize);
         add(lbl, gbc);
         gbc.gridx = 3;
         gbc.gridwidth = 1;
@@ -452,17 +459,12 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
 
     /**
      * The turret configuration should be one of {@link CVChassisView#TURRET_NONE TURRET_NONE},
-     * {@link CVChassisView#TURRET_SINGLE TURRET_SINGLE}, {@link CVChassisView#TURRET_DUAL TURRET_DUAL}, or
-     * {@link CVChassisView#TURRET_CHIN TURRET_CHIN}.
+     * {@link CVChassisView#TURRET_SINGLE TURRET_SINGLE}, {@link CVChassisView#TURRET_DUAL TURRET_DUAL},
+     * or {@link CVChassisView#TURRET_CHIN TURRET_CHIN}.
      * @return The currently selected turret configuration.
      */
     public int getTurretConfiguration() {
-        Integer config = (Integer) cbTurrets.getSelectedItem();
-        if (config == null) {
-            return TURRET_NONE; // Failsafe in case this gets called while in an indeterminate state
-        } else {
-            return config;
-        }
+        return Objects.requireNonNullElse((Integer) cbTurrets.getSelectedItem(), TURRET_NONE);
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/combatVehicle/CVTransportView.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVTransportView.java
@@ -22,8 +22,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import javax.swing.JSpinner;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -74,17 +73,18 @@ public class CVTransportView extends BuildView implements ChangeListener {
 
         gbc.gridx = 1;
         gbc.gridy = 0;
-        gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("CVTransportView.lblFixed.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblFixed", "CVTransportView.lblFixed.text", labelSize), gbc);
+
         gbc.gridx = 2;
         gbc.gridy = 0;
-        add(createLabel(resourceMap.getString("CVTransportView.lblPod.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblPod", "CVTransportView.lblPod.text", labelSize), gbc);
 
         gbc.gridx = 0;
         gbc.gridy = 1;
-        add(createLabel(resourceMap.getString("CVTransportView.lblTroopSpace.text"), labelSizeLg), gbc);
-        
+        add(createLabel(resourceMap, "lblTroopSpace", "CVTransportView.lblTroopSpace.text", labelSize), gbc);
+
         gbc.gridx = 1;
         setFieldSize(spnFixedTroop, editorSize);
         add(spnFixedTroop, gbc);
@@ -103,7 +103,9 @@ public class CVTransportView extends BuildView implements ChangeListener {
                     1 / bayType.getWeight());
             gbc.gridx = 0;
             gbc.gridy++;
-            add(createLabel(bayType.getDisplayName(), labelSizeLg), gbc);
+            final JLabel lblBayType = createLabel("lbl" + bayType.name(), bayType.getDisplayName(), labelSizeLg);
+            lblBayType.setToolTipText(tooltip);
+            add(lblBayType, gbc);
             
             gbc.gridx = 1;
             SpinnerNumberModel model = new SpinnerNumberModel(0.0, 0.0, null, 0.5);

--- a/megameklab/src/megameklab/ui/fighterAero/ASChassisView.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASChassisView.java
@@ -93,7 +93,8 @@ public class ASChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridy = 0;
-        add(createLabel(resourceMap.getString("FighterChassisView.spnTonnage.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTonnage", "FighterChassisView.spnTonnage.text",
+                "FighterChassisView.spnTonnage.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 0;
         setFieldSize(spnTonnage, spinnerSize);
@@ -113,7 +114,8 @@ public class ASChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridy = 1;
         gbc.gridwidth = 1;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("FighterChassisView.txtSI.text"), labelSize),gbc);
+        add(createLabel(resourceMap, "lblSI", "FighterChassisView.txtSI.text",
+                "FighterChassisView.txtSI.tooltip", labelSize), gbc);
         setFieldSize(txtSI, editorSize);
         txtSI.setToolTipText(resourceMap.getString("FighterChassisView.txtSI.tooltip"));
         txtSI.setEditable(false);
@@ -131,7 +133,8 @@ public class ASChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 2;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("FighterChassisView.cbFighterType.text"), labelSize),gbc);
+        add(createLabel(resourceMap, "lblFighterType", "FighterChassisView.cbFighterType.text",
+                "FighterChassisView.cbFighterType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 2;
         gbc.gridwidth = 3;
@@ -143,7 +146,8 @@ public class ASChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 3;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("FighterChassisView.cbEngine.text"), labelSize),gbc);
+        add(createLabel(resourceMap, "lblEngine", "FighterChassisView.cbEngine.text",
+                "FighterChassisView.cbEngine.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 3;
         gbc.gridwidth = 3;
@@ -156,7 +160,8 @@ public class ASChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 4;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("FighterChassisView.cbCockpit.text"), labelSize),gbc);
+        add(createLabel(resourceMap, "lblCockpit", "FighterChassisView.cbCockpit.text",
+                "FighterChassisView.cbCockpit.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 4;
         gbc.gridwidth = 3;

--- a/megameklab/src/megameklab/ui/generalUnit/BAProtoArmorView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BAProtoArmorView.java
@@ -1,5 +1,5 @@
 /*
- * MegaMekLab - Copyright (C) 2017 - The MegaMek Team
+ * Copyright (c) 2017-2022 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -13,34 +13,24 @@
  */
 package megameklab.ui.generalUnit;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import megamek.common.util.EncodeControl;
+import megamek.common.verifier.TestProtomech;
+import megameklab.ui.listeners.ArmorAllocationListener;
+import megameklab.ui.util.TechComboBox;
+import megameklab.util.UnitUtil;
+
+import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import javax.swing.JButton;
-import javax.swing.JSpinner;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-
-import megamek.common.BattleArmor;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.MiscType;
-import megamek.common.Protomech;
-import megamek.common.TechConstants;
-import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
-import megamek.common.verifier.TestProtomech;
-import megameklab.ui.util.TechComboBox;
-import megameklab.ui.listeners.ArmorAllocationListener;
-import megameklab.util.UnitUtil;
 
 /**
  * Structure table armor panel for units that allocate armor by point instead of ton.
@@ -59,7 +49,7 @@ public class BAProtoArmorView extends BuildView implements ActionListener, Chang
     private final static String CMD_MAXIMIZE  = "MAXIMIZE";
     private final static String CMD_REMAINING = "REMAINING";
     
-    private final TechComboBox<EquipmentType> cbArmorType = new TechComboBox<>(eq -> eq.getName());
+    private final TechComboBox<EquipmentType> cbArmorType = new TechComboBox<>(EquipmentType::getName);
     private final SpinnerNumberModel spnArmorPointsModel = new SpinnerNumberModel(0, 0, null, 1);
     private final JSpinner spnArmorPoints = new JSpinner(spnArmorPointsModel);
     private final JButton btnMaximize = new JButton();
@@ -81,7 +71,8 @@ public class BAProtoArmorView extends BuildView implements ActionListener, Chang
         gbc.gridx = 0;
         gbc.gridy = 0;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("ArmorView.cbArmorType.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblArmorType", "ArmorView.cbArmorType.text",
+                "ArmorView.cbArmorType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 0;
         gbc.gridwidth = 2;
@@ -93,7 +84,8 @@ public class BAProtoArmorView extends BuildView implements ActionListener, Chang
         gbc.gridx = 0;
         gbc.gridy = 1;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("ArmorView.spnArmorPoints.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblArmorPoints", "ArmorView.spnArmorPoints.text",
+                "ArmorView.spnArmorPoints.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 1;
         setFieldSize(spnArmorPoints.getEditor(), editorSize);

--- a/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
@@ -215,9 +215,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     }
 
     public void setAsCustomization() {
-        txtChassis.setEditable(false);
         txtChassis.setEnabled(false);
-        txtYear.setEditable(false);
         txtYear.setEnabled(false);
     }
 

--- a/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
@@ -58,12 +58,12 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     private final JTextField txtModel = new JTextField(5);
     private final IntRangeTextField txtYear = new IntRangeTextField(3);
     private final FactionComboBox cbFaction = new FactionComboBox();
-    private final JLabel lblFaction = createLabel("", labelSize);
+    private final JLabel lblFaction = createLabel("lblFaction", "", labelSize);
     private final JTextField txtSource = new JTextField(3);
     private final CustomComboBox<Integer> cbTechBase = new CustomComboBox<>(i -> String.valueOf(techBaseNames[i]));
     private final JComboBox<SimpleTechLevel> cbTechLevel = new JComboBox<>();
     private final IntRangeTextField txtManualBV = new IntRangeTextField(3);
-    private final JLabel lblMulId = createLabel("", labelSize);
+    private final JLabel lblMulId = createLabel("lblMulId", "", labelSize);
     private final IntRangeTextField txtMulId = new IntRangeTextField(8);
     private final JButton browseMul = new JButton("Open MUL in Browser");
 
@@ -90,7 +90,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.anchor = GridBagConstraints.WEST;
         gbc.insets = new Insets(0, 0, 1, 2);
-        add(createLabel(resourceMap.getString("BasicInfoView.txtChassis.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblChassis", "BasicInfoView.txtChassis.text",
+                "BasicInfoView.txtChassis.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         txtChassis.setToolTipText(resourceMap.getString("BasicInfoView.txtChassis.tooltip"));
         add(txtChassis, gbc);
@@ -99,7 +100,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
 
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("BasicInfoView.txtModel.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblModel", "BasicInfoView.txtModel.text",
+                "BasicInfoView.txtModel.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         txtModel.setToolTipText(resourceMap.getString("BasicInfoView.txtModel.tooltip"));
         add(txtModel, gbc);
@@ -128,7 +130,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
 
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("BasicInfoView.txtYear.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblYear", "BasicInfoView.txtYear.text",
+                "BasicInfoView.txtYear.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         add(txtYear, gbc);
         txtYear.setToolTipText(resourceMap.getString("BasicInfoView.txtYear.tooltip"));
@@ -148,7 +151,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
 
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("BasicInfoView.txtSource.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblSource", "BasicInfoView.txtSource.text",
+                "BasicInfoView.txtSource.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(txtSource, controlSize);
         txtSource.setToolTipText(resourceMap.getString("BasicInfoView.txtSource.tooltip"));
@@ -157,7 +161,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
 
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("BasicInfoView.cbTechBase.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTechBase", "BasicInfoView.cbTechBase.text",
+                "BasicInfoView.cbTechBase.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(cbTechBase, controlSize);
         cbTechBase.setToolTipText(resourceMap.getString("BasicInfoView.cbTechBase.tooltip"));
@@ -166,7 +171,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
 
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("BasicInfoView.cbTechLevel.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTechLevel", "BasicInfoView.cbTechLevel.text",
+                "BasicInfoView.cbTechLevel.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(cbTechLevel, controlSize);
         cbTechLevel.setToolTipText(resourceMap.getString("BasicInfoView.cbTechLevel.tooltip"));
@@ -176,7 +182,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
 
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("BasicInfoView.txtManualBV.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblManualBV", "BasicInfoView.txtManualBV.text",
+                "BasicInfoView.txtManualBV.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(txtManualBV, controlSize);
         txtManualBV.setToolTipText(resourceMap.getString("BasicInfoView.txtManualBV.tooltip"));

--- a/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
@@ -1,5 +1,5 @@
 /*
- * MegaMekLab - Copyright (C) 2017 - The MegaMek Team
+ * Copyright (c) 2017-2022 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -40,30 +40,20 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * @author Neoancient
  */
 public class BasicInfoView extends BuildView implements ITechManager, ActionListener, FocusListener {
-    
-    private final List<BuildListener> listeners = new CopyOnWriteArrayList<>();
-    public void addListener(BuildListener l) {
-        if (null != l) {
-            listeners.add(l);
-        }
-    }
-    public void removeListener(BuildListener l) {
-        listeners.remove(l);
-    }
-    
+    //region Variable Declarations
     private static final TechAdvancement TA_MIXED_TECH = Entity.getMixedTechAdvancement();
     private static final int CLAN_START = 2807;
     private static final int IS_MIXED_START = TA_MIXED_TECH.getIntroductionDate(false);
     private static final int CLAN_MIXED_START = TA_MIXED_TECH.getIntroductionDate(true);
-    
+
     private static final int BASE_IS = 0;
     private static final int BASE_CLAN = 1;
     private static final int BASE_IS_MIXED = 2;
     private static final int BASE_CLAN_MIXED = 3;
-    
+
     private String[] techBaseNames;
     private TechAdvancement baseTA;
-    
+
     private final JTextField txtChassis = new JTextField(5);
     private final JTextField txtModel = new JTextField(5);
     private final IntRangeTextField txtYear = new IntRangeTextField(3);
@@ -76,14 +66,18 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     private final JLabel lblMulId = createLabel("", labelSize);
     private final IntRangeTextField txtMulId = new IntRangeTextField(8);
     private final JButton browseMul = new JButton("Open MUL in Browser");
-    
-    private int prevYear = 3145;
 
+    private int prevYear = 3145;
+    private final List<BuildListener> listeners = new CopyOnWriteArrayList<>();
+    //endregion Variable Declarations
+
+    //region Constructors
     public BasicInfoView(TechAdvancement baseTA) {
         this.baseTA = baseTA;
         initUI();
     }
-    
+    //endregion Constructors
+
     private void initUI() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl()); 
         techBaseNames = resourceMap.getString("BasicInfoView.cbTechBase.values").split(",");
@@ -93,7 +87,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
 
         gbc.gridx = 0;
         gbc.gridy = 0;
-        gbc.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.anchor = GridBagConstraints.WEST;
         gbc.insets = new Insets(0, 0, 1, 2);
         add(createLabel(resourceMap.getString("BasicInfoView.txtChassis.text"), labelSize), gbc);
@@ -219,18 +213,28 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         
         refreshFaction();
     }
-    
+
     public void setAsCustomization() {
         txtChassis.setEditable(false);
         txtChassis.setEnabled(false);
         txtYear.setEditable(false);
         txtYear.setEnabled(false);
     }
-    
+
+    public void addListener(BuildListener l) {
+        if (null != l) {
+            listeners.add(l);
+        }
+    }
+
+    public void removeListener(BuildListener l) {
+        listeners.remove(l);
+    }
+
     public String getChassis() {
         return txtChassis.getText();
     }
-    
+
     public void setChassis(String chassis) {
         txtChassis.setText(chassis);
     }
@@ -238,7 +242,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     public String getModel() {
         return txtModel.getText();
     }
-    
+
     public void setModel(String model) {
         txtModel.setText(model);
     }
@@ -247,24 +251,21 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     public int getTechIntroYear() {
         return txtYear.getIntVal();
     }
-    
+
     public void setYear(int year) {
         txtYear.setIntVal(year);
         refreshTechBase();
     }
-    
+
     @Override
     public int getTechFaction() {
         if (!CConfig.getBooleanParam(CConfig.TECH_SHOW_FACTION)) {
             return ITechnology.F_NONE;
         }
         Integer retVal = (Integer) cbFaction.getSelectedItem();
-        if (retVal == null) {
-            return ITechnology.F_NONE;
-        }
-        return retVal;
+        return (retVal == null) ? ITechnology.F_NONE : retVal;
     }
-    
+
     public void setTechFaction(int techFaction) {
         cbFaction.setSelectedItem(techFaction);
     }
@@ -276,11 +277,11 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         }
         return getTechIntroYear();
     }
-    
+
     public String getSource() {
         return txtSource.getText();
     }
-    
+
     public void setSource(String source) {
         txtSource.setText(source);
     }
@@ -291,7 +292,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     public int getManualBV() {
         return txtManualBV.getIntVal(-1);
     }
-    
+
     public void setManualBV(int bv) {
         if (bv >= 0) {
             txtManualBV.setIntVal(bv);
@@ -299,7 +300,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
             txtManualBV.setText("");
         }
     }
-    
+
     @Override
     public boolean useClanTechBase() {
         if (getTechIntroYear() < CLAN_START) {
@@ -320,31 +321,30 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         return ((null != selected)
                 && ((selected == BASE_IS_MIXED) || (selected == BASE_CLAN_MIXED)));
     }
-    
+
     public void setTechBase(boolean clan, boolean mixed) {
         int item = 0;
         if (clan && (getTechIntroYear() > CLAN_START)) {
             item++;
         }
+
         if (mixed) {
             item += 2;
         }
         cbTechBase.setSelectedItem(item);
         refreshFaction();
     }
-    
+
     @Override
     public SimpleTechLevel getTechLevel() {
-        if (cbTechLevel.getSelectedItem() == null) {
-            return SimpleTechLevel.STANDARD;
-        }
-        return (SimpleTechLevel)cbTechLevel.getSelectedItem();
+        return (cbTechLevel.getSelectedItem() == null) ? SimpleTechLevel.STANDARD
+                : (SimpleTechLevel) cbTechLevel.getSelectedItem();
     }
-    
+
     public void setTechLevel(SimpleTechLevel level) {
         cbTechLevel.setSelectedItem(level);
     }
-    
+
     private void refreshTechBase() {
         Integer prev = (Integer) cbTechBase.getSelectedItem();
         cbTechBase.removeActionListener(this);
@@ -362,20 +362,24 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         if (sphereAvailable) {
             cbTechBase.addItem(BASE_IS);
         }
+
         if (clanAvailable) {
             cbTechBase.addItem(BASE_CLAN);
         }
+
         if (sphereAvailable && mixedTechAvailable) {
             cbTechBase.addItem(BASE_IS_MIXED);
         }
+
         if (clanAvailable && mixedTechAvailable) {
             cbTechBase.addItem(BASE_CLAN_MIXED);
         }
-        if (null != prev) {
+
+        if (prev != null) {
             cbTechBase.setSelectedItem(prev);
         }
         cbTechBase.addActionListener(this);
-        if (cbTechBase.getSelectedItem() == null || !cbTechBase.getSelectedItem().equals(prev)) {
+        if ((cbTechBase.getSelectedItem() == null) || !cbTechBase.getSelectedItem().equals(prev)) {
             cbTechBase.setSelectedItem(0);
         }
         refreshTechLevel();
@@ -389,8 +393,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         SimpleTechLevel baseLevel;
         if (CConfig.getBooleanParam(CConfig.TECH_PROGRESSION)) {
             baseLevel = baseTA.getSimpleLevel(getGameYear());
-            if (useMixedTech() && (baseLevel.ordinal() <
-                    Entity.getMixedTechAdvancement().getSimpleLevel(getGameYear()).ordinal())) {
+            if (useMixedTech()
+                    && (baseLevel.ordinal() < Entity.getMixedTechAdvancement().getSimpleLevel(getGameYear()).ordinal())) {
                 baseLevel = Entity.getMixedTechAdvancement().getSimpleLevel(getGameYear());
             }
         } else {
@@ -400,12 +404,15 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
                 baseLevel = Entity.getMixedTechAdvancement().getStaticTechLevel();
             }
         }
-        if (!useClanTechBase() && SimpleTechLevel.INTRO.ordinal() >= baseLevel.ordinal()) {
+
+        if (!useClanTechBase() && (SimpleTechLevel.INTRO.ordinal() >= baseLevel.ordinal())) {
             cbTechLevel.addItem(SimpleTechLevel.INTRO);
         }
+
         if (SimpleTechLevel.STANDARD.ordinal() >= baseLevel.ordinal()) {
             cbTechLevel.addItem(SimpleTechLevel.STANDARD);
         }
+
         if (SimpleTechLevel.ADVANCED.ordinal() >= baseLevel.ordinal()) {
             cbTechLevel.addItem(SimpleTechLevel.ADVANCED);
         }
@@ -413,11 +420,11 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         cbTechLevel.addItem(SimpleTechLevel.UNOFFICIAL);
         cbTechLevel.setSelectedItem(prev);
         cbTechLevel.addActionListener(this);
-        if (cbTechLevel.getSelectedItem() == null || cbTechLevel.getSelectedItem() != prev) {
+        if ((cbTechLevel.getSelectedItem() == null) || (cbTechLevel.getSelectedItem() != prev)) {
             cbTechLevel.setSelectedIndex(0);
         }
     }
-    
+
     private void refreshFaction() {
         if (CConfig.getBooleanParam(CConfig.TECH_SHOW_FACTION)) {
             cbFaction.removeActionListener(this);
@@ -435,14 +442,14 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
             cbFaction.setVisible(false);
         }
     }
-    
+
     @Override
     public void focusGained(FocusEvent e) {
         if (e.getSource().equals(txtYear)) {
             prevYear = getTechIntroYear();
         }
     }
-    
+
     @Override
     public void focusLost(FocusEvent e) {
         if (e.getSource() == txtChassis) {
@@ -460,8 +467,9 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
                 int year = Math.max(getTechIntroYear(), baseTA.getIntroductionDate(useClanTechBase()));
                 listeners.forEach(l -> l.yearChanged(year));
                 prevYear = year;
-            } catch (NumberFormatException ignored) {
+            } catch (Exception ex) {
                 // If text is not a legal integer value, reset to the previous value
+                LogManager.getLogger().error("", ex);
             } finally {
                 setYear(prevYear);
             }
@@ -474,7 +482,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         }
         listeners.forEach(BuildListener::refreshSummary);
     }
-    
+
     @Override
     public void actionPerformed(ActionEvent e) {
         if (e.getSource() == cbFaction) {
@@ -488,33 +496,35 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         }
         listeners.forEach(BuildListener::refreshSummary);
     }
-    
+
     @Override
     public boolean unofficialNoYear() {
         return CConfig.getBooleanParam(CConfig.TECH_UNOFFICAL_NO_YEAR);
     }
-    
+
     @Override
     public boolean useVariableTechLevel() {
         return CConfig.getBooleanParam(CConfig.TECH_PROGRESSION);
     }
-    
+
     @Override
     public boolean showExtinct() {
         return CConfig.getBooleanParam(CConfig.TECH_EXTINCT);
     }
 
     /**
-     * Returns true when the "Open MUL in Browser" Button can be used which is when
-     * the current MUL ID field has a valid MUL (> 0) and the system seems to support
-     * calling a standard browser.
+     * The MUL button should be shown when the current MUL ID field has a valid MUL (> 0) and the
+     * system seems to support calling a standard browser.
+     * @return true when the "Open MUL in Browser" Button can be used
      */
     private boolean shouldShowMULButton() {
         return (txtMulId.getIntVal(-1) > 0) && Desktop.isDesktopSupported()
                 && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE);
     }
 
-    /** Opens the Master Unit List in the System Standard Explorer, if possible. */
+    /**
+     * Opens the Master Unit List in the System Standard Explorer, if possible.
+     */
     private void openMUL() {
         try {
             if (shouldShowMULButton()) {
@@ -525,5 +535,4 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
             JOptionPane.showMessageDialog(this, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
         }
     }
-    
 }

--- a/megameklab/src/megameklab/ui/generalUnit/BuildView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BuildView.java
@@ -1,5 +1,5 @@
 /*
- * MegaMekLab - Copyright (C) 2017 - The MegaMek Team
+ * Copyright (c) 2017-2022 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
@@ -13,12 +13,11 @@
  */
 package megameklab.ui.generalUnit;
 
-import java.awt.Dimension;
+import megamek.common.annotations.Nullable;
 
-import javax.swing.JComponent;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.SwingConstants;
+import javax.swing.*;
+import java.awt.*;
+import java.util.ResourceBundle;
 
 /**
  * Base class that has some common layout methods for main ui component views.
@@ -26,24 +25,43 @@ import javax.swing.SwingConstants;
  * @author Neoancient
  */
 public abstract class BuildView extends JPanel {
-    final protected Dimension labelSize = new Dimension(110, 25);
-    final protected Dimension labelSizeLg = new Dimension(180, 25);
-    final protected Dimension controlSize = new Dimension(180, 25);
-    final protected Dimension spinnerSize = new Dimension(55, 25);
-    final protected Dimension spinnerSizeLg = new Dimension(70, 25);
-    final protected Dimension editorSize = new Dimension(40, 25);
-    final protected Dimension editorSizeLg = new Dimension(55, 25);
+    protected final Dimension labelSize = new Dimension(110, 25);
+    protected final Dimension labelSizeLg = new Dimension(180, 25);
+    protected final Dimension controlSize = new Dimension(180, 25);
+    protected final Dimension spinnerSize = new Dimension(55, 25);
+    protected final Dimension spinnerSizeLg = new Dimension(70, 25);
+    protected final Dimension editorSize = new Dimension(40, 25);
+    protected final Dimension editorSizeLg = new Dimension(55, 25);
 
-    public JLabel createLabel(String text, Dimension maxSize) {
-        JLabel label = new JLabel(text, SwingConstants.RIGHT);
+    public JLabel createLabel(final ResourceBundle resources, final String name, final String text,
+                              final Dimension maxSize) {
+        return createLabel(resources, name, text, null, maxSize);
+    }
+
+    public JLabel createLabel(final ResourceBundle resources, final String name, final String text,
+                              final @Nullable String toolTipText, final Dimension maxSize) {
+        return createLabel(name, resources.getString(text),
+                (toolTipText == null) ? null : resources.getString(toolTipText), maxSize);
+    }
+
+    public JLabel createLabel(final String name, final String text, final Dimension maxSize) {
+        return createLabel(name, text, null, maxSize);
+    }
+
+    public JLabel createLabel(final String name, final String text,
+                              final @Nullable String toolTipText, final Dimension maxSize) {
+        final JLabel label = new JLabel(text, SwingConstants.RIGHT);
+        label.setToolTipText(toolTipText);
+        if (!name.isBlank()) {
+            label.setName(name);
+        }
         setFieldSize(label, maxSize);
         return label;
     }
 
-    public void setFieldSize(JComponent box, Dimension maxSize) {
+    public void setFieldSize(final JComponent box, final Dimension maxSize) {
         box.setPreferredSize(maxSize);
         box.setMaximumSize(maxSize);
         box.setMinimumSize(maxSize);
     }
-
 }

--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -13,8 +13,17 @@
  */
 package megameklab.ui.generalUnit;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
+import megamek.common.*;
+import megamek.common.util.EncodeControl;
+import megamek.common.verifier.TestAero;
+import megameklab.ui.listeners.BuildListener;
+import megameklab.ui.util.CustomComboBox;
+import megameklab.util.UnitUtil;
+
+import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -22,19 +31,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import javax.swing.JLabel;
-import javax.swing.JSpinner;
-import javax.swing.SpinnerNumberModel;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-
-import megamek.common.*;
-import megamek.common.util.EncodeControl;
-import megamek.common.verifier.TestAero;
-import megameklab.ui.util.CustomComboBox;
-import megameklab.ui.listeners.BuildListener;
-import megameklab.util.UnitUtil;
 
 /**
  * Controls for selecting type and number of heat sinks for mechs and asfs.
@@ -110,7 +106,8 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
 
         gbc.gridx = 0;
         gbc.gridy = 0;
-        add(createLabel(resourceMap.getString("HeatSinkView.cbHSType.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblHSType", "HeatSinkView.cbHSType.text",
+                "HeatSinkView.cbHSType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 4;
         setFieldSize(cbHSType, controlSize);
@@ -122,7 +119,8 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("HeatSinkView.spnCount.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblCount", "HeatSinkView.spnCount.text",
+                "HeatSinkView.spnCount.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(spnCount.getEditor(), editorSize);
         spnCount.setToolTipText(resourceMap.getString("HeatSinkView.spnCount.tooltip"));

--- a/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
@@ -13,26 +13,24 @@
  */
 package megameklab.ui.generalUnit;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
+import megamek.common.*;
+import megamek.common.util.EncodeControl;
+import megamek.common.verifier.TestEntity;
+import megameklab.ui.listeners.ArmorAllocationListener;
+import megameklab.ui.util.CustomComboBox;
+import megameklab.ui.util.TechComboBox;
+import megameklab.util.UnitUtil;
+
+import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import javax.swing.*;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-
-import megamek.common.*;
-import megamek.common.util.EncodeControl;
-import megamek.common.verifier.TestEntity;
-import megameklab.ui.util.CustomComboBox;
-import megameklab.ui.util.TechComboBox;
-import megameklab.ui.listeners.ArmorAllocationListener;
-import megameklab.util.UnitUtil;
 
 /**
  * Panel for assigning armor type and tonnage for mechs, (combat) vehicles, and fighters.
@@ -60,7 +58,7 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
     private final JCheckBox chkPatchwork = new JCheckBox();
     private final JButton btnMaximize = new JButton();
     private final JButton btnUseRemaining = new JButton();
-    private final JLabel lblArmorTonnage = createLabel("", labelSizeLg);
+    private final JLabel lblArmorTonnage = createLabel("lblArmorTonnage", "", labelSizeLg);
     
     private final ITechManager techManager;
     
@@ -101,7 +99,8 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("ArmorView.cbArmorType.text"), labelSizeLg), gbc);
+        add(createLabel(resourceMap, "lblArmorType", "ArmorView.cbArmorType.text",
+                "ArmorView.cbArmorType.tooltip", labelSizeLg), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 2;
         setFieldSize(cbArmorType, controlSize);
@@ -116,7 +115,8 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
             gbc.gridx = 0;
             gbc.gridy++;
             gbc.gridwidth = 1;
-            JLabel label = createLabel(resourceMap.getString("ArmorView.cbSVTechRating.text"), labelSizeLg);
+            JLabel label = createLabel(resourceMap, "lblSVTechRating", "ArmorView.cbSVTechRating.text",
+                    "ArmorView.cbSVTechRating.tooltip", labelSizeLg);
             add(label, gbc);
             svControlList.add(label);
             gbc.gridx = 1;
@@ -130,7 +130,8 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
             gbc.gridx = 0;
             gbc.gridy++;
             gbc.gridwidth = 1;
-            label = createLabel(resourceMap.getString("ArmorView.cbBARRating.text"), labelSizeLg);
+            label = createLabel(resourceMap, "lblBARRating", "ArmorView.cbBARRating.text",
+                    "ArmorView.cbBARRating.tooltip", labelSizeLg);
             add(label, gbc);
             svControlList.add(label);
             gbc.gridx = 1;

--- a/megameklab/src/megameklab/ui/generalUnit/MovementView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/MovementView.java
@@ -63,10 +63,10 @@ public class MovementView extends BuildView implements ActionListener, ChangeLis
     private final TechComboBox<EquipmentType> cbJumpType =
                 new TechComboBox<>(eq -> eq.getName().replaceAll("\\s+\\[.*?]",  ""));
     
-    private final JLabel lblWalk = createLabel("", labelSize);
-    private final JLabel lblRun = createLabel("", labelSize);
-    private final JLabel lblJump = createLabel("", labelSize);
-    private final JLabel lblJumpType = createLabel("", labelSize);
+    private final JLabel lblWalk = createLabel("lblWalk", "", labelSize);
+    private final JLabel lblRun = createLabel("lblRun", "", labelSize);
+    private final JLabel lblJump = createLabel("lblJump", "", labelSize);
+    private final JLabel lblJumpType = createLabel("lblJumpType", "", labelSize);
     
     private final JTextField txtRunBase = new JTextField();
     private final JTextField txtWalkFinal = new JTextField();

--- a/megameklab/src/megameklab/ui/largeAero/DSChassisView.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSChassisView.java
@@ -88,7 +88,8 @@ public class DSChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridy = 0;
-        add(createLabel(resourceMap.getString("DropshipChassisView.spnTonnage.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTonnage", "DropshipChassisView.spnTonnage.text",
+                "DropshipChassisView.spnTonnage.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 0;
         gbc.fill = GridBagConstraints.HORIZONTAL;
@@ -117,7 +118,8 @@ public class DSChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 2;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("DropshipChassisView.cbBaseType.text"), labelSize),gbc);
+        add(createLabel(resourceMap, "lblBaseType", "DropshipChassisView.cbBaseType.text",
+                "DropshipChassisView.cbBaseType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 2;
         gbc.gridwidth = 3;
@@ -129,7 +131,8 @@ public class DSChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 3;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("DropshipChassisView.cbChassisType.text"), labelSize),gbc);
+        add(createLabel(resourceMap, "lblChassisType", "DropshipChassisView.cbChassisType.text",
+                "DropshipChassisView.cbChassisType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 3;
         gbc.gridwidth = 3;
@@ -141,7 +144,8 @@ public class DSChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 4;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("DropshipChassisView.spnSI.text"), labelSize),gbc);
+        add(createLabel(resourceMap, "lblSI", "DropshipChassisView.spnSI.text",
+                "DropshipChassisView.spnSI.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 4;
         gbc.gridwidth = 3;

--- a/megameklab/src/megameklab/ui/largeAero/LACrewView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LACrewView.java
@@ -68,7 +68,7 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
     private final JSpinner spnEscapePods = new JSpinner(new SpinnerNumberModel(0, 0, null, 1));
     private final JButton btnAssignQuarters = new JButton();
 
-    private final JLabel lblBAMarines = createLabel("", labelSize);
+    private final JLabel lblBAMarines = createLabel("lblBAMarines", "", labelSize);
     private final ITechManager techManager;
     private boolean ignoreChangeEvents = false;
     
@@ -84,7 +84,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 0;
         gbc.gridy = 0;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnBaseCrew.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblBaseCrew", "AerospaceCrewView.spnBaseCrew.text",
+                "AerospaceCrewView.spnBaseCrew.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(spnBaseCrew, spinnerSize);
         add(spnBaseCrew, gbc);
@@ -93,7 +94,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnGunners.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblGunners", "AerospaceCrewView.spnGunners.text",
+                "AerospaceCrewView.spnGunners.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(spnGunners, spinnerSize);
         add(spnGunners, gbc);
@@ -102,7 +104,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.lblTotalCrew.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTotalCrew", "AerospaceCrewView.lblTotalCrew.text",
+                "AerospaceCrewView.lblTotalCrew.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         add(lblTotalCrew, gbc);
         lblTotalCrew.setToolTipText(resourceMap.getString("AerospaceCrewView.lblTotalCrew.tooltip"));
@@ -110,7 +113,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnOfficers.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblOfficers", "AerospaceCrewView.spnOfficers.text",
+                "AerospaceCrewView.spnOfficers.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(spnOfficers, spinnerSize);
         spnOfficers.setToolTipText(resourceMap.getString("AerospaceCrewView.spnOfficers.tooltip"));
@@ -119,7 +123,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.lblBayPersonnel.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblBayPersonnel", "AerospaceCrewView.lblBayPersonnel.text",
+                "AerospaceCrewView.lblBayPersonnel.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         add(lblBayPersonnel, gbc);
         lblBayPersonnel.setToolTipText(resourceMap.getString("AerospaceCrewView.lblBayPersonnel.tooltip"));
@@ -127,7 +132,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnPassengers.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblPassengers", "AerospaceCrewView.spnPassengers.text",
+                "AerospaceCrewView.spnPassengers.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(spnPassengers, spinnerSize);
         spnPassengers.setToolTipText(resourceMap.getString("AerospaceCrewView.spnPassengers.tooltip"));
@@ -136,7 +142,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnMarines.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblMarines", "AerospaceCrewView.spnMarines.text",
+                "AerospaceCrewView.spnMarines.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(spnMarines, spinnerSize);
         spnMarines.setToolTipText(resourceMap.getString("AerospaceCrewView.spnMarines.tooltip"));
@@ -161,7 +168,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         gbc.gridx = 2;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnQuartersFirstClass.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblQuartersFirstClass", "AerospaceCrewView.spnQuartersFirstClass.text",
+                "AerospaceCrewView.spnQuartersFirstClass.tooltip", labelSize), gbc);
         gbc.gridx = 3;
         setFieldSize(spnQuartersFirstClass, spinnerSize);
         spnQuartersFirstClass.setToolTipText(resourceMap.getString("AerospaceCrewView.spnQuartersFirstClass.tooltip"));
@@ -170,7 +178,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 2;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnQuartersStandard.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblQuartersStandard", "AerospaceCrewView.spnQuartersStandard.text",
+                "AerospaceCrewView.spnQuartersStandard.tooltip", labelSize), gbc);
         gbc.gridx = 3;
         setFieldSize(spnQuartersStandard, spinnerSize);
         spnQuartersStandard.setToolTipText(resourceMap.getString("AerospaceCrewView.spnQuartersStandard.tooltip"));
@@ -179,7 +188,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 2;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnQuartersSecondClass.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblQuartersSecondClass", "AerospaceCrewView.spnQuartersSecondClass.text",
+                "AerospaceCrewView.spnQuartersSecondClass.tooltip", labelSize), gbc);
         gbc.gridx = 3;
         setFieldSize(spnQuartersSecondClass, spinnerSize);
         spnQuartersSecondClass.setToolTipText(resourceMap.getString("AerospaceCrewView.spnQuartersSecondClass.tooltip"));
@@ -188,7 +198,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 2;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnQuartersSteerage.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblQuartersSteerage", "AerospaceCrewView.spnQuartersSteerage.text",
+                "AerospaceCrewView.spnQuartersSteerage.tooltip", labelSize), gbc);
         gbc.gridx = 3;
         setFieldSize(spnQuartersSteerage, spinnerSize);
         spnQuartersSteerage.setToolTipText(resourceMap.getString("AerospaceCrewView.spnQuartersSteerage.tooltip"));
@@ -206,7 +217,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         gbc.gridx = 2;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnLifeBoats.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblLifeBoats", "AerospaceCrewView.spnLifeBoats.text",
+                "AerospaceCrewView.spnLifeBoats.tooltip", labelSize), gbc);
         gbc.gridx = 3;
         setFieldSize(spnLifeBoats, spinnerSize);
         spnLifeBoats.setToolTipText(resourceMap.getString("AerospaceCrewView.spnLifeBoats.tooltip"));
@@ -215,7 +227,8 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
         
         gbc.gridx = 2;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("AerospaceCrewView.spnEscapePods.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblEscapePods", "AerospaceCrewView.spnEscapePods.text",
+                "AerospaceCrewView.spnEscapePods.tooltip", labelSize), gbc);
         gbc.gridx = 3;
         setFieldSize(spnEscapePods, spinnerSize);
         spnEscapePods.setToolTipText(resourceMap.getString("AerospaceCrewView.spnEscapePods.tooltip"));

--- a/megameklab/src/megameklab/ui/largeAero/WSChassisView.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSChassisView.java
@@ -82,7 +82,7 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
     
     public WSChassisView(ITechManager techManager) {
         this.techManager = techManager;
-        lblRange = createLabel("", labelSize);
+        lblRange = createLabel("lblRange", "", labelSize);
         initUI();
     }
     
@@ -97,7 +97,8 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 0;
         gbc.gridwidth = 2;
-        add(createLabel(resourceMap.getString("AdvAeroChassisView.spnTonnage.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTonnage", "AdvAeroChassisView.spnTonnage.text",
+                "AdvAeroChassisView.spnTonnage.tooltip", labelSize), gbc);
         gbc.gridx = 2;
         gbc.gridy = 0;
         gbc.gridwidth = 2;
@@ -118,7 +119,8 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 1;
         gbc.gridwidth = 2;
-        add(createLabel(resourceMap.getString("AdvAeroChassisView.cbBaseType.text"), labelSize),gbc);
+        add(createLabel(resourceMap, "lblBaseType", "AdvAeroChassisView.cbBaseType.text",
+                "AdvAeroChassisView.cbBaseType.tooltip", labelSize), gbc);
         gbc.gridx = 2;
         gbc.gridy = 1;
         gbc.gridwidth = 2;
@@ -162,7 +164,8 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 4;
         gbc.gridwidth = 2;
-        add(createLabel(resourceMap.getString("AdvAeroChassisView.spnSI.text"), labelSize),gbc);
+        add(createLabel(resourceMap, "lblSI", "AdvAeroChassisView.spnSI.text",
+                "AdvAeroChassisView.spnSI.tooltip", labelSize), gbc);
         gbc.gridx = 2;
         gbc.gridy = 4;
         gbc.gridwidth = 2;

--- a/megameklab/src/megameklab/ui/mek/BMChassisView.java
+++ b/megameklab/src/megameklab/ui/mek/BMChassisView.java
@@ -162,7 +162,8 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridy = 0;
-        add(createLabel(resourceMap.getString("MekChassisView.spnTonnage.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTonnage", "MekChassisView.spnTonnage.text",
+                "MekChassisView.spnTonnage.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 0;
         setFieldSize(spnTonnage, spinnerSize);
@@ -180,7 +181,8 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridy = 1;
-        add(createLabel(resourceMap.getString("MekChassisView.cbBaseType.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblBaseType", "MekChassisView.cbBaseType.text",
+                "MekChassisView.cbBaseType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 1;
         gbc.gridwidth = 3;
@@ -192,7 +194,8 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 2;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("MekChassisView.cbMotiveType.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblMotiveType", "MekChassisView.cbMotiveType.text",
+                "MekChassisView.cbMotiveType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 2;
         gbc.gridwidth = 3;
@@ -204,7 +207,8 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 3;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("MekChassisView.cbStructure.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblStructure", "MekChassisView.cbStructure.text",
+                "MekChassisView.cbStructure.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 3;
         gbc.gridwidth = 3;
@@ -216,7 +220,8 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 4;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("MekChassisView.cbEngine.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblEngine", "MekChassisView.cbEngine.text",
+                "MekChassisView.cbEngine.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 4;
         gbc.gridwidth = 3;
@@ -228,7 +233,8 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 5;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("MekChassisView.cbGyro.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblGyro", "MekChassisView.cbGyro.text",
+                "MekChassisView.cbGyro.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 5;
         gbc.gridwidth = 3;
@@ -240,7 +246,8 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 6;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("MekChassisView.cbCockpit.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblCockpit", "MekChassisView.cbCockpit.text",
+                "MekChassisView.cbCockpit.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 6;
         gbc.gridwidth = 3;
@@ -252,7 +259,8 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 7;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("MekChassisView.cbEnhancement.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblEnhancement", "MekChassisView.cbEnhancement.text",
+                "MekChassisView.cbEnhancement.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 7;
         gbc.gridwidth = 3;

--- a/megameklab/src/megameklab/ui/protoMek/PMChassisView.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMChassisView.java
@@ -101,7 +101,8 @@ public class PMChassisView extends BuildView implements ActionListener, ChangeLi
 
         gbc.gridx = 0;
         gbc.gridy = 0;
-        add(createLabel(resourceMap.getString("ProtomekChassisView.spnTonnage.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTonnage", "ProtomekChassisView.spnTonnage.text",
+                "ProtomekChassisView.spnTonnage.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 0;
         setFieldSize(spnTonnage, spinnerSize);
@@ -112,7 +113,7 @@ public class PMChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy = 1;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("ProtomekChassisView.cbMotiveType.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblMotiveType", "ProtomekChassisView.cbMotiveType.text", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridy = 1;
         gbc.gridwidth = 3;
@@ -130,34 +131,34 @@ public class PMChassisView extends BuildView implements ActionListener, ChangeLi
         chkMainGun.setToolTipText(resourceMap.getString("ProtomekChassisView.chkMainGun.tooltip"));
         add(chkMainGun, gbc);
         chkMainGun.addActionListener(this);
-        
+
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 2;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("ProtomekChassisView.lblEnhancements.text"), labelSize), gbc);
-        
+        add(createLabel(resourceMap, "lblEnhancements", "ProtomekChassisView.lblEnhancements.text", labelSize), gbc);
+
         gbc.gridx = 0;
         gbc.gridy++;
         chkMyomerBooster.setText(resourceMap.getString("ProtomekChassisView.chkMyomerBooster.text"));
         chkMyomerBooster.setToolTipText(resourceMap.getString("ProtomekChassisView.chkMyomerBooster.tooltip"));
         add(chkMyomerBooster, gbc);
         chkMyomerBooster.addActionListener(this);
-        
+
         gbc.gridx = 0;
         gbc.gridy++;
         chkPartialWing.setText(resourceMap.getString("ProtomekChassisView.chkPartialWing.text"));
         chkPartialWing.setToolTipText(resourceMap.getString("ProtomekChassisView.chkPartialWing.tooltip"));
         add(chkPartialWing, gbc);
         chkPartialWing.addActionListener(this);
-        
+
         gbc.gridx = 0;
         gbc.gridy++;
         chkMagneticClamps.setText(resourceMap.getString("ProtomekChassisView.chkMagneticClamps.text"));
         chkMagneticClamps.setToolTipText(resourceMap.getString("ProtomekChassisView.chkMagneticClamps.tooltip"));
         add(chkMagneticClamps, gbc);
         chkMagneticClamps.addActionListener(this);
-        
+
         gbc.gridx = 0;
         gbc.gridy++;
         chkISInterface.setText(resourceMap.getString("ProtomekChassisView.chkISInterface.text"));
@@ -178,7 +179,7 @@ public class PMChassisView extends BuildView implements ActionListener, ChangeLi
             cbMotiveType.setSelectedItem(MOTIVE_TYPE_BIPED);
         }
         cbMotiveType.addActionListener(this);
-        
+
         chkMyomerBooster.setSelected(proto.hasMisc(MiscType.F_MASC));
         chkPartialWing.setSelected(proto.hasMisc(MiscType.F_PARTIAL_WING));
         chkMagneticClamps.setSelected(proto.hasMisc(MiscType.F_MAGNETIC_CLAMP));

--- a/megameklab/src/megameklab/ui/supportVehicle/SVChassisView.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVChassisView.java
@@ -78,7 +78,7 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
     private final CustomComboBox<Integer> cbEngineTechRating = new CustomComboBox<>(ITechnology::getRatingName);
     private final CustomComboBox<Integer> cbTurrets = new CustomComboBox<>(i -> turretNames[i]);
     private final JCheckBox chkSponson = new JCheckBox();
-    private final JLabel lblPintle = createLabel("", labelSize);
+    private final JLabel lblPintle = createLabel("lblPintle", "", labelSize);
     private final JCheckBox chkPintleLeft = new JCheckBox();
     private final JCheckBox chkPintleRight = new JCheckBox();
     private final JSpinner spnChassisTurretWt = new JSpinner(spnTurretWtModel);
@@ -113,7 +113,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridy = 0;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("SVChassisView.spnTonnage.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTonnage", "SVChassisView.spnTonnage.text",
+                "SVChassisView.spnTonnage.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         setFieldSize(spnTonnage, spinnerSizeLg);
         spnTonnage.setToolTipText(resourceMap.getString("SVChassisView.spnTonnage.tooltip"));
@@ -133,7 +134,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridwidth = 2;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("SVChassisView.cbStructureTechRating.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblStructureTechRating", "SVChassisView.cbStructureTechRating.text",
+                "SVChassisView.cbStructureTechRating.tooltip", labelSize), gbc);
         gbc.gridx = 2;
         gbc.gridwidth = 1;
         setFieldSize(cbStructureTechRating, spinnerSize);
@@ -146,7 +148,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridwidth = 1;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("SVChassisView.cbType.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblType", "SVChassisView.cbType.text",
+                "SVChassisView.cbType.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 2;
         setFieldSize(cbType, controlSize);
@@ -159,7 +162,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridwidth = 1;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("SVChassisView.cbEngine.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblEngine", "SVChassisView.cbEngine.text",
+                "SVChassisView.cbEngine.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 2;
         setFieldSize(cbEngine, controlSize);
@@ -174,7 +178,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridwidth = 2;
         gbc.gridy++;
-        add(createLabel(resourceMap.getString("SVChassisView.cbEngineTechRating.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblEngineTechRating", "SVChassisView.cbEngineTechRating.text",
+                "SVChassisView.cbEngineTechRating.tooltip", labelSize), gbc);
         gbc.gridx = 2;
         gbc.gridwidth = 1;
         setFieldSize(cbEngineTechRating, spinnerSize);
@@ -186,7 +191,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("CVChassisView.cbTurrets.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTurrets", "CVChassisView.cbTurrets.text",
+                "CVChassisView.cbTurrets.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 2;
         setFieldSize(cbTurrets, controlSize);
@@ -225,7 +231,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap.getString("SVChassisView.cbFireCon.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblFireCon", "SVChassisView.cbFireCon.text",
+                "SVChassisView.cbFireCon.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 2;
         setFieldSize(cbFireControl, controlSize);
@@ -256,8 +263,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        JLabel lbl = createLabel(resourceMap.getString("SVChassisView.spnTurret1Wt.text"), labelSize);
-        omniPanel.add(lbl, gbc);
+        omniPanel.add(createLabel(resourceMap, "lblTurret1Wt", "SVChassisView.spnTurret1Wt.text",
+                "CVChassisView.spnTurretWt.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 2;
         setFieldSize(spnChassisTurretWt, spinnerSizeLg);
@@ -268,8 +275,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        lbl = createLabel(resourceMap.getString("SVChassisView.spnTurret2Wt.text"), labelSize);
-        omniPanel.add(lbl, gbc);
+        omniPanel.add(createLabel(resourceMap, "lblTurret2Wt", "SVChassisView.spnTurret2Wt.text",
+                "CVChassisView.spnTurret2Wt.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 2;
         setFieldSize(spnChassisTurret2Wt, spinnerSizeLg);
@@ -280,8 +287,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        lbl = createLabel(resourceMap.getString("SVChassisView.spnSponsonPintleWt.text"), labelSize);
-        omniPanel.add(lbl, gbc);
+        omniPanel.add(createLabel(resourceMap, "lblSponsonPintleWt", "SVChassisView.spnSponsonPintleWt.text",
+                "SVChassisView.spnSponsonPintleWt.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 2;
         setFieldSize(spnChassisSponsonPintleWt, spinnerSizeLg);
@@ -292,8 +299,8 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        lbl = createLabel(resourceMap.getString("SVChassisView.spnFireConWt.text"), labelSize);
-        omniPanel.add(lbl, gbc);
+        omniPanel.add(createLabel(resourceMap, "lblFireConWt", "SVChassisView.spnFireConWt.text",
+                "SVChassisView.spnFireConWt.tooltip", labelSize), gbc);
         gbc.gridx = 1;
         gbc.gridwidth = 2;
         setFieldSize(spnFireConWt, spinnerSizeLg);

--- a/megameklab/src/megameklab/ui/supportVehicle/SVCrewView.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVCrewView.java
@@ -97,12 +97,13 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridx = 0;
         gbc.gridy = 0;
         gbc.gridwidth = GridBagConstraints.REMAINDER;
-        add(createLabel(resourceMap.getString("SVCrewView.lbMinimumCrew.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblMinimumCrew", "SVCrewView.lblMinimumCrew.text", labelSize), gbc);
 
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 2;
-        add(createLabel(resourceMap.getString("SVCrewView.txtReqBaseCrew.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblReqBaseCrew", "SVCrewView.txtReqBaseCrew.text",
+                "SVCrewView.txtReqBaseCrew.tooltip", labelSize), gbc);
         gbc.gridwidth = 1;
         gbc.gridx = 2;
         setFieldSize(txtReqBaseCrew, spinnerSize);
@@ -112,7 +113,8 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 2;
-        add(createLabel(resourceMap.getString("SVCrewView.txtReqGunners.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblReqGunners", "SVCrewView.txtReqGunners.text",
+                "SVCrewView.txtReqGunners.tooltip", labelSize), gbc);
         gbc.gridwidth = 1;
         gbc.gridx = 2;
         setFieldSize(txtReqGunners, spinnerSize);
@@ -122,7 +124,8 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 2;
-        add(createLabel(resourceMap.getString("SVCrewView.txtReqOther.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblReqOther", "SVCrewView.txtReqOther.text",
+                "SVCrewView.txtReqOther.tooltip", labelSize), gbc);
         gbc.gridwidth = 1;
         gbc.gridx = 2;
         setFieldSize(txtReqOther, spinnerSize);
@@ -132,7 +135,8 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 2;
-        add(createLabel(resourceMap.getString("SVCrewView.txtReqOfficers.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblReqOfficers", "SVCrewView.txtReqOfficers.text",
+                "SVCrewView.txtReqOfficers.tooltip", labelSize), gbc);
         gbc.gridwidth = 1;
         gbc.gridx = 2;
         setFieldSize(txtReqOfficers, spinnerSize);
@@ -142,7 +146,7 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 2;
-        add(createLabel(resourceMap.getString("SVCrewView.txtTotalMinCrew.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblTotalMinCrew", "SVCrewView.txtTotalMinCrew.text", labelSize), gbc);
         gbc.gridwidth = 1;
         gbc.gridx = 2;
         setFieldSize(txtTotalMinCrew, spinnerSize);
@@ -151,19 +155,20 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 2;
-        add(createLabel(resourceMap.getString("SVCrewView.lblSeatingHeader.extraSeats"), labelSizeLg), gbc);
+        add(createLabel(resourceMap, "lblSeatingHeader", "SVCrewView.lblSeatingHeader.extraSeats", labelSize), gbc);
         gbc.gridwidth = 1;
         gbc.gridx = 2;
         lblPodSeating.setText(resourceMap.getString("SVCrewView.lblPodQuarters.text"));
         add(lblPodSeating, gbc);
         gbc.gridx = 3;
-        add(createLabel(resourceMap.getString("SVCrewView.lblSeatingWeight.text"), labelSize), gbc);
+        add(createLabel(resourceMap, "lblSeatingWeight", "SVCrewView.lblSeatingWeight.text", labelSize), gbc);
 
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 1;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("SVCrewView.spnStandardSeats.text"), labelSizeLg), gbc);
+        add(createLabel(resourceMap, "lblStandardSeats", "SVCrewView.spnStandardSeats.text",
+                "SVCrewView.spnStandardSeats.tooltip", labelSizeLg), gbc);
         gbc.gridx = 1;
         setFieldSize(spnStandardSeats, spinnerSize);
         spnStandardSeats.setToolTipText(resourceMap.getString("SVCrewView.spnStandardSeats.tooltip"));
@@ -183,7 +188,8 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridy++;
         gbc.gridwidth = 1;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("SVCrewView.spnPillionSeats.text"), labelSizeLg), gbc);
+        add(createLabel(resourceMap, "lblPillionSeats", "SVCrewView.spnPillionSeats.text",
+                "SVCrewView.spnPillionSeats.tooltip", labelSizeLg), gbc);
         gbc.gridx = 1;
         setFieldSize(spnPillionSeats, spinnerSize);
         spnPillionSeats.setToolTipText(resourceMap.getString("SVCrewView.spnPillionSeats.tooltip"));
@@ -203,7 +209,8 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridy++;
         gbc.gridwidth = 1;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("SVCrewView.spnEjectionSeats.text"), labelSizeLg), gbc);
+        add(createLabel(resourceMap, "lblEjectionSeats", "SVCrewView.spnEjectionSeats.text",
+                "SVCrewView.spnEjectionSeats.tooltip", labelSizeLg), gbc);
         gbc.gridx = 1;
         setFieldSize(spnEjectionSeats, spinnerSize);
         spnEjectionSeats.setToolTipText(resourceMap.getString("SVCrewView.spnEjectionSeats.tooltip"));
@@ -223,7 +230,7 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridy++;
         gbc.gridwidth = 2;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("SVCrewView.lblQuarters.text"), labelSizeLg), gbc);
+        add(createLabel(resourceMap, "lblQuarters", "SVCrewView.lblQuarters.text", labelSizeLg), gbc);
         gbc.gridwidth = 1;
         gbc.gridx = 2;
         lblPodQuarters.setText(resourceMap.getString("SVCrewView.lblPodQuarters.text"));
@@ -240,7 +247,8 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridy++;
         gbc.gridwidth = 1;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("SVCrewView.spnFirstClass.text"), labelSizeLg), gbc);
+        add(createLabel(resourceMap, "lblFirstClass", "SVCrewView.spnFirstClass.text",
+                "SVCrewView.spnFirstClass.tooltip", labelSizeLg), gbc);
         gbc.gridx = 1;
         setFieldSize(spnFirstClass, spinnerSize);
         spnFirstClass.setToolTipText(resourceMap.getString("SVCrewView.spnFirstClass.tooltip"));
@@ -263,7 +271,8 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridy++;
         gbc.gridwidth = 1;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("SVCrewView.spnSecondClass.text"), labelSizeLg), gbc);
+        add(createLabel(resourceMap, "lblSecondClass", "SVCrewView.spnSecondClass.text",
+                "SVCrewView.spnSecondClass.tooltip", labelSizeLg), gbc);
         gbc.gridx = 1;
         setFieldSize(spnSecondClass, spinnerSize);
         spnSecondClass.setToolTipText(resourceMap.getString("SVCrewView.spnSecondClass.tooltip"));
@@ -286,7 +295,8 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridy++;
         gbc.gridwidth = 1;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("SVCrewView.spnCrewQuarters.text"), labelSizeLg), gbc);
+        add(createLabel(resourceMap, "lblCrewQuarters", "SVCrewView.spnCrewQuarters.text",
+                "SVCrewView.spnCrewQuarters.tooltip", labelSizeLg), gbc);
         gbc.gridx = 1;
         setFieldSize(spnCrewQuarters, spinnerSize);
         spnCrewQuarters.setToolTipText(resourceMap.getString("SVCrewView.spnCrewQuarters.tooltip"));
@@ -309,7 +319,8 @@ public class SVCrewView extends BuildView implements ChangeListener {
         gbc.gridy++;
         gbc.gridwidth = 1;
         gbc.anchor = GridBagConstraints.WEST;
-        add(createLabel(resourceMap.getString("SVCrewView.spnSteerage.text"), labelSizeLg), gbc);
+        add(createLabel(resourceMap, "lblSteerage", "SVCrewView.spnSteerage.text",
+                "SVCrewView.spnSteerage.tooltip", labelSizeLg), gbc);
         gbc.gridx = 1;
         setFieldSize(spnSteerage, spinnerSize);
         spnSteerage.setToolTipText(resourceMap.getString("SVCrewView.spnSteerage.tooltip"));


### PR DESCRIPTION
For Review:
The first commit is a refactor, the second removes some useless setEditable calls, the third adds tooltips to a bunch of labels that should have had them already.