### PR TITLE
MM #3257: Show CASE in the crit block title for Meks

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
@@ -490,7 +490,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                     while (getJumpship().getCollarById(num) != null) {
                         num++;
                     }
-                    getJumpship().addTransporter(new DockingCollar(1, num));
+                    getJumpship().addTransporter(new DockingCollar(num));
                 }
             }
             if (null != refresh) {

--- a/megameklab/src/megameklab/ui/mek/BMCriticalView.java
+++ b/megameklab/src/megameklab/ui/mek/BMCriticalView.java
@@ -120,14 +120,6 @@ public class BMCriticalView extends IView {
 
         synchronized (getMech()) {
             clPanel.setVisible(getMech() instanceof TripodMech);
-//            String title = getMech() instanceof QuadMech ? "Front Left Leg" : "Left Arm";
-//            laPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
-//            title = getMech() instanceof QuadMech ? "Front Right Leg" : "Right Arm";
-//            raPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
-//            title = getMech() instanceof QuadMech ? "Rear Left Leg" : "Left Leg";
-//            llPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
-//            title = getMech() instanceof QuadMech ? "Rear Right Leg" : "Right Leg";
-//            rlPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
             setTitles();
 
             for (int location = 0; location < getMech().locations(); location++) {

--- a/megameklab/src/megameklab/ui/mek/BMCriticalView.java
+++ b/megameklab/src/megameklab/ui/mek/BMCriticalView.java
@@ -120,14 +120,15 @@ public class BMCriticalView extends IView {
 
         synchronized (getMech()) {
             clPanel.setVisible(getMech() instanceof TripodMech);
-            String title = getMech() instanceof QuadMech ? "Front Left Leg" : "Left Arm";
-            laPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
-            title = getMech() instanceof QuadMech ? "Front Right Leg" : "Right Arm";
-            raPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
-            title = getMech() instanceof QuadMech ? "Rear Left Leg" : "Left Leg";
-            llPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
-            title = getMech() instanceof QuadMech ? "Rear Right Leg" : "Right Leg";
-            rlPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+//            String title = getMech() instanceof QuadMech ? "Front Left Leg" : "Left Arm";
+//            laPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+//            title = getMech() instanceof QuadMech ? "Front Right Leg" : "Right Arm";
+//            raPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+//            title = getMech() instanceof QuadMech ? "Rear Left Leg" : "Left Leg";
+//            llPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+//            title = getMech() instanceof QuadMech ? "Rear Right Leg" : "Right Leg";
+//            rlPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+            setTitles();
 
             for (int location = 0; location < getMech().locations(); location++) {
                 Vector<String> critNames = new Vector<>(1, 1);
@@ -170,6 +171,37 @@ public class BMCriticalView extends IView {
             }
             
             validate();
+        }
+    }
+
+    private void setTitles() {
+        String title = getMech().getLocationName(Mech.LOC_LARM) + caseSuffix(Mech.LOC_LARM);
+        laPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+        title = getMech().getLocationName(Mech.LOC_RARM) + caseSuffix(Mech.LOC_RARM);
+        raPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+        title = getMech().getLocationName(Mech.LOC_LLEG) + caseSuffix(Mech.LOC_LLEG);
+        llPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+        title = getMech().getLocationName(Mech.LOC_RLEG) + caseSuffix(Mech.LOC_RLEG);
+        rlPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+        title = getMech().getLocationName(Mech.LOC_CLEG) + caseSuffix(Mech.LOC_CLEG);
+        clPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+        title = getMech().getLocationName(Mech.LOC_LT) + caseSuffix(Mech.LOC_LT);
+        ltPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+        title = getMech().getLocationName(Mech.LOC_RT) + caseSuffix(Mech.LOC_RT);
+        rtPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+        title = getMech().getLocationName(Mech.LOC_CT) + caseSuffix(Mech.LOC_CT);
+        ctPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+        title = getMech().getLocationName(Mech.LOC_HEAD) + caseSuffix(Mech.LOC_HEAD);
+        hdPanel.setBorder(CritCellUtil.locationBorderNoLine(title));
+    }
+
+    private String caseSuffix(int location) {
+        if (getMech().hasCASEII(location)) {
+            return " (CASE II)";
+        } else if (getMech().locationHasCase(location)) {
+            return " (CASE)";
+        } else {
+            return "";
         }
     }
 

--- a/megameklab/src/megameklab/ui/mek/BMUtils.java
+++ b/megameklab/src/megameklab/ui/mek/BMUtils.java
@@ -473,30 +473,18 @@ public final class BMUtils {
     }
 
     /**
-     * For the given Mek, adds clan CASE in every location that has potentially
-     * explosive equipment (this includes PPC Capacitors) and removes it from every
-     * location that has none.
-     * <P>This method doesn't check what type the given Mek is nor its tech base.
-     * <P>As clan CASE does not need critical slots, this method does not check
-     * whether other CASE types are already present on a location.
+     * For the given Mek, adds Clan CASE in every location that has potentially
+     * explosive equipment (this includes PPC Capacitors) and removes it from all
+     * other locations.
+     * Calls {@link Mech#addClanCase()}. This method does not check if other
+     * CASE types are already present on a location.
      *
      * @param mek the mek to update
      */
     public static void updateClanCasePlacement(Mech mek) {
-        EquipmentType clCase = EquipmentType.get(EquipmentTypeLookup.CLAN_CASE);
-        removeAllMounteds(mek, clCase);
-
-        Set<Integer> autoCaseLocations = mek.getEquipment().stream()
-                .filter(m -> m.getType().isExplosive(m, true))
-                .map(Mounted::getLocation)
-                .collect(toSet());
-
-        for (int loc : autoCaseLocations) {
-            try {
-                mek.addEquipment(new Mounted(mek, clCase), loc, false);
-            } catch (LocationFullException ignore) {
-                // cannot happen as Clan CASE does not require crit slots
-            }
+        if (mek.isClan()) {
+            removeAllMounteds(mek, EquipmentType.get(EquipmentTypeLookup.CLAN_CASE));
+            mek.addClanCase();
         }
     }
 }

--- a/megameklab/src/megameklab/ui/mek/BMUtils.java
+++ b/megameklab/src/megameklab/ui/mek/BMUtils.java
@@ -472,4 +472,31 @@ public final class BMUtils {
         return true;
     }
 
+    /**
+     * For the given Mek, adds clan CASE in every location that has potentially
+     * explosive equipment (this includes PPC Capacitors) and removes it from every
+     * location that has none.
+     * <P>This method doesn't check what type the given Mek is nor its tech base.
+     * <P>As clan CASE does not need critical slots, this method does not check
+     * whether other CASE types are already present on a location.
+     *
+     * @param mek the mek to update
+     */
+    public static void updateClanCasePlacement(Mech mek) {
+        EquipmentType clCase = EquipmentType.get(EquipmentTypeLookup.CLAN_CASE);
+        removeAllMounteds(mek, clCase);
+
+        Set<Integer> autoCaseLocations = mek.getEquipment().stream()
+                .filter(m -> m.getType().isExplosive(m, true))
+                .map(Mounted::getLocation)
+                .collect(toSet());
+
+        for (int loc : autoCaseLocations) {
+            try {
+                mek.addEquipment(new Mounted(mek, clCase), loc, false);
+            } catch (LocationFullException ignore) {
+                // cannot happen as Clan CASE does not require crit slots
+            }
+        }
+    }
 }

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -55,6 +55,7 @@ import megamek.common.weapons.srms.StreakSRMWeapon;
 import megamek.common.weapons.tag.CLLightTAG;
 import megamek.common.weapons.tag.CLTAG;
 import megamek.common.weapons.tag.ISTAG;
+import megameklab.ui.mek.BMUtils;
 import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
@@ -411,8 +412,8 @@ public class UnitUtil {
             boolean rearMounted) throws LocationFullException {
         unit.addEquipment(mounted, loc, rearMounted);
         mounted.setOmniPodMounted(canPodMount(unit, mounted));
-        if (mounted.getType().isExplosive(mounted, true) && (unit instanceof Mech) && unit.isClan()) {
-            ((Mech) unit).addClanCase();
+        if ((unit instanceof Mech) && unit.isClan()) {
+            BMUtils.updateClanCasePlacement((Mech) unit);
         }
     }
 
@@ -1324,8 +1325,8 @@ public class UnitUtil {
                 // Exception thrown for not having equipment to link to yet, which is acceptable here
             }
         }
-        if (eq.getType().isExplosive(eq, true) && (unit instanceof Mech) && unit.isClan()) {
-            ((Mech) unit).addClanCase();
+        if ((unit instanceof Mech) && unit.isClan()) {
+            BMUtils.updateClanCasePlacement((Mech) unit);
         }
     }
 

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -412,7 +412,7 @@ public class UnitUtil {
             boolean rearMounted) throws LocationFullException {
         unit.addEquipment(mounted, loc, rearMounted);
         mounted.setOmniPodMounted(canPodMount(unit, mounted));
-        if ((unit instanceof Mech) && unit.isClan()) {
+        if (unit instanceof Mech) {
             BMUtils.updateClanCasePlacement((Mech) unit);
         }
     }
@@ -1325,7 +1325,7 @@ public class UnitUtil {
                 // Exception thrown for not having equipment to link to yet, which is acceptable here
             }
         }
-        if ((unit instanceof Mech) && unit.isClan()) {
+        if (unit instanceof Mech) {
             BMUtils.updateClanCasePlacement((Mech) unit);
         }
     }


### PR DESCRIPTION
This came out of fixing MM #3257 (Clan automatic CASE for PPC Capacitors):
- On Meks, the crit view now shows for each location if it has CASE. The Record Sheets do that already and it shows clearly if there is a Clan CASE present which is otherwise invisible. This was very useful for looking at this issue and I expect it would be useful for mixed units where Clan CASE is not automatic but can (theoretically) be added.
- Adds an MML-side method that adds and removes Clan auto-CASE as necessary. The MM side method that was previously called adds CASE but doesn't remove it (and MML has the better utility methods for doing so).

![image](https://user-images.githubusercontent.com/17069663/162638312-066c4074-eaa1-44b4-8841-294d507281e7.png)
