### PR TITLE
Fixes an encoding issue for PDF record sheets with reference tables enabled.

### DIFF
--- a/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
+++ b/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
@@ -46,7 +46,7 @@ public class PhysicalAttacks extends ReferenceTable {
         addPunchAttacks(sheet.getEntity());
         addRow(bundle.getString("kick"), "-2", String.valueOf(kickDamage));
         if (!(sheet.getEntity() instanceof QuadMech)) {
-            addRow(bundle.getString("push"), "-1", "—");
+            addRow(bundle.getString("push"), "-1", "\u2014");
         }
         if (sheet.getEntity().hasSystem(Mech.ACTUATOR_HAND, Mech.LOC_LARM)
                && sheet.getEntity().hasSystem(Mech.ACTUATOR_HAND, Mech.LOC_RARM)) {


### PR DESCRIPTION
There was a UTF-8 literal causing an output encoding issue with the Push attack line in the Physical Attack table.  This changes the raw UTF-8 character to a Java Unicode literal. Fixes #1111 