### PR TITLE
Fix ConcurrentModificationException in BMUtils::fillInFMU

### DIFF
--- a/megameklab/src/megameklab/ui/mek/BMUtils.java
+++ b/megameklab/src/megameklab/ui/mek/BMUtils.java
@@ -79,7 +79,8 @@ public final class BMUtils {
      * locations on the Mek as long as there are any.
      */
     public static void fillInFMU(Mech mek) {
-        for (Mounted mount : mek.getEquipment()) {
+        // Work with a copy because the equipment list may be modified.
+        for (Mounted mount : new ArrayList<>(mek.getEquipment())) {
             if (!BMUtils.isFMU(mount) || (mount.getLocation() != Entity.LOC_NONE)) {
                 continue;
             }


### PR DESCRIPTION
BMUtils::fillInFMU can modify the equipmentList while iterating over it. By iterating over a copy we avoid the ConcurrentModificationException.

Fixes #1121 and #1137.