### PR TITLE
Don't assign secondary location to non-split equipment

### DIFF
--- a/megameklab/src/megameklab/ui/mek/BMCriticalTransferHandler.java
+++ b/megameklab/src/megameklab/ui/mek/BMCriticalTransferHandler.java
@@ -124,7 +124,7 @@ public class BMCriticalTransferHandler extends TransferHandler {
         }
         int neededPrimarySlots = Math.min(neededTotalSlots, freePrimarySlots);
         int neededSecondarySlots = Math.max(0, neededTotalSlots - freePrimarySlots);
-        int secondLocation = mek.getTransferLocation(location);
+        int secondLocation = Entity.LOC_NONE;
 
         // Determine if we should spread equipment over multiple locations
         if ((neededTotalSlots > freePrimarySlots)


### PR DESCRIPTION
When dragging splittable equipment into a location, a secondary location is assigned whether used or not. Since the block that follows the modified line handles selecting the secondary location when needed, the initial value should be LOC_NONE.

Fixes #1125