### PR TITLE
Show DWP data on BA record sheets

### DIFF
--- a/megameklab/src/megameklab/printing/PrintBattleArmor.java
+++ b/megameklab/src/megameklab/printing/PrintBattleArmor.java
@@ -133,6 +133,16 @@ public class PrintBattleArmor extends PrintEntity {
     }
 
     @Override
+    protected String formatWalk() {
+        if (battleArmor.hasDWP()) {
+            return formatMovement(battleArmor.getWalkMP(),
+                    battleArmor.getWalkMP(true, false, false, true, false));
+        } else {
+            return super.formatWalk();
+        }
+    }
+
+    @Override
     public String formatMiscNotes() {
         final StringJoiner sj = new StringJoiner(" ");
         if (battleArmor.isBurdened() && ((battleArmor.getJumpMP(false, true, true) > 0)

--- a/megameklab/src/megameklab/printing/StandardInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/StandardInventoryEntry.java
@@ -265,6 +265,9 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
         if (mount.isSquadSupportWeapon()) {
             name.append(" (SSW)");
         }
+        if (mount.isDWPMounted()) {
+            name.append(" (DWP)");
+        }
         if (mount.getEntity().isAero()) {
             name.append(" ").append(StringUtils.getAeroEquipmentInfo(mount));
         }


### PR DESCRIPTION
The BA record sheet only shows the burdened ground MP for units with detachable weapon packs. I have adjusted it to show both values following the format used in XTRO:Clans for the Elemental II (X). I have also added an indicator of which particular equipment needs to be dropped to get full movement.