### PR TITLE
Add missing columns to BA cluster reference table

### DIFF
--- a/megameklab/src/megameklab/printing/reference/ClusterHitsTable.java
+++ b/megameklab/src/megameklab/printing/reference/ClusterHitsTable.java
@@ -74,7 +74,9 @@ public class ClusterHitsTable extends ReferenceTable {
             if (entity instanceof BattleArmor) {
                 for (Mounted mounted : entity.getIndividualWeaponList()) {
                     if (mounted.getType() instanceof MissileWeapon) {
-                        clusterSizes.add(Math.min(40, size * ((MissileWeapon) mounted.getType()).getRackSize()));
+                        for (int i = 1; i <= size; i++) {
+                            clusterSizes.add(Math.min(40, i * ((MissileWeapon) mounted.getType()).getRackSize()));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The cluster hits optional reference tables only include the cluster hits columns for missile weapons for a full-strength BA squad. As troopers are eliminated other columns are needed.