### PR TITLE
MML Issue 1133: more save prompts

### DIFF
--- a/megameklab/resources/megameklab/resources/Dialogs.properties
+++ b/megameklab/resources/megameklab/resources/Dialogs.properties
@@ -46,6 +46,8 @@ ConfigurationDialog.cbRSScale.tooltip=Allows changing the scale for use with min
 ConfigurationDialog.txtScale.tooltip=The factor for all movement and range values
 ConfigurationDialog.chkSummaryFormatTRO.text=Use TRO format for text export
 ConfigurationDialog.chkSummaryFormatTRO.tooltip=When checked, text exports are formatted in technical readout style, otherwise as a traditional MegaMek unit summary.
+ConfigurationDialog.chkSkipSavePrompts.text=Disable save prompts. Use at your own risk!
+ConfigurationDialog.chkSkipSavePrompts.tooltip=When checked, no safety dialogs warning about losing changes when switching unit or unit type will be shown.
 
 RecordSheetTask.printing=Printing
 RecordSheetTask.exporting=Exporting

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -1162,6 +1162,10 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
     }
 
     private void jMenuResetEntity_actionPerformed(ActionEvent event) {
+        if (!getFrame().safetyPrompt()) {
+            return;
+        }
+
         CConfig.updateSaveFiles("Reset Unit");
         CConfig.setParam(CConfig.CONFIG_SAVE_FILE_1, "");
         Entity en = getFrame().getEntity();
@@ -1399,6 +1403,10 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
                         resources.getString("message.abortUnitLoad.text"));
             }
             return;
+        } else {
+            if (!getFrame().safetyPrompt()) {
+                return;
+            }
         }
 
         UnitUtil.updateLoadedUnit(newUnit);
@@ -1514,9 +1522,11 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
      * @param type an <code>int</code> corresponding to the unit type to construct
      */
     private void newUnit(long type, boolean primitive, Entity en) {
-        getFrame().setVisible(false);
-        LoadingDialog ld = new LoadingDialog(getFrame(), type, primitive, false, en);
-        ld.setVisible(true);
+        if (frame.safetyPrompt()) {
+            getFrame().setVisible(false);
+            LoadingDialog ld = new LoadingDialog(getFrame(), type, primitive, false, en);
+            ld.setVisible(true);
+        }
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
@@ -35,6 +35,7 @@ import java.util.ResourceBundle;
 public class MiscSettingsPanel extends JPanel {
 
     private final JCheckBox chkSummaryFormatTRO = new JCheckBox();
+    private final JCheckBox chkSkipSavePrompts = new JCheckBox();
 
     MiscSettingsPanel() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs", new EncodeControl());
@@ -43,10 +44,15 @@ public class MiscSettingsPanel extends JPanel {
         chkSummaryFormatTRO.setToolTipText(resourceMap.getString("ConfigurationDialog.chkSummaryFormatTRO.tooltip"));
         chkSummaryFormatTRO.setSelected(CConfig.getBooleanParam(CConfig.MISC_SUMMARY_FORMAT_TRO));
 
+        chkSkipSavePrompts.setText(resourceMap.getString("ConfigurationDialog.chkSkipSavePrompts.text"));
+        chkSkipSavePrompts.setToolTipText(resourceMap.getString("ConfigurationDialog.chkSkipSavePrompts.tooltip"));
+        chkSkipSavePrompts.setSelected(CConfig.getBooleanParam(CConfig.MISC_SKIP_SAFETY_PROMPTS));
+
         JPanel gridPanel = new JPanel(new SpringLayout());
         gridPanel.add(chkSummaryFormatTRO);
+        gridPanel.add(chkSkipSavePrompts);
 
-        SpringUtilities.makeCompactGrid(gridPanel, 1, 1, 0, 0, 15, 10);
+        SpringUtilities.makeCompactGrid(gridPanel, 2, 1, 0, 0, 15, 10);
         gridPanel.setBorder(new EmptyBorder(20, 30, 20, 30));
         setLayout(new FlowLayout(FlowLayout.LEFT));
         add(gridPanel);
@@ -55,6 +61,7 @@ public class MiscSettingsPanel extends JPanel {
     Map<String, String> getMiscSettings() {
         Map<String, String> miscSettings = new HashMap<>();
         miscSettings.put(CConfig.MISC_SUMMARY_FORMAT_TRO, String.valueOf(chkSummaryFormatTRO.isSelected()));
+        miscSettings.put(CConfig.MISC_SKIP_SAFETY_PROMPTS, String.valueOf(chkSkipSavePrompts.isSelected()));
         return miscSettings;
     }
 }

--- a/megameklab/src/megameklab/ui/util/IntRangeTextField.java
+++ b/megameklab/src/megameklab/ui/util/IntRangeTextField.java
@@ -81,7 +81,7 @@ public class IntRangeTextField extends JFormattedTextField {
         maximum = max;
     }
 
-    private InputVerifier inputVerifier = new InputVerifier() {
+    private final InputVerifier inputVerifier = new InputVerifier() {
         @Override
         public boolean verify(JComponent input) {
             try {
@@ -93,7 +93,7 @@ public class IntRangeTextField extends JFormattedTextField {
         }
 
         @Override
-        public boolean shouldYieldFocus(JComponent input) {
+        public boolean shouldYieldFocus(JComponent input, JComponent target) {
             if (!verify(input)) {
                 int val = getIntVal();
                 if (minimum != null && val < minimum) {
@@ -106,7 +106,7 @@ public class IntRangeTextField extends JFormattedTextField {
         }
     };
 
-    private DocumentFilter docFilter = new DocumentFilter() {
+    private final DocumentFilter docFilter = new DocumentFilter() {
 
         @Override
         public void insertString(FilterBypass fb, int offset, String string, AttributeSet attr)
@@ -122,7 +122,6 @@ public class IntRangeTextField extends JFormattedTextField {
         @Override
         public void replace(FilterBypass fb, int offset, int length, String text, AttributeSet attrs)
                 throws BadLocationException {
-            // TODO Auto-generated method stub
             for (int i = 0; i < text.length(); i++) {
                 if (!Character.isDigit(text.charAt(i))) {
                     return;
@@ -132,7 +131,7 @@ public class IntRangeTextField extends JFormattedTextField {
         }
 
     };
-    
+
     /**
      * Parses the text as an {@code int}.
      * @return The {@code int} value of the text, or zero if the text is not a valid int value

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -84,6 +84,7 @@ public class CConfig {
     public static final String TECH_UNOFFICAL_NO_YEAR = "techUnofficialNoYear";
 
     public static final String MISC_SUMMARY_FORMAT_TRO = "useTROFormat";
+    public static final String MISC_SKIP_SAFETY_PROMPTS = "skipSafetyPrompts";
     
     public static final String CONFIG_SAVE_LOC = "Save-Location-Default";
     public static final String CONFIG_PLAF = "lookAndFeel";
@@ -128,6 +129,7 @@ public class CConfig {
                 new File(System.getProperty("user.dir")
                         + "/data/mechfiles/").getAbsolutePath());
         defaults.setProperty(MISC_SUMMARY_FORMAT_TRO, Boolean.toString(true));
+        defaults.setProperty(MISC_SKIP_SAFETY_PROMPTS, Boolean.toString(false));
         defaults.setProperty(RS_PROGRESS_BAR, Boolean.toString(true));
         defaults.setProperty(RS_COLOR, Boolean.toString(true));
         defaults.setProperty(RS_SHOW_QUIRKS, Boolean.toString(true));


### PR DESCRIPTION
Fixes #1133 

This adds a safety prompt to all actions that cause loss of the current unit, i.e. Reset, Switch Unit Type, Load Unit, Quit (quit already had this prompt, it is now unified with the other actions).

![image](https://user-images.githubusercontent.com/17069663/179309668-899d3871-1aaf-415f-9cd6-b7323731d778.png)

For devs or others who like a little suspense there is a Misc Setting in the Settings menu to disable those prompts completely (all of them!)