### PR TITLE
Fix label for UMU MP on mech record sheets

### DIFF
--- a/megameklab/data/images/recordsheets/templates_iso/mech_biped_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_biped_default.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_biped_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_biped_default.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quad_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quad_default.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quad_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quad_default.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_default.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_default.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_toheat.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_toheat.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_tripod_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_tripod_default.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_tripod_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_tripod_default.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_biped_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_biped_default.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_biped_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_biped_default.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_biped_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_biped_toheat.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_biped_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_biped_toheat.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quad_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quad_default.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quad_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quad_default.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quad_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quad_toheat.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quad_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quad_toheat.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quadvee_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quadvee_default.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quadvee_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quadvee_default.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quadvee_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quadvee_toheat.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quadvee_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quadvee_toheat.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="44.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_tripod_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_tripod_default.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_tripod_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_tripod_default.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
@@ -621,7 +621,7 @@
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
@@ -613,15 +613,15 @@
                                                                       >Lorem Ipsum</text
                                                                       ><text fill="#231f20" x="6.000" y="38.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Movement Points:</text
-                                                                      ><text x="6.000" y="47.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.532" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Walking:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpWalk" y="47.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="28.629" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Running:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpRun" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="lblJump" textLength="29.883" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text fill="#231f20" x="6.000" id="lblJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" text-anchor="start"
                                                                       >Jumping:</text
                                                                       ><text fill="#231f20" x="56.000" id="mpJump" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text


### PR DESCRIPTION
MML has the code that changes the text from "Jumping:" to "Underwater:" but the labels are missing in the SVG templates.

Fixes #1147