### PR TITLE
Add ammo to small craft in single-ton lots

### DIFF
--- a/megameklab/src/megameklab/ui/largeAero/LAEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LAEquipmentDatabaseView.java
@@ -57,7 +57,7 @@ class LAEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
         } else {
             if (equip instanceof AmmoType) {
                 Mounted aMount = UnitUtil.findUnallocatedAmmo(getAero(), equip);
-                if (null != aMount) {
+                if ((null != aMount) && getAero().usesWeaponBays()) {
                     aMount.setShotsLeft(aMount.getUsableShotsLeft() + ((AmmoType) equip).getShots() * count);
                 } else {
                     mount = new Mounted(getAero(), equip);


### PR DESCRIPTION
Small craft use the large craft construction rules but differ in that they do not use weapons bays. Ammo should be added in single-ton lots rather than grouped together. The ammo is being added but not shown because the equipment panel doesn't account for multi-ton ammo for units without weapon bays.

Fixes #1166 