### PR TITLE
Add the engine type to Mek, Fighter and Vee RS

### DIFF
--- a/megameklab/data/images/recordsheets/templates_iso/fighter_aerospace_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/fighter_aerospace_default.svg
@@ -633,6 +633,10 @@
                                                                       >Rules Level:</text
                                                                       ><text fill="#231f20" x="154.840" id="rulesLevel" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:60.760" text-anchor="start"
                                                                       >Standard</text
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
                                                                       ><text x="112.300" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="labelRole" textLength="16.160" lengthAdjust="spacingAndGlyphs"
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="154.840" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:60.760" text-anchor="start"

--- a/megameklab/data/images/recordsheets/templates_iso/fighter_conventional_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/fighter_conventional_default.svg
@@ -633,6 +633,10 @@
                                                                       >Rules Level:</text
                                                                       ><text fill="#231f20" x="154.840" id="rulesLevel" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:60.760" text-anchor="start"
                                                                       >Standard</text
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
                                                                       ><text x="112.300" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="labelRole" textLength="16.160" lengthAdjust="spacingAndGlyphs"
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="154.840" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:60.760" text-anchor="start"

--- a/megameklab/data/images/recordsheets/templates_iso/mech_biped_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_biped_default.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="154.840" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:60.760" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 212.600,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="165.828" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="209.600" id="inventory" height="220.641" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,301.641 L 212.600,301.641" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="313.641" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_biped_toheat.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="154.840" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:60.760" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 212.600,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="165.828" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="209.600" id="inventory" height="220.641" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,301.641 L 212.600,301.641" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="313.641" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_lam_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_lam_default.svg
@@ -671,12 +671,16 @@
                                                                       >Max Thrust:</text
                                                                       ><text fill="#231f20" x="206.072" id="mpMaxThrust" y="83.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><path d="M 3.000,87.000 L 212.600,87.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="97.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="92.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="92.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,96.500 L 219.400,96.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="105.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="165.828" id="unitScale" y="97.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="105.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="209.600" id="inventory" height="202.641" y="97.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="167.643" y="105.500"
                                                                       /><path d="M 3.000,301.641 L 212.600,301.641" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="313.641" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_lam_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_lam_toheat.svg
@@ -671,12 +671,16 @@
                                                                       >Max Thrust:</text
                                                                       ><text fill="#231f20" x="206.072" id="mpMaxThrust" y="83.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><path d="M 3.000,87.000 L 212.600,87.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="97.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="92.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="92.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,96.500 L 219.400,96.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="105.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="165.828" id="unitScale" y="97.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="105.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="209.600" id="inventory" height="202.641" y="97.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="167.643" y="105.500"
                                                                       /><path d="M 3.000,301.641 L 212.600,301.641" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="313.641" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quad_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quad_default.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="154.840" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:60.760" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 212.600,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="165.828" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="209.600" id="inventory" height="220.641" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,301.641 L 212.600,301.641" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="313.641" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quad_toheat.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="154.840" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:60.760" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 212.600,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="165.828" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="209.600" id="inventory" height="220.641" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,301.641 L 212.600,301.641" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="313.641" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_default.svg
@@ -651,12 +651,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="154.840" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 212.600,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="165.828" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="209.600" id="inventory" height="220.641" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,301.641 L 212.600,301.641" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="313.641" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_quadvee_toheat.svg
@@ -651,12 +651,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="154.840" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 212.600,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="165.828" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="209.600" id="inventory" height="220.641" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,301.641 L 212.600,301.641" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="313.641" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_tripod_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_tripod_default.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="154.840" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:60.760" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 212.600,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="165.828" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="209.600" id="inventory" height="220.641" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,301.641 L 212.600,301.641" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="313.641" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/mech_tripod_toheat.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="154.840" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:60.760" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 212.600,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="165.828" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="209.600" id="inventory" height="220.641" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,301.641 L 212.600,301.641" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="313.641" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_us/fighter_aerospace_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/fighter_aerospace_default.svg
@@ -633,6 +633,10 @@
                                                                       >Rules Level:</text
                                                                       ><text fill="#231f20" x="158.240" id="rulesLevel" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:64.160" text-anchor="start"
                                                                       >Standard</text
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
                                                                       ><text x="115.700" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="labelRole" textLength="16.160" lengthAdjust="spacingAndGlyphs"
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="158.240" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:64.160" text-anchor="start"

--- a/megameklab/data/images/recordsheets/templates_us/fighter_conventional_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/fighter_conventional_default.svg
@@ -633,6 +633,10 @@
                                                                       >Rules Level:</text
                                                                       ><text fill="#231f20" x="158.240" id="rulesLevel" y="56.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:64.160" text-anchor="start"
                                                                       >Standard</text
+                                                                      ><text x="6.000" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
                                                                       ><text x="115.700" y="65.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" id="labelRole" textLength="16.160" lengthAdjust="spacingAndGlyphs"
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="158.240" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:64.160" text-anchor="start"

--- a/megameklab/data/images/recordsheets/templates_us/mech_biped_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_biped_default.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="158.240" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:64.160" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 219.400,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="194.143" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,275.143 L 219.400,275.143" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="287.143" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_biped_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_biped_toheat.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="158.240" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:64.160" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 219.400,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="194.143" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,275.143 L 219.400,275.143" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="287.143" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_lam_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_lam_default.svg
@@ -671,12 +671,16 @@
                                                                       >Max Thrust:</text
                                                                       ><text fill="#231f20" x="210.968" id="mpMaxThrust" y="83.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><path d="M 3.000,87.000 L 219.400,87.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="97.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="92.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="92.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,96.500 L 219.400,96.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="105.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="97.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="105.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="176.143" y="97.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="167.643" y="105.500"
                                                                       /><path d="M 3.000,275.143 L 219.400,275.143" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="287.143" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_lam_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_lam_toheat.svg
@@ -671,12 +671,16 @@
                                                                       >Max Thrust:</text
                                                                       ><text fill="#231f20" x="210.968" id="mpMaxThrust" y="83.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="middle"
                                                                       >0</text
-                                                                      ><path d="M 3.000,87.000 L 219.400,87.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="97.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="92.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="92.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,96.500 L 219.400,96.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="105.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="97.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="105.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="176.143" y="97.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="167.643" y="105.500"
                                                                       /><path d="M 3.000,275.143 L 219.400,275.143" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="287.143" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quad_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quad_default.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="158.240" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:64.160" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 219.400,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="194.143" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,275.143 L 219.400,275.143" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="287.143" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quad_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quad_toheat.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="158.240" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:64.160" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 219.400,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="194.143" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,275.143 L 219.400,275.143" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="287.143" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quadvee_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quadvee_default.svg
@@ -651,12 +651,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="158.240" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 219.400,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="194.143" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,275.143 L 219.400,275.143" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="287.143" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_quadvee_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_quadvee_toheat.svg
@@ -651,12 +651,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="158.240" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 219.400,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="194.143" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,275.143 L 219.400,275.143" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="287.143" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_tripod_default.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_tripod_default.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="158.240" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:64.160" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 219.400,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="194.143" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,275.143 L 219.400,275.143" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="287.143" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
+++ b/megameklab/data/images/recordsheets/templates_us/mech_tripod_toheat.svg
@@ -641,12 +641,16 @@
                                                                       >Role:</text
                                                                       ><text fill="#231f20" x="158.240" id="role" y="65.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal;mml-field-width:64.160" text-anchor="start"
                                                                       >Lorem Ipsum</text
-                                                                      ><path d="M 3.000,69.000 L 219.400,69.000" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
-                                                                      /><text x="3.000" y="79.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
+                                                                      ><text x="6.000" y="74.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:7.700px;font-weight:bold;font-style:normal" textLength="40.915" lengthAdjust="spacingAndGlyphs"
+                                                                      >Engine Type:</text
+                                                                      ><text fill="#231f20" x="56.000" id="engineType" y="74.000" style="font-family:Eurostile;font-size:7.700px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      >Lorem Ipsum</text
+                                                                      ><path d="M 3.000,78.500 L 219.400,78.500" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
+                                                                      /><text x="3.000" y="87.500" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:8.600px;font-weight:bold;font-style:normal" textLength="121.508" lengthAdjust="spacingAndGlyphs"
                                                                       >Weapons &amp; Equipment Inventory</text
-                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="79.000" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
+                                                                      ><text fill="#231f20" x="171.132" id="unitScale" y="87.500" style="font-family:Eurostile;font-size:6.760px;font-weight:normal;font-style:normal" text-anchor="start"
                                                                       >(hexes)</text
-                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="194.143" y="79.000"
+                                                                      ><rect fill="none" x="3.000" width="216.400" id="inventory" height="185.643" y="87.500"
                                                                       /><path d="M 3.000,275.143 L 219.400,275.143" stroke-width="1.932" stroke-linejoin="round" stroke="#000000"
                                                                       /><text x="13.845" y="287.143" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="14.117" lengthAdjust="spacingAndGlyphs"
                                                                       >BV:</text

--- a/megameklab/src/megameklab/printing/PrintAero.java
+++ b/megameklab/src/megameklab/printing/PrintAero.java
@@ -125,6 +125,8 @@ public class PrintAero extends PrintEntity {
         super.writeTextFields();
         setTextField(HS_TYPE, formatHeatSinkType());
         setTextField(HS_COUNT, formatHeatSinkCount());
+        setTextField(ENGINE_TYPE, aero.getEngine().getShortEngineName()
+                .replaceAll("\\[.*]", "").trim());
     }
 
     @Override

--- a/megameklab/src/megameklab/printing/PrintMech.java
+++ b/megameklab/src/megameklab/printing/PrintMech.java
@@ -229,6 +229,8 @@ public class PrintMech extends PrintEntity {
             setTextField(MP_FLANK, formatQuadVeeFlank());
             setTextField(LBL_VEE_MODE, ((QuadVee) mech).getMotiveTypeString() + "s");
         }
+        setTextField(ENGINE_TYPE, mech.getEngine().getShortEngineName()
+                .replaceAll("\\[.*]", "").trim());
     }
 
     @Override

--- a/megameklab/src/megameklab/printing/PrintTank.java
+++ b/megameklab/src/megameklab/printing/PrintTank.java
@@ -128,8 +128,8 @@ public class PrintTank extends PrintEntity {
     protected void writeTextFields() {
         super.writeTextFields();
         setTextField(MOVEMENT_TYPE, tank.getMovementModeAsString());
-        setTextField(ENGINE_TYPE, tank.getEngine().getEngineName()
-                .replaceAll("\\d+|\\[.*]", "").trim());
+        setTextField(ENGINE_TYPE, tank.getEngine().getShortEngineName()
+                .replaceAll("\\[.*]", "").trim());
         if (tank.getOriginalJumpMP() > 0) {
             setTextField(MP_JUMP, formatJump());
         } else {


### PR DESCRIPTION
Fixes #1169 
* Adds the engine rating to the engine type line on Combat Vees
* Adds a similar engine type line to Meks & Fighters
![image](https://user-images.githubusercontent.com/17069663/199693132-1c9399b4-fbb7-4365-8043-bf412d86662e.png)
![image](https://user-images.githubusercontent.com/17069663/199693163-f364a9ef-b683-41df-91eb-f2357aae93cf.png)
![image](https://user-images.githubusercontent.com/17069663/199693245-a96352b7-c6cc-4cb7-a38c-e1b6270708f8.png)
![image](https://user-images.githubusercontent.com/17069663/199693274-133f5deb-ee80-43bd-9429-171c69b8e397.png)
![image](https://user-images.githubusercontent.com/17069663/200111447-b73ecc8d-9cb8-4d0f-84a5-20efa8a0ec6d.png)
![image](https://user-images.githubusercontent.com/17069663/200111540-d6a9b795-42bc-4db4-acc5-7868506883ad.png)

