### PR TITLE
Issue 1179 (Plasma Rifle (IS) label)

### DIFF
--- a/megameklab/src/megameklab/printing/StandardInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/StandardInventoryEntry.java
@@ -298,7 +298,8 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
         while (e.hasMoreElements()) {
             final EquipmentType et = e.nextElement();
             if ((et.getTechBase() != mount.getType().getTechBase())
-                    && et.getName().equals(mount.getType().getName())) {
+                    && et.getName().equals(mount.getType().getName())
+                    && !et.isUnofficial()) {
                 showMixedTechBase.put(mount.getType(), true);
                 showMixedTechBase.put(et, true);
                 return true;


### PR DESCRIPTION
Fixes #1179 
This removes any unofficial weapons such as the C-Plasma Rifle from consideration in the method that finds if an (IS) or (C) label is to be added on a mixed tech unit.

(The method tries finding the equivalent of the weapon in question in the other tech base - now unofficials are ignored in this search meaning that it finds no C-Plasma Rifle and therefore does not need to add (IS) to the IS-Plasma Rifle).

![image](https://user-images.githubusercontent.com/17069663/200112226-b63da236-af07-4139-a759-4b7cd05cbc58.png)
