### PR TITLE
Tearing out EncodeControl

### DIFF
--- a/megameklab/src/megameklab/printing/RecordSheetTask.java
+++ b/megameklab/src/megameklab/printing/RecordSheetTask.java
@@ -13,7 +13,6 @@
  */
 package megameklab.printing;
 
-import megamek.common.util.EncodeControl;
 import org.apache.logging.log4j.LogManager;
 import org.apache.pdfbox.io.MemoryUsageSetting;
 import org.apache.pdfbox.multipdf.PDFMergerUtility;
@@ -152,8 +151,7 @@ public abstract class RecordSheetTask extends SwingWorker<Void, Integer> {
 
         @Override
         protected String popupLabel() {
-            ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs",
-                    new EncodeControl());
+            ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs");
             return resourceMap.getString("RecordSheetTask.printing");
         }
 
@@ -176,8 +174,7 @@ public abstract class RecordSheetTask extends SwingWorker<Void, Integer> {
 
         @Override
         protected String popupLabel() {
-            ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs",
-                    new EncodeControl());
+            ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs");
             return resourceMap.getString("RecordSheetTask.exporting");
         }
 

--- a/megameklab/src/megameklab/printing/reference/ReferenceTableBase.java
+++ b/megameklab/src/megameklab/printing/reference/ReferenceTableBase.java
@@ -13,7 +13,6 @@
  */
 package megameklab.printing.reference;
 
-import megamek.common.util.EncodeControl;
 import megameklab.printing.PrintRecordSheet;
 import megameklab.util.CConfig;
 import org.apache.batik.util.SVGConstants;
@@ -33,8 +32,7 @@ abstract public class ReferenceTableBase {
     private static final double STROKE_WIDTH = 1.6;
     static final double PADDING = 3.0;
 
-    protected final ResourceBundle bundle = ResourceBundle.getBundle(getClass().getName(),
-            new EncodeControl());
+    protected final ResourceBundle bundle = ResourceBundle.getBundle(getClass().getName());
     final PrintRecordSheet sheet;
 
     public static double getMargins(PrintRecordSheet sheet) {

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -20,7 +20,6 @@ import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.loaders.BLKFile;
 import megamek.common.templates.TROView;
-import megamek.common.util.EncodeControl;
 import megameklab.MMLConstants;
 import megameklab.ui.dialog.LoadingDialog;
 import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
@@ -55,7 +54,7 @@ import java.util.stream.Stream;
 public class MenuBar extends JMenuBar implements ClipboardOwner {
     //region Variable Declarations
     private final MegaMekLabMainUI frame;
-    private final ResourceBundle resources = ResourceBundle.getBundle("megameklab.resources.Menu", new EncodeControl());
+    private final ResourceBundle resources = ResourceBundle.getBundle("megameklab.resources.Menu");
     //endregion Variable Declarations
 
     //region Constructors

--- a/megameklab/src/megameklab/ui/StartupGUI.java
+++ b/megameklab/src/megameklab/ui/StartupGUI.java
@@ -21,7 +21,6 @@ import megamek.client.ui.swing.widget.SkinSpecification;
 import megamek.client.ui.swing.widget.SkinSpecification.UIComponents;
 import megamek.client.ui.swing.widget.SkinXMLHandler;
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.util.ImageUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megameklab.MMLConstants;
@@ -56,7 +55,7 @@ public class StartupGUI extends JPanel {
         startupScreenImages.put(1921, "data/images/misc/mml_start_spooky_uhd.jpg"); // TODO : Remove inline filename
     }
     
-    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Splash", new EncodeControl());
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Splash");
     
     public StartupGUI() {       
         initComponents();

--- a/megameklab/src/megameklab/ui/battleArmor/BAChassisView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAChassisView.java
@@ -21,7 +21,6 @@ package megameklab.ui.battleArmor;
 import megamek.common.BattleArmor;
 import megamek.common.EntityWeightClass;
 import megamek.common.ITechManager;
-import megamek.common.util.EncodeControl;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.BABuildListener;
 import megameklab.ui.util.CustomComboBox;
@@ -71,7 +70,7 @@ public class BAChassisView extends BuildView implements ActionListener, ChangeLi
     }
     
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         cbChassisType.setModel(new DefaultComboBoxModel<>(resourceMap.getString("BAChassisView.cbBodyType.values").split(",")));
         cbTurretType.setModel(new DefaultComboBoxModel<>(resourceMap.getString("BAChassisView.cbTurretType.values").split(",")));
         setLayout(new GridBagLayout());

--- a/megameklab/src/megameklab/ui/battleArmor/BAEnhancementView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAEnhancementView.java
@@ -24,7 +24,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.JCheckBox;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.BABuildListener;
 
@@ -61,7 +60,7 @@ public class BAEnhancementView extends BuildView implements ActionListener {
     }
     
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();

--- a/megameklab/src/megameklab/ui/combatVehicle/CVChassisView.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVChassisView.java
@@ -19,7 +19,6 @@
 package megameklab.ui.combatVehicle;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestTank;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.CVBuildListener;
@@ -105,7 +104,7 @@ public class CVChassisView extends BuildView implements ActionListener, ChangeLi
     }
     
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         turretNames = resourceMap.getString("CVChassisView.turrets.values").split(",");
         for (EntityMovementMode m : MOTIVE_TYPES) {
             motiveNames.put(m, m.toString());

--- a/megameklab/src/megameklab/ui/combatVehicle/CVTransportView.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVTransportView.java
@@ -15,7 +15,6 @@ package megameklab.ui.combatVehicle;
 
 import megamek.common.Bay;
 import megamek.common.Tank;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.BayData;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.CVBuildListener;
@@ -63,7 +62,7 @@ public class CVTransportView extends BuildView implements ChangeListener {
     }
     
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();

--- a/megameklab/src/megameklab/ui/dialog/AbstractMMLButtonDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/AbstractMMLButtonDialog.java
@@ -19,7 +19,6 @@
 package megameklab.ui.dialog;
 
 import megamek.client.ui.baseComponents.AbstractButtonDialog;
-import megamek.common.util.EncodeControl;
 import megameklab.MegaMekLab;
 
 import javax.swing.*;
@@ -54,7 +53,7 @@ public abstract class AbstractMMLButtonDialog extends AbstractButtonDialog {
      */
     protected AbstractMMLButtonDialog(final JFrame frame, final boolean modal, final String name,
                                       final String title) {
-        this(frame, modal, ResourceBundle.getBundle("megameklab.resources.Dialogs", new EncodeControl()),
+        this(frame, modal, ResourceBundle.getBundle("megameklab.resources.Dialogs"),
                 name, title);
     }
 

--- a/megameklab/src/megameklab/ui/dialog/AbstractMMLDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/AbstractMMLDialog.java
@@ -15,7 +15,6 @@
 package megameklab.ui.dialog;
 
 import megamek.client.ui.baseComponents.AbstractDialog;
-import megamek.common.util.EncodeControl;
 import megameklab.MegaMekLab;
 
 import javax.swing.*;
@@ -42,7 +41,7 @@ public abstract class AbstractMMLDialog extends AbstractDialog {
      * to create modal dialogs.
      */
     protected AbstractMMLDialog(final JFrame frame, final boolean modal, final String name, final String title) {
-        this(frame, modal, ResourceBundle.getBundle("megameklab.resources.Dialogs", new EncodeControl()), name, title);
+        this(frame, modal, ResourceBundle.getBundle("megameklab.resources.Dialogs"), name, title);
     }
 
     /**

--- a/megameklab/src/megameklab/ui/dialog/settings/ExportSettingsPanel.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/ExportSettingsPanel.java
@@ -18,7 +18,6 @@
  */
 package megameklab.ui.dialog.settings;
 
-import megamek.common.util.EncodeControl;
 import megameklab.printing.PaperSize;
 import megameklab.ui.util.IntRangeTextField;
 import megameklab.ui.util.SpringUtilities;
@@ -53,7 +52,7 @@ class ExportSettingsPanel extends JPanel {
     private final IntRangeTextField txtScale = new IntRangeTextField(3);
 
     ExportSettingsPanel() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs");
 
         for (PaperSize paper : PaperSize.values()) {
             cbPaper.addItem(paper.displayName);

--- a/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
@@ -18,7 +18,6 @@
  */
 package megameklab.ui.dialog.settings;
 
-import megamek.common.util.EncodeControl;
 import megameklab.ui.util.SpringUtilities;
 import megameklab.util.CConfig;
 
@@ -38,7 +37,7 @@ public class MiscSettingsPanel extends JPanel {
     private final JCheckBox chkSkipSavePrompts = new JCheckBox();
 
     MiscSettingsPanel() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs");
 
         chkSummaryFormatTRO.setText(resourceMap.getString("ConfigurationDialog.chkSummaryFormatTRO.text"));
         chkSummaryFormatTRO.setToolTipText(resourceMap.getString("ConfigurationDialog.chkSummaryFormatTRO.tooltip"));

--- a/megameklab/src/megameklab/ui/dialog/settings/TechSettingsPanel.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/TechSettingsPanel.java
@@ -19,7 +19,6 @@
 package megameklab.ui.dialog.settings;
 
 import megamek.common.ITechnology;
-import megamek.common.util.EncodeControl;
 import megameklab.ui.util.IntRangeTextField;
 import megameklab.ui.util.SpringUtilities;
 import megameklab.util.CConfig;
@@ -44,7 +43,7 @@ public class TechSettingsPanel extends JPanel {
     private final JCheckBox chkUnofficialIgnoreYear = new JCheckBox();
 
     TechSettingsPanel() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs");
         chkTechProgression.addActionListener(e -> {
             chkTechUseYear.setEnabled(chkTechProgression.isSelected());
             txtTechYear.setEnabled(chkTechProgression.isSelected()

--- a/megameklab/src/megameklab/ui/fighterAero/ASChassisView.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASChassisView.java
@@ -22,7 +22,6 @@ import megamek.common.Aero;
 import megamek.common.Engine;
 import megamek.common.Entity;
 import megamek.common.ITechManager;
-import megamek.common.util.EncodeControl;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.AeroBuildListener;
 import megameklab.ui.util.CustomComboBox;
@@ -85,7 +84,7 @@ public class ASChassisView extends BuildView implements ActionListener, ChangeLi
     }
     
     public void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         fighterTypeNames = resourceMap.getString("FighterChassisView.cbFighterType.values").split(",");

--- a/megameklab/src/megameklab/ui/generalUnit/ArmorAllocationView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/ArmorAllocationView.java
@@ -31,7 +31,6 @@ import javax.swing.SwingConstants;
 import javax.swing.UIManager;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestSupportVehicle;
 import megameklab.ui.generalUnit.ArmorLocationView.ArmorLocationListener;
 import megameklab.ui.listeners.ArmorAllocationListener;
@@ -110,7 +109,7 @@ public class ArmorAllocationView extends BuildView implements ArmorLocationListe
     private final JButton btnAutoAllocate = new JButton();
     private final JLabel lblPointsPerTon = new JLabel("", SwingConstants.RIGHT);
 
-    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
     private long entitytype;
     private boolean showPatchwork = false;
     private String tooltipFormat;

--- a/megameklab/src/megameklab/ui/generalUnit/ArmorLocationView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/ArmorLocationView.java
@@ -28,7 +28,6 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 
 /**
  * Panel used to set armor value for a single location. Optionally used for rear location as well,
@@ -63,7 +62,7 @@ public class ArmorLocationView extends BuildView implements ChangeListener {
     ArmorLocationView(int location) {
         this.location = location;
         
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         lblRear.setText(resourceMap.getString("ArmorLocationView.lblRear.text"));
         maxFormat = resourceMap.getString("ArmorLocationView.lblMax.format");
         setBorder(BorderFactory.createTitledBorder(

--- a/megameklab/src/megameklab/ui/generalUnit/BAProtoArmorView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BAProtoArmorView.java
@@ -20,7 +20,6 @@ package megameklab.ui.generalUnit;
 
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestProtomech;
 import megameklab.ui.listeners.ArmorAllocationListener;
 import megameklab.ui.util.TechComboBox;
@@ -70,7 +69,7 @@ public class BAProtoArmorView extends BuildView implements ActionListener, Chang
     }
 
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
 
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();

--- a/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
@@ -20,7 +20,6 @@ package megameklab.ui.generalUnit;
 
 import megamek.MMConstants;
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megameklab.ui.listeners.BuildListener;
 import megameklab.ui.util.CustomComboBox;
 import megameklab.ui.util.FactionComboBox;
@@ -84,7 +83,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     //endregion Constructors
 
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl()); 
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         techBaseNames = resourceMap.getString("BasicInfoView.cbTechBase.values").split(",");
 
         setLayout(new GridBagLayout());

--- a/megameklab/src/megameklab/ui/generalUnit/FluffTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/FluffTab.java
@@ -31,7 +31,6 @@ import javax.swing.border.Border;
 
 import megamek.common.Entity;
 import megamek.common.EntityFluff;
-import megamek.common.util.EncodeControl;
 import megameklab.ui.EntitySource;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
@@ -76,7 +75,7 @@ public class FluffTab extends ITab implements FocusListener {
     }
 
     private void initUi() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Tabs", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Tabs");
         Border border = BorderFactory.createLineBorder(Color.BLACK);
 
         setLayout(new BoxLayout(this, BoxLayout.X_AXIS));

--- a/megameklab/src/megameklab/ui/generalUnit/FuelView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/FuelView.java
@@ -14,7 +14,6 @@
 package megameklab.ui.generalUnit;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestEntity;
 import megameklab.ui.listeners.BuildListener;
@@ -44,7 +43,7 @@ public class FuelView extends BuildView implements ActionListener, ChangeListene
         listeners.remove(l);
     }
 
-    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
 
     private final SpinnerNumberModel spnFuelModel = new SpinnerNumberModel(0.0, 0.0, null, 0.5);
     private final SpinnerNumberModel spnFuelCapacityModel = new SpinnerNumberModel(0, 0, null, 1);

--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -19,7 +19,6 @@
 package megameklab.ui.generalUnit;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestAero;
 import megameklab.ui.listeners.BuildListener;
 import megameklab.ui.util.CustomComboBox;
@@ -102,7 +101,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     }
     
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         mechDisplayNames = resourceMap.getString("HeatSinkView.mechNames.values").split(",");
         aeroDisplayNames = resourceMap.getString("HeatSinkView.aeroNames.values").split(",");
         

--- a/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
@@ -19,7 +19,6 @@
 package megameklab.ui.generalUnit;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestEntity;
 import megameklab.ui.listeners.ArmorAllocationListener;
 import megameklab.ui.util.CustomComboBox;
@@ -75,7 +74,7 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
 
     private final List<JComponent> svControlList = new ArrayList<>();
 
-    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
 
     /**
      * Create the armor panel

--- a/megameklab/src/megameklab/ui/generalUnit/MovementView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/MovementView.java
@@ -19,7 +19,6 @@
 package megameklab.ui.generalUnit;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestBattleArmor;
 import megamek.common.verifier.TestEntity;
 import megamek.common.verifier.TestMech;
@@ -86,7 +85,7 @@ public class MovementView extends BuildView implements ActionListener, ChangeLis
     }
     
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         walkNames = resourceMap.getString("MovementView.lblWalk.values").split(",");
         runNames = resourceMap.getString("MovementView.lblRun.values").split(",");
         jumpNames = resourceMap.getString("MovementView.lblJump.values").split(",");

--- a/megameklab/src/megameklab/ui/generalUnit/PatchworkArmorView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/PatchworkArmorView.java
@@ -28,7 +28,6 @@ import javax.swing.JLabel;
 import javax.swing.border.TitledBorder;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestEntity;
 import megameklab.ui.util.TechComboBox;
 import megameklab.ui.listeners.ArmorAllocationListener;
@@ -62,7 +61,7 @@ public class PatchworkArmorView extends BuildView implements ActionListener {
     }
     
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         setLayout(new GridBagLayout());
         
         setBorder(BorderFactory.createTitledBorder(

--- a/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
@@ -14,7 +14,6 @@
 package megameklab.ui.generalUnit;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.BayData;
 import megamek.common.verifier.TestAdvancedAerospace;
 import megamek.common.verifier.TestAero;
@@ -76,8 +75,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
     }
     
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Tabs",
-                new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Tabs");
 
         setLayout(new BorderLayout());
         if (getEntity().hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
@@ -536,8 +534,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
         private static final int COL_POD       = 6;
         private static final int NUM_COLS      = 7;
 
-        private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Tabs",
-                new EncodeControl());
+        private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Tabs");
 
         private final List<Bay> bayList = new ArrayList<>();
         private final List<BayData> bayTypeList = new ArrayList<>();

--- a/megameklab/src/megameklab/ui/infantry/CIPlatoonTypeView.java
+++ b/megameklab/src/megameklab/ui/infantry/CIPlatoonTypeView.java
@@ -31,7 +31,6 @@ import javax.swing.event.ChangeListener;
 import megamek.common.EntityMovementMode;
 import megamek.common.ITechManager;
 import megamek.common.Infantry;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestInfantry;
 import megameklab.ui.util.CustomComboBox;
 import megameklab.ui.generalUnit.BuildView;
@@ -50,7 +49,7 @@ public class CIPlatoonTypeView extends BuildView implements ActionListener, Chan
     public void removeListener(InfantryBuildListener l) {
         listeners.remove(l);
     }
-    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
 
     private enum InfantryMotiveType {
         FOOT(EntityMovementMode.INF_LEG, false, "PlatoonTypeView.cbMotiveType.foot"),

--- a/megameklab/src/megameklab/ui/infantry/CIWeaponView.java
+++ b/megameklab/src/megameklab/ui/infantry/CIWeaponView.java
@@ -14,7 +14,6 @@
 package megameklab.ui.infantry;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestInfantry;
 import megamek.common.weapons.artillery.ArtilleryCannonWeapon;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
@@ -67,7 +66,7 @@ public class CIWeaponView extends BuildView implements ActionListener {
     }
 
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         fgMotiveMsg = resourceMap.getString("InfantryWeaponView.txtGuns.badMotive");
         noneMsg = resourceMap.getString("InfantryWeaponView.none");
 

--- a/megameklab/src/megameklab/ui/largeAero/DSChassisView.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSChassisView.java
@@ -22,7 +22,6 @@ import megamek.common.Dropship;
 import megamek.common.Entity;
 import megamek.common.ITechManager;
 import megamek.common.SmallCraft;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestAero;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.DropshipBuildListener;
@@ -79,7 +78,7 @@ public class DSChassisView extends BuildView implements ActionListener, ChangeLi
     }
 
     public void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         cbBaseType.setModel(new DefaultComboBoxModel<>(resourceMap.getString("DropshipChassisView.cbBaseType.values").split(",")));

--- a/megameklab/src/megameklab/ui/largeAero/LACrewView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LACrewView.java
@@ -22,7 +22,6 @@ import megamek.common.Aero;
 import megamek.common.BattleArmor;
 import megamek.common.EntityWeightClass;
 import megamek.common.ITechManager;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestAero;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.AeroVesselBuildListener;
@@ -79,7 +78,7 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
     
     public void initUI() {
         setLayout(new GridBagLayout());
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         GridBagConstraints gbc = new GridBagConstraints();
         
         gbc.gridx = 0;

--- a/megameklab/src/megameklab/ui/largeAero/LACriticalView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LACriticalView.java
@@ -20,7 +20,6 @@ import megamek.common.LocationFullException;
 import megamek.common.SmallCraft;
 import megamek.common.Warship;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestAdvancedAerospace;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestEntity;
@@ -50,7 +49,7 @@ public class LACriticalView extends IView {
     // and non-WarShip capital ships use 6, plus one for system-wide
     private static final int MAX_ARCS = 9;
     
-    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
 
     private final JComponent fwdLeftPanel;
     private final JComponent bsLeftPanel;

--- a/megameklab/src/megameklab/ui/largeAero/WSChassisView.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSChassisView.java
@@ -19,7 +19,6 @@
 package megameklab.ui.largeAero;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestAdvancedAerospace;
 import megamek.common.verifier.TestAero;
 import megameklab.ui.generalUnit.BuildView;
@@ -81,7 +80,7 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
     }
     
     public void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         cbBaseType.setModel(new DefaultComboBoxModel<>(resourceMap.getString("AdvAeroChassisView.cbBaseType.values").split(",")));

--- a/megameklab/src/megameklab/ui/largeAero/WSGravDeckView.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSGravDeckView.java
@@ -15,7 +15,6 @@ package megameklab.ui.largeAero;
 
 import megamek.common.Jumpship;
 import megamek.common.annotations.Nullable;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestAdvancedAerospace;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.AdvancedAeroBuildListener;
@@ -61,7 +60,7 @@ public class WSGravDeckView extends BuildView implements ActionListener, TableMo
     }
     
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         setLayout(new BorderLayout());
         add(new JScrollPane(tblGravDecks), BorderLayout.CENTER);
         
@@ -129,7 +128,7 @@ public class WSGravDeckView extends BuildView implements ActionListener, TableMo
         private int maxSize = 250;
         
         GravDeckTableModel() {
-            ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+            ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
             colNames = resourceMap.getString("GravDeckView.columnNames.values").split(",");    
         }
 

--- a/megameklab/src/megameklab/ui/mek/BMBuildTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildTab.java
@@ -17,7 +17,6 @@ package megameklab.ui.mek;
 
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Mounted;
-import megamek.common.util.EncodeControl;
 import megameklab.ui.EntitySource;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
@@ -35,7 +34,7 @@ public class BMBuildTab extends ITab {
     private RefreshListener refresh = null;
     private final BMCriticalView critView;
     private final BMBuildView buildView;
-    private final ResourceBundle resources = ResourceBundle.getBundle("megameklab.resources.Tabs", new EncodeControl());
+    private final ResourceBundle resources = ResourceBundle.getBundle("megameklab.resources.Tabs");
 
     private final JToggleButton autoFillUnHittables = new JToggleButton(resources.getString("BuildTab.autoFillUnhittables.text"));
     private final JToggleButton autoCompact = new JToggleButton(resources.getString("BuildTab.autoCompact.text"));

--- a/megameklab/src/megameklab/ui/mek/BMChassisView.java
+++ b/megameklab/src/megameklab/ui/mek/BMChassisView.java
@@ -19,7 +19,6 @@
 package megameklab.ui.mek;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.MekBuildListener;
 import megameklab.ui.util.CustomComboBox;
@@ -143,7 +142,7 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
     }
 
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         baseTypesModel = new DefaultComboBoxModel<>(resourceMap.getString("MekChassisView.baseType.values").split(","));
         standardTypesModel = new DefaultComboBoxModel<>(resourceMap.getString("MekChassisView.motiveType.values").split(","));
         lamTypesModel = new DefaultComboBoxModel<>(resourceMap.getString("MekChassisView.lamType.values").split(","));

--- a/megameklab/src/megameklab/ui/mek/BMLAMFuelView.java
+++ b/megameklab/src/megameklab/ui/mek/BMLAMFuelView.java
@@ -19,7 +19,6 @@
 package megameklab.ui.mek;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megameklab.ui.EntitySource;
 import megameklab.ui.listeners.MekBuildListener;
 import megameklab.ui.util.IView;
@@ -47,7 +46,7 @@ public class BMLAMFuelView extends IView implements ChangeListener {
 
     private final List<MekBuildListener> listeners = new CopyOnWriteArrayList<>();
 
-    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
     private final SpinnerNumberModel fuelTonsSpnModel = new SpinnerNumberModel(0, 0, 84, 1);
     private final JSpinner fuelTonsSpn = new JSpinner(fuelTonsSpnModel);
     private final JLabel totalFuelPointsLabel = new JLabel();

--- a/megameklab/src/megameklab/ui/protoMek/PMChassisView.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMChassisView.java
@@ -22,7 +22,6 @@ import megamek.common.EquipmentType;
 import megamek.common.ITechManager;
 import megamek.common.MiscType;
 import megamek.common.Protomech;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestProtomech;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.ProtomekBuildListener;
@@ -93,7 +92,7 @@ public class PMChassisView extends BuildView implements ActionListener, ChangeLi
     }
 
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         motiveTypeNames = resourceMap.getString("ProtomekChassisView.cbMotiveType.values").split(",");
         
         setLayout(new GridBagLayout());

--- a/megameklab/src/megameklab/ui/supportVehicle/SVChassisView.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVChassisView.java
@@ -19,7 +19,6 @@
 package megameklab.ui.supportVehicle;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestSupportVehicle;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.SVBuildListener;
@@ -98,7 +97,7 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
     }
 
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         for (TestSupportVehicle.SVType t : TestSupportVehicle.SVType.values()) {
             typeNames.put(t, resourceMap.getString("SVType." + t.toString()));
         }

--- a/megameklab/src/megameklab/ui/supportVehicle/SVCrewView.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVCrewView.java
@@ -19,7 +19,6 @@
 package megameklab.ui.supportVehicle;
 
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megamek.common.verifier.TestSupportVehicle;
 import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.SVBuildListener;
@@ -84,7 +83,7 @@ public class SVCrewView extends BuildView implements ChangeListener {
     private final JLabel txtSteerageWeight = new JLabel("", SwingConstants.CENTER);
     private final JLabel txtSteerageSlots = new JLabel("", SwingConstants.CENTER);
 
-    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views", new EncodeControl());
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
 
     public SVCrewView() {
         initUi();

--- a/megameklab/src/megameklab/util/UnitPrintManager.java
+++ b/megameklab/src/megameklab/util/UnitPrintManager.java
@@ -17,7 +17,6 @@ package megameklab.util;
 
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.common.*;
-import megamek.common.util.EncodeControl;
 import megameklab.printing.*;
 import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
 import org.apache.commons.io.FilenameUtils;
@@ -37,7 +36,7 @@ import java.util.stream.Collectors;
 
 public class UnitPrintManager {
 
-    private static final ResourceBundle menuResources = ResourceBundle.getBundle("megameklab.resources.Menu", new EncodeControl());
+    private static final ResourceBundle menuResources = ResourceBundle.getBundle("megameklab.resources.Menu");
 
     public static void printEntity(Entity entity) {
         List<Entity> unitList = Collections.singletonList(entity);


### PR DESCRIPTION
ResourceBundles default to UTF-8 as of Java 9 instead of ISO-8859-1, so we no longer need the workaround.