### PR TITLE
Fix: package org.w3c.dom is accessible from more than one module - Eclipse IDE

### DIFF
--- a/megameklab/build.gradle
+++ b/megameklab/build.gradle
@@ -36,14 +36,24 @@ dependencies {
         // We don't need the python and javascript engine taking up space
         exclude group: 'org.python', module: 'jython'
         exclude group: 'org.mozilla', module: 'rhino'
+        // Prevent multiple dependencies - contains packages now included in Java runtime.
+        exclude group: 'xml-apis'
     }
-    implementation 'org.apache.xmlgraphics:batik-codec:1.14'
-    implementation 'org.apache.xmlgraphics:batik-dom:1.14'
+    implementation ('org.apache.xmlgraphics:batik-codec:1.14') {
+        // Prevent multiple dependencies - contains packages now included in Java runtime.
+        exclude group: 'xml-apis'
+    }
+    implementation ('org.apache.xmlgraphics:batik-dom:1.14') {
+        // Prevent multiple dependencies - contains packages now included in Java runtime.
+        exclude group: 'xml-apis'
+    }
     implementation 'org.apache.xmlgraphics:batik-rasterizer:1.14'
     implementation 'org.apache.xmlgraphics:batik-svggen:1.14'
     implementation ('org.apache.xmlgraphics:fop:2.7') {
         // We don't need this proprietary module
         exclude group: 'com.sun.media', module: 'jai-codec'
+        // Prevent multiple dependencies - contains packages now included in Java runtime.
+        exclude group: 'xml-apis'
     }
 
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.1'


### PR DESCRIPTION
Resolves the following Eclipse IDE errors:
"The package org.w3c.dom is accessible from more than one module: , java.xml" and
"The package javax.xml.parsers is accessible from more than one module: , java.xml"

These packages are included as part of the Java Runtime Environment after Java 11?

I appears IntelliJ was fixed in the past but Eclipse was still having an issue due to transient dependencies due to the inclusion of the xml-apis from several included xml libraries.

This exclude in the gradle build file prevents Eclipse from tripping over this multiple dependency.

This was tested by building from both Eclipse and from the gradle wrapper.
Eclipse Version:
Version: 2023-03 (4.27.0)
Build id: 20230309-1520