### PR TITLE
Issue 1247: Show BA Popup Mine as Other Equipment

### DIFF
--- a/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
@@ -89,6 +89,7 @@ public enum EquipmentDatabaseCategory {
                     && !(eq.hasFlag(F_PARTIAL_WING) && en.hasETypeFlag(Entity.ETYPE_PROTOMECH))
                     && !(eq.hasFlag(F_SPONSON_TURRET) && en.isSupportVehicle())
                     && !eq.hasFlag(F_PINTLE_TURRET))
+                    || eq.is(BattleArmor.MINE_LAUNCHER)
                     || (eq instanceof TAGWeapon)
                     || ((eq instanceof AmmoType) && (((AmmoType) eq).getAmmoType() == AmmoType.T_COOLANT_POD))
                     || eq.hasFlag(F_AMS)),


### PR DESCRIPTION
BA popup mines didn't fall into any filter category.

Fixes #1247 