### PR TITLE
Revert Eclipse Gradle Multiple Dependency fix. #1263

### DIFF
--- a/megameklab/build.gradle
+++ b/megameklab/build.gradle
@@ -36,24 +36,24 @@ dependencies {
         // We don't need the python and javascript engine taking up space
         exclude group: 'org.python', module: 'jython'
         exclude group: 'org.mozilla', module: 'rhino'
-        // Prevent multiple dependencies - contains packages now included in Java runtime.
-        exclude group: 'xml-apis'
+        // Uncomment to work around Eclipse IDE Multiple Dependency errors. 
+        //exclude group: 'xml-apis'
     }
     implementation ('org.apache.xmlgraphics:batik-codec:1.14') {
-        // Prevent multiple dependencies - contains packages now included in Java runtime.
-        exclude group: 'xml-apis'
+        // Uncomment to work around Eclipse IDE Multiple Dependency errors. 
+        //exclude group: 'xml-apis'
     }
     implementation ('org.apache.xmlgraphics:batik-dom:1.14') {
-        // Prevent multiple dependencies - contains packages now included in Java runtime.
-        exclude group: 'xml-apis'
+        // Uncomment to work around Eclipse IDE Multiple Dependency errors. 
+        //exclude group: 'xml-apis'
     }
     implementation 'org.apache.xmlgraphics:batik-rasterizer:1.14'
     implementation 'org.apache.xmlgraphics:batik-svggen:1.14'
     implementation ('org.apache.xmlgraphics:fop:2.7') {
         // We don't need this proprietary module
         exclude group: 'com.sun.media', module: 'jai-codec'
-        // Prevent multiple dependencies - contains packages now included in Java runtime.
-        exclude group: 'xml-apis'
+        // Uncomment to work around Eclipse IDE Multiple Dependency errors. 
+        //exclude group: 'xml-apis'
     }
 
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.1'


### PR DESCRIPTION
Reverting Gradle Build file change to enable Eclipse Multiple Dependency IDE errors.  Excluding xml-apis fixes Eclipse build errors, but it needed by megameklab to print unit sheets.  The print error was reported in #1263 for build 0.49.13