### PR TITLE
Eclipse IDE multiple Module error fix - take 2

### DIFF
--- a/megameklab/build.gradle
+++ b/megameklab/build.gradle
@@ -36,27 +36,26 @@ dependencies {
         // We don't need the python and javascript engine taking up space
         exclude group: 'org.python', module: 'jython'
         exclude group: 'org.mozilla', module: 'rhino'
-        // Uncomment to work around Eclipse IDE Multiple Dependency errors. 
-        //exclude group: 'xml-apis'
+        exclude group: 'xml-apis'
     }
     implementation ('org.apache.xmlgraphics:batik-codec:1.14') {
-        // Uncomment to work around Eclipse IDE Multiple Dependency errors. 
-        //exclude group: 'xml-apis'
+        exclude group: 'xml-apis'
     }
     implementation ('org.apache.xmlgraphics:batik-dom:1.14') {
-        // Uncomment to work around Eclipse IDE Multiple Dependency errors. 
-        //exclude group: 'xml-apis'
+        exclude group: 'xml-apis'
     }
     implementation 'org.apache.xmlgraphics:batik-rasterizer:1.14'
     implementation 'org.apache.xmlgraphics:batik-svggen:1.14'
     implementation ('org.apache.xmlgraphics:fop:2.7') {
         // We don't need this proprietary module
         exclude group: 'com.sun.media', module: 'jai-codec'
-        // Uncomment to work around Eclipse IDE Multiple Dependency errors. 
-        //exclude group: 'xml-apis'
+        exclude group: 'xml-apis'
     }
 
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.1'
+
+    //Required for printing scaled vector graphics (SVG) - EclipseIDE Comipatability.
+    runtimeOnly 'xml-apis:xml-apis-ext:1.3.04'
 }
 
 mainClassName = 'megameklab.MegaMekLab'


### PR DESCRIPTION
Second take at fixing the Eclipse IDE Multiple Module error in a way that doesn't also break Scaled Vector Graphics printing.  This attempt excludes the offending `xml-apis` group but then adds the `xml-apis-ext` as runtime only which ensures it is included in the final build but doesn't trip up Eclipse IDE.

With this fix I'm able successfully import the megameklab gradle project into the Eclipse IDE while still able to print and export-to-pdf.  Further test is needed to ensure no other edge cases trigger "class not found" errors.
