### PR TITLE
Record Sheets: Show Coolant Pods in the inventory

### DIFF
--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -234,8 +234,7 @@ public class InventoryWriter {
             if (UnitUtil.isMineDispenser(m.getType()) || UnitUtil.isRemoteSensorDispenser(m.getType())) {
                 ammo.merge(m.getShortName(), m.getBaseShotsLeft(), Integer::sum);
             }
-            if ((m.getType() instanceof AmmoType)
-                    || (m.getLocation() == Entity.LOC_NONE)
+            if ((m.getLocation() == Entity.LOC_NONE)
                     || !UnitUtil.isPrintableEquipment(m.getType(), sheet.getEntity())) {
                 continue;
             }

--- a/megameklab/src/megameklab/util/StringUtils.java
+++ b/megameklab/src/megameklab/util/StringUtils.java
@@ -237,6 +237,8 @@ public class StringUtils {
             info = "[PB,OS,AI]";
         } else if ((mount.getType() instanceof MiscType) && mount.getType().hasFlag(MiscType.F_TALON)) {
             info = Integer.toString(KickAttackAction.getDamageFor(unit, Mech.LOC_LLEG, false));
+        } else if (mount.is(EquipmentTypeLookup.COOLANT_POD)) {
+            info = "[PE,OS,X]";
         } else {
             info = "  [E]";
         }
@@ -359,6 +361,8 @@ public class StringUtils {
                 info = info.substring(0, info.length() - 1) + "]";
 
             }
+        } else if (mount.is(EquipmentTypeLookup.COOLANT_POD)) {
+            info = "[PE,OS,X]";
         } else {
             info = "[E]";
         }

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -1068,10 +1068,13 @@ public class UnitUtil {
      * @return       Whether the equipment should be shown on the record sheet
      */
     public static boolean isPrintableEquipment(EquipmentType eq, Entity entity) {
-        if (entity instanceof BattleArmor) {
+        if (eq instanceof AmmoType) {
+            return ((AmmoType) eq).getAmmoType() == AmmoType.T_COOLANT_POD;
+        } else if (entity instanceof BattleArmor) {
             return isPrintableBAEquipment(eq);
+        } else {
+            return isPrintableEquipment(eq, entity instanceof Mech);
         }
-        return isPrintableEquipment(eq, entity instanceof Mech);
     }
 
     /**


### PR DESCRIPTION
Fixes #1273 

@HammerGS I checked the Goth D in RS Golden Century (Coolant Pods not shown) and the Awesome 11R in XTRO Republic II (also not shown). But showing them makes sense, right?

![image](https://github.com/MegaMek/megameklab/assets/17069663/6f838537-49eb-431a-95f5-a46e7bbffd72)
![image](https://github.com/MegaMek/megameklab/assets/17069663/9da7f0cf-0ada-4fb0-b8c3-5d15e99607a5)
