### PR TITLE
Record Sheets: Update physical attack damage values in ref tables

### DIFF
--- a/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
+++ b/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
@@ -30,10 +30,14 @@ public class PhysicalAttacks extends ReferenceTable {
         setHeaders(bundle.getString("attack"), bundle.getString("toHit"), bundle.getString("damage"));
         setColumnAnchor(0, SVGConstants.SVG_START_VALUE);
         int kickDamage = (int) Math.floor(sheet.getEntity().getWeight() / 5.0);
-        int dfaDamage = (int) Math.floor(sheet.getEntity().getWeight() / 10.0) * 3;
+        int dfaDamage = (int) Math.ceil(sheet.getEntity().getWeight() / 10.0 * 3);
         if (sheet.getEntity().hasWorkingMisc(MiscType.F_TALON)) {
-            kickDamage = (int) Math.floor(kickDamage * 1.5);
-            dfaDamage = (int) Math.floor(dfaDamage * 1.5);
+            kickDamage = (int) Math.round(kickDamage * 1.5);
+            dfaDamage = (int) Math.round(dfaDamage * 1.5);
+        }
+        String kickDamageString = String.valueOf(kickDamage);
+        if (sheet.getEntity().hasWorkingMisc(MiscType.F_TSM)) {
+            kickDamageString += " [" + kickDamage * 2 + "]";
         }
         boolean hasTorsoSpikes = false;
         for (Mounted mounted : sheet.getEntity().getMisc()) {
@@ -44,7 +48,7 @@ public class PhysicalAttacks extends ReferenceTable {
             }
         }
         addPunchAttacks(sheet.getEntity());
-        addRow(bundle.getString("kick"), "-2", String.valueOf(kickDamage));
+        addRow(bundle.getString("kick"), "-2", kickDamageString);
         if (!(sheet.getEntity() instanceof QuadMech)) {
             addRow(bundle.getString("push"), "-1", "\u2014");
         }
@@ -71,12 +75,13 @@ public class PhysicalAttacks extends ReferenceTable {
     private void addPunchAttacks(Entity entity) {
         int left = countActuators(entity, Mech.LOC_LARM);
         int right = countActuators(entity, Mech.LOC_RARM);
-        int baseDamage = (int) Math.floor(entity.getWeight() / 10.0);
+        int baseDamage = (int) Math.ceil(entity.getWeight() / 10.0);
+        boolean hasTSM = entity.hasWorkingMisc(MiscType.F_TSM);
         if (left == right) {
-            addPunchAttack(bundle.getString("punch"), left, baseDamage);
+            addPunchAttack(bundle.getString("punch"), left, baseDamage, hasTSM);
         } else {
-            addPunchAttack(bundle.getString("punch") + " (LA)", left, baseDamage);
-            addPunchAttack(bundle.getString("punch") + " (RA)", right, baseDamage);
+            addPunchAttack(bundle.getString("punch") + " (LA)", left, baseDamage, hasTSM);
+            addPunchAttack(bundle.getString("punch") + " (RA)", right, baseDamage, hasTSM);
         }
     }
 
@@ -92,13 +97,18 @@ public class PhysicalAttacks extends ReferenceTable {
         }
     }
 
-    private void addPunchAttack(String name, int actuators, int baseDamage) {
+    private void addPunchAttack(String name, int actuators, int baseDamage, boolean hasTSM) {
+        String tsmDamage = hasTSM ? " [" + baseDamage * 2 + "]" : "";
         if (actuators == 4) {
-            addRow(name, "+0", String.valueOf(baseDamage));
+            addRow(name, "+0", baseDamage + tsmDamage);
         } else if (actuators == 3) {
-            addRow(name, "+1", String.valueOf(baseDamage));
+            addRow(name, "+1", baseDamage + tsmDamage);
         } else if (actuators == 2) {
-            addRow(name, "+2", String.valueOf(baseDamage / 2));
+            tsmDamage = hasTSM ? " [" + Math.max(baseDamage / 2, 1) * 2 + "]" : "";
+            addRow(name, "+3", Math.max(baseDamage / 2, 1) + tsmDamage);
+        } else if (actuators == 1) {
+            tsmDamage = hasTSM ? " [" + Math.max(baseDamage / 4, 1) * 2 + "]" : "";
+            addRow(name, "+3", Math.max(baseDamage / 4, 1) + tsmDamage);
         }
     }
 

--- a/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
+++ b/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
@@ -98,18 +98,18 @@ public class PhysicalAttacks extends ReferenceTable {
     }
 
     private void addPunchAttack(String name, int actuators, int baseDamage, boolean hasTSM) {
-        String tsmDamage = hasTSM ? " [" + baseDamage * 2 + "]" : "";
+        String modifier = "+3";
         if (actuators == 4) {
-            addRow(name, "+0", baseDamage + tsmDamage);
+            modifier = "+0";
         } else if (actuators == 3) {
-            addRow(name, "+1", baseDamage + tsmDamage);
+            modifier = "+1";
         } else if (actuators == 2) {
-            tsmDamage = hasTSM ? " [" + Math.max(baseDamage / 2, 1) * 2 + "]" : "";
-            addRow(name, "+3", Math.max(baseDamage / 2, 1) + tsmDamage);
+            baseDamage = Math.max(baseDamage / 2, 1);
         } else if (actuators == 1) {
-            tsmDamage = hasTSM ? " [" + Math.max(baseDamage / 4, 1) * 2 + "]" : "";
-            addRow(name, "+3", Math.max(baseDamage / 4, 1) + tsmDamage);
+            baseDamage = Math.max(baseDamage / 4, 1);
         }
+        String tsmDamage = hasTSM ? " [" + baseDamage * 2 + "]" : "";
+        addRow(name, modifier, baseDamage + tsmDamage);
     }
 
     private void addPhysicalWeapon(Entity entity) {

--- a/megameklab/src/megameklab/util/StringUtils.java
+++ b/megameklab/src/megameklab/util/StringUtils.java
@@ -223,8 +223,9 @@ public class StringUtils {
                 info = info.substring(0, info.length() - 1) + "]";
 
             }
-        } else if ((mount.getType() instanceof MiscType) && (mount.getType().hasFlag(MiscType.F_CLUB) || mount.getType().hasFlag(MiscType.F_HAND_WEAPON))) {
-            if (mount.getType().hasSubType(MiscType.S_VIBRO_LARGE) || mount.getType().hasSubType(MiscType.S_VIBRO_MEDIUM) || mount.getType().hasSubType(MiscType.S_VIBRO_SMALL)) {
+        } else if ((mount.getType() instanceof MiscType) && (mount.getType().hasFlag(MiscType.F_CLUB)
+                || mount.getType().hasFlag(MiscType.F_HAND_WEAPON))) {
+            if (((MiscType) mount.getType()).isVibroblade()) {
                 // manually set vibros to active to get correct damage
                 mount.setMode(1);
             }


### PR DESCRIPTION
Fixes #1262 
Fixes #1258 
Fixes #1245 

Also now shows TSM damage for kick and punch attacks in brackets (note the kick damage for this Caesar 5D with Talons and TSM)
![image](https://github.com/MegaMek/megameklab/assets/17069663/f8093362-fffe-4d9d-80cd-63850f36ad81)
