### PR TITLE
AS Crit View: Compact criticals after removing equipment

### DIFF
--- a/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
@@ -33,6 +33,7 @@ import java.awt.*;
 public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener, EntitySource, AppCloser {
     private Entity entity = null;
     protected MenuBar mmlMenuBar;
+    protected boolean refreshRequired = false;
     
     public MegaMekLabMainUI() {
         setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
@@ -168,5 +169,18 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
     @Override
     public Entity getEntity() {
         return entity;
+    }
+
+
+    public void scheduleRefresh() {
+        refreshRequired = true;
+        SwingUtilities.invokeLater(this::performRefresh);
+    }
+
+    private void performRefresh() {
+        if (refreshRequired) {
+            refreshRequired = false;
+            refreshAll();
+        }
     }
 }

--- a/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
@@ -172,6 +172,7 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
     }
 
 
+    @Override
     public void scheduleRefresh() {
         refreshRequired = true;
         SwingUtilities.invokeLater(this::performRefresh);

--- a/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
@@ -526,7 +526,7 @@ public class BABuildView extends IView implements ActionListener, MouseListener 
                 });
                 popup.add(item);
             }
-            popup.show(this, e.getX(), e.getY());
+            popup.show(equipmentTable, e.getX(), e.getY());
         }
     }
 

--- a/megameklab/src/megameklab/ui/fighterAero/ASBuildTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASBuildTab.java
@@ -88,7 +88,6 @@ public class ASBuildTab extends ITab implements ActionListener {
 
 
     private void resetCrits() {
-        long begin = System.nanoTime();
         for (Mounted mount : getAero().getEquipment()) {
             if (!mount.isWeaponGroup() && TestAero.eqRequiresLocation(mount.getType(), true)
                     && !UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
@@ -98,8 +97,6 @@ public class ASBuildTab extends ITab implements ActionListener {
         }
 
         refresh.scheduleRefresh();
-        long dur = System.nanoTime() - begin;
-        System.out.println(dur/1000000+" ms");
     }
 
 

--- a/megameklab/src/megameklab/ui/fighterAero/ASBuildTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASBuildTab.java
@@ -88,6 +88,7 @@ public class ASBuildTab extends ITab implements ActionListener {
 
 
     private void resetCrits() {
+        long begin = System.nanoTime();
         for (Mounted mount : getAero().getEquipment()) {
             if (!mount.isWeaponGroup() && TestAero.eqRequiresLocation(mount.getType(), true)
                     && !UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
@@ -96,7 +97,9 @@ public class ASBuildTab extends ITab implements ActionListener {
             }
         }
 
-        refresh.refreshAll();
+        refresh.scheduleRefresh();
+        long dur = System.nanoTime() - begin;
+        System.out.println(dur/1000000+" ms");
     }
 
 
@@ -116,7 +119,7 @@ public class ASBuildTab extends ITab implements ActionListener {
 
     public void refreshAll() {
         if (refresh != null) {
-            refresh.refreshAll();
+            refresh.scheduleRefresh();
         }
     }
 

--- a/megameklab/src/megameklab/ui/fighterAero/ASBuildView.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASBuildView.java
@@ -310,7 +310,7 @@ public class ASBuildView extends IView implements ActionListener, MouseListener 
                     popup.add(item);
                 }
             }
-            popup.show(this, evt.getX(), evt.getY());
+            popup.show(equipmentTable, evt.getX(), evt.getY());
         }
     }
 

--- a/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
@@ -147,8 +147,7 @@ public class ASMainUI extends MegaMekLabMainUI {
     }
 
     @Override
-    public void refreshArmor() {
-    }
+    public void refreshArmor() { }
 
     @Override
     public void refreshBuild() {

--- a/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
@@ -550,7 +550,7 @@ public class ASStructureTab extends ITab implements AeroBuildListener, ArmorAllo
     @Override
     public void resetChassis() {
         UnitUtil.resetBaseChassis(getAero());
-        refresh.refreshAll();
+        refresh.scheduleRefresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/generalUnit/PreviewTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/PreviewTab.java
@@ -27,6 +27,9 @@ import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
 
 public class PreviewTab extends ITab {
 
@@ -42,10 +45,10 @@ public class PreviewTab extends ITab {
         panPreview.addTab("TRO", panelTROView);
         panPreview.addTab("AS Card", cardPanel);
         add(panPreview, BorderLayout.CENTER);
-        refresh();
+        addComponentListener(refreshOnShow);
     }
 
-    public void refresh() {
+    public void update() {
         boolean populateTextFields = true;
         final Entity selectedUnit = eSource.getEntity();
         selectedUnit.recalculateTechAdvancement();
@@ -74,4 +77,18 @@ public class PreviewTab extends ITab {
         }
     }
 
+    public void refresh() {
+        // This active refresh is needed for the few cases where the unit can be changed when the preview is
+        // active, e.g. setting the fluff image.
+        if (isVisible()) {
+            update();
+        }
+    }
+
+    ComponentListener refreshOnShow = new ComponentAdapter() {
+        @Override
+        public void componentShown(ComponentEvent e) {
+            update();
+        }
+    };
 }

--- a/megameklab/src/megameklab/ui/largeAero/LABuildView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LABuildView.java
@@ -253,7 +253,7 @@ public class LABuildView extends IView implements MouseListener {
                 }
             }
 
-            popup.show(this, evt.getX(), evt.getY());
+            popup.show(equipmentTable, evt.getX(), evt.getY());
         }
     }
 

--- a/megameklab/src/megameklab/ui/mek/BMBuildView.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildView.java
@@ -292,7 +292,7 @@ public class BMBuildView extends IView implements ActionListener, MouseListener 
                     }
                 }
             }
-            popup.show(this, e.getX(), e.getY());
+            popup.show(equipmentTable, e.getX(), e.getY());
         }
     }
 

--- a/megameklab/src/megameklab/ui/mek/BMCriticalTransferHandler.java
+++ b/megameklab/src/megameklab/ui/mek/BMCriticalTransferHandler.java
@@ -22,6 +22,7 @@ package megameklab.ui.mek;
 import megamek.common.*;
 import megamek.common.verifier.TestEntity;
 import megameklab.ui.EntitySource;
+import megameklab.ui.util.AbstractCriticalTransferHandler;
 import megameklab.ui.util.BAASBMDropTargetCriticalList;
 import megameklab.ui.util.CriticalTableModel;
 import megameklab.ui.util.RefreshListener;
@@ -39,15 +40,12 @@ import java.util.*;
  *
  * @author jtighe (torren@users.sourceforge.net)
  */
-public class BMCriticalTransferHandler extends TransferHandler {
-    private final EntitySource eSource;
+public class BMCriticalTransferHandler extends AbstractCriticalTransferHandler {
     private int location = -1;
-    private final RefreshListener refresh;
     private final BMCriticalView parentView;
 
     public BMCriticalTransferHandler(EntitySource eSource, RefreshListener refresh, BMCriticalView parentView) {
-        this.eSource = eSource;
-        this.refresh = refresh;
+        super(eSource, refresh);
         this.parentView = parentView;
     }
 
@@ -307,31 +305,7 @@ public class BMCriticalTransferHandler extends TransferHandler {
     }
 
     @Override
-    public int getSourceActions(JComponent c) {
-        return TransferHandler.MOVE;
-    }
-
-    private void changeMountStatus(Mounted eq, int location) {
-        changeMountStatus(eq, location, -1);
-    }
-
-    private void changeMountStatus(Mounted eq, int location, int secondaryLocation) {
-        UnitUtil.changeMountStatus(getUnit(), eq, location, secondaryLocation, false);
-        doRefresh();
-    }
-
-    public Entity getUnit() {
-        return eSource.getEntity();
-    }
-
-    @Override
     protected void exportDone(JComponent source, Transferable data, int action) {
         parentView.unmarkAllLocations();
-    }
-
-    private void doRefresh() {
-        if (refresh != null) {
-            refresh.refreshAll();
-        }
     }
 }

--- a/megameklab/src/megameklab/ui/protoMek/PMBuildView.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMBuildView.java
@@ -203,7 +203,7 @@ public class PMBuildView extends IView implements ActionListener, MouseListener 
                 }
             }
 
-            popup.show(this, evt.getX(), evt.getY());
+            popup.show(equipmentTable, evt.getX(), evt.getY());
         }
     }
 

--- a/megameklab/src/megameklab/ui/util/AbstractCriticalTransferHandler.java
+++ b/megameklab/src/megameklab/ui/util/AbstractCriticalTransferHandler.java
@@ -1,0 +1,47 @@
+package megameklab.ui.util;
+
+import megamek.common.Entity;
+import megamek.common.Mounted;
+import megameklab.ui.EntitySource;
+import megameklab.util.UnitUtil;
+
+import javax.swing.*;
+
+public class AbstractCriticalTransferHandler extends TransferHandler {
+
+    protected final EntitySource eSource;
+    protected RefreshListener refresh;
+
+    public AbstractCriticalTransferHandler(EntitySource eSource, RefreshListener refresh) {
+        this.eSource = eSource;
+        this.refresh = refresh;
+    }
+
+    @Override
+    public int getSourceActions(JComponent c) {
+        return TransferHandler.MOVE;
+    }
+
+    protected void changeMountStatus(Mounted eq, int location) {
+        changeMountStatus(eq, location, -1);
+    }
+
+    protected void changeMountStatus(Mounted eq, int location, int secondaryLocation) {
+        UnitUtil.changeMountStatus(getUnit(), eq, location, secondaryLocation, false);
+        doRefresh();
+    }
+
+    protected Entity getUnit() {
+        return eSource.getEntity();
+    }
+
+    public void setRefresh(RefreshListener refresh) {
+        this.refresh = refresh;
+    }
+
+    protected void doRefresh() {
+        if (refresh != null) {
+            refresh.refreshAll();
+        }
+    }
+}

--- a/megameklab/src/megameklab/ui/util/AbstractCriticalTransferHandler.java
+++ b/megameklab/src/megameklab/ui/util/AbstractCriticalTransferHandler.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2023 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
 package megameklab.ui.util;
 
 import megamek.common.Entity;

--- a/megameklab/src/megameklab/ui/util/BAASBMDropTargetCriticalList.java
+++ b/megameklab/src/megameklab/ui/util/BAASBMDropTargetCriticalList.java
@@ -451,6 +451,10 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
             UnitUtil.removeMounted(getUnit(), mounted);
         }
 
+        if (getUnit().isFighter() && mounted.getLocation() != Entity.LOC_NONE) {
+            UnitUtil.compactCriticals(getUnit(), mounted.getLocation());
+        }
+
         // Check linkings after you remove everything.
         try {
             MechFileParser.postLoadInit(getUnit());
@@ -480,6 +484,9 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
         }
 
         UnitUtil.removeCriticals(getUnit(), mounted);
+        if (getUnit().isFighter() && mounted.getLocation() != Entity.LOC_NONE) {
+            UnitUtil.compactCriticals(getUnit(), mounted.getLocation());
+        }
 
         // Check linkings after you remove everything.
         try {

--- a/megameklab/src/megameklab/ui/util/BAASCriticalTransferHandler.java
+++ b/megameklab/src/megameklab/ui/util/BAASCriticalTransferHandler.java
@@ -37,14 +37,11 @@ import java.util.Objects;
  *
  * @author jtighe (torren@users.sourceforge.net)
  */
-public class BAASCriticalTransferHandler extends TransferHandler {
-    private final EntitySource eSource;
+public class BAASCriticalTransferHandler extends AbstractCriticalTransferHandler {
     private int location = -1;
-    private final RefreshListener refresh;
 
     public BAASCriticalTransferHandler(EntitySource eSource, RefreshListener refresh) {
-        this.eSource = eSource;
-        this.refresh = refresh;
+        super(eSource, refresh);
     }
 
     @Override
@@ -52,7 +49,7 @@ public class BAASCriticalTransferHandler extends TransferHandler {
         if (data == null) {
             return;
         }
-        Mounted mounted = null;
+        Mounted mounted;
         try {
             mounted = getUnit().getEquipment(Integer.parseInt((String) data.getTransferData(DataFlavor.stringFlavor)));
         } catch (Exception ex) {
@@ -168,8 +165,7 @@ public class BAASCriticalTransferHandler extends TransferHandler {
                 location = Integer.parseInt(list.getName());
             }
             Transferable t = info.getTransferable();
-            int slotNumber = list.getDropLocation().getIndex();
-            
+
             try {
                 Mounted eq = getUnit().getEquipment(Integer.parseInt(
                         (String) t.getTransferData(DataFlavor.stringFlavor)));
@@ -183,6 +179,9 @@ public class BAASCriticalTransferHandler extends TransferHandler {
                     if ((eq.getLocation() != Entity.LOC_NONE)
                             || (eq.getSecondLocation() != Entity.LOC_NONE)) {
                         UnitUtil.removeCriticals(getUnit(), eq);
+                        if (getUnit().isFighter() && eq.getLocation() != Entity.LOC_NONE) {
+                            UnitUtil.compactCriticals(getUnit(), eq.getLocation());
+                        }
                         changeMountStatus(eq, Entity.LOC_NONE);
                     } else {
                         eq.setOmniPodMounted(UnitUtil.canPodMount(getUnit(), eq));
@@ -273,25 +272,5 @@ public class BAASCriticalTransferHandler extends TransferHandler {
             }
         }
         return null;
-    }
-
-    @Override
-    public int getSourceActions(JComponent c) {
-        return TransferHandler.MOVE;
-    }
-
-    private void changeMountStatus(Mounted eq, int location) {
-        changeMountStatus(eq, location, -1);
-    }
-
-    private void changeMountStatus(Mounted eq, int location, int secondaryLocation) {
-        UnitUtil.changeMountStatus(getUnit(), eq, location, secondaryLocation, false);
-        if (refresh != null) {
-            refresh.refreshAll();
-        }
-    }
-
-    public Entity getUnit() {
-        return eSource.getEntity();
     }
 }

--- a/megameklab/src/megameklab/ui/util/CriticalTransferHandler.java
+++ b/megameklab/src/megameklab/ui/util/CriticalTransferHandler.java
@@ -119,6 +119,9 @@ public class CriticalTransferHandler extends TransferHandler {
                     mount.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
                 } else {
                     UnitUtil.removeCriticals(getUnit(), mount);
+                    if (getUnit().isFighter() && mount.getLocation() != Entity.LOC_NONE) {
+                        UnitUtil.compactCriticals(getUnit(), mount.getLocation());
+                    }
                     changeMountStatus(mount, Entity.LOC_NONE, false);
                 }
             } catch (Exception ex) {

--- a/megameklab/src/megameklab/ui/util/RefreshListener.java
+++ b/megameklab/src/megameklab/ui/util/RefreshListener.java
@@ -18,6 +18,14 @@ package megameklab.ui.util;
 import java.util.EventListener;
 
 public interface RefreshListener extends EventListener {
+
+    /**
+     * Schedules a full refresh. This can be called any number of times but the refresh itself will be performed
+     * only once at the end of the current Swing UI Event (it is scheduled using
+     * {@link javax.swing.SwingUtilities#invokeLater(Runnable)}) and prevented from running several times in a row.
+     */
+    void scheduleRefresh();
+
     void refreshHeader();
     void refreshStatus();
     void refreshAll();

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -3289,13 +3289,16 @@ public class UnitUtil {
                                              final int toLoc, final boolean includeForward,
                                              final boolean includeRear)
             throws LocationFullException {
-        /*
-         * First we remove any equipment already in the location, but keep a list of it
-         * to use as much as possible. 
-         */
+        // Remove any equipment already in the location, but keep a list of it
+        // to reuse as much as possible.
         List<Mounted> removed = entity.getEquipment().stream()
                 .filter(m -> m.getLocation() == toLoc)
                 .filter(m -> m.isRearMounted() ? includeRear : includeForward)
+                .collect(Collectors.toList());
+
+        // Add to this any equipment that is already unequipped (= in Entity.LOC_NONE) and free to be used
+        List<Mounted> unequipped = entity.getEquipment().stream()
+                .filter(m -> m.getLocation() == Entity.LOC_NONE)
                 .collect(Collectors.toList());
 
         removed.forEach(m -> UnitUtil.removeCriticals(entity, m));
@@ -3307,7 +3310,8 @@ public class UnitUtil {
         removed.stream()
                 .filter(m -> (m.getType() instanceof BayWeapon))
                 .forEach(m -> removeMounted(entity, m));
-        
+
+        removed.addAll(unequipped);
 
         // Now we go through the equipment in the location to copy and add it to the other location.
         // If there is a match in what we removed, use that. Otherwise, add the equipment to the


### PR DESCRIPTION
Fighter units use the crit slot system. Equipment is always shown in the crit view as if there were no gaps but removing e.g. equipment no. 2 in a location will currently leave the second slot empty. This leads to the right-click menu not working for some equipment after removing another equipment.

![image](https://github.com/MegaMek/megameklab/assets/17069663/c18e4e53-84a1-4742-a485-7c7886b4a050)

This PR compacts the crit slots on fighters when equipment is removed (deleted or removed by menu or dragged out) from a location, so that there don't remain empty crit slots between equipment. The change is not visible except for the popup menu now working more consistently.

Edit:
This proved a bit of a rabbit hole. So this PR now also:
- Removes the ability to rear-mount weapons on fighters(!) according to TM p.195 (only AFT-mounted weapons can be rear-facing)
- Makes the preview tab update whenever it is shown instead of for every change; this removes the quite noticeable lag when dragging equipment around between slots
- For fighters, greatly reduces the number of actual refreshes happening when the unit is edited by invoking the refresh at the end of the current GUI action (SwingUtilities.invokeLater) and making sure it happens only once. This also helps reducing input lag
- improves placement of the popup menu on the unallocated equipment list in the crit view
