### PR TITLE
Ammo w/o weapon filter

### DIFF
--- a/megameklab/src/megameklab/ui/util/AbstractEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/util/AbstractEquipmentDatabaseView.java
@@ -77,6 +77,7 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
     protected final JToggleButton hideOneShotButton = new JToggleButton(ONE_SHOT.getDisplayName());
     protected final JToggleButton hideTorpedoButton = new JToggleButton(TORPEDO.getDisplayName());
     protected final JToggleButton hideAPButton = new JToggleButton(AP.getDisplayName());
+    protected final JToggleButton hideUnusableAmmoButton = new JToggleButton(UNUSABLE_AMMO.getDisplayName(), true);
     protected final JToggleButton hideUnavailButton = new JToggleButton(UNAVAILABLE.getDisplayName(), true);
 
     protected final JTextField txtFilter = new JTextField("", 15);
@@ -90,7 +91,7 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
 
     private final Map<JToggleButton, EquipmentDatabaseCategory> hideToggles = Map.of(hideProtoButton, PROTOTYPE,
             hideOneShotButton, ONE_SHOT, hideTorpedoButton, TORPEDO, hideAPButton, AP,
-            hideUnavailButton, UNAVAILABLE);
+            hideUnusableAmmoButton, UNUSABLE_AMMO, hideUnavailButton, UNAVAILABLE);
 
     private static final String ADD_TEXT = "  << Add ";
 
@@ -98,7 +99,8 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
         super(eSource);
         masterEquipmentModel = new EquipmentTableModel(eSource.getEntity(), eSource.getTechManager());
         masterEquipmentTable = new EquipmentDatabaseTable(masterEquipmentModel);
-        masterEquipmentTable.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "add");
+        masterEquipmentTable.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+                .put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "add");
         masterEquipmentTable.getActionMap().put("add", addAction);
 
         equipmentSorter = new TableRowSorter<>(masterEquipmentModel);
@@ -353,6 +355,7 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
         buttonPanel.add(hideOneShotButton);
         buttonPanel.add(hideTorpedoButton);
         buttonPanel.add(hideAPButton);
+        buttonPanel.add(hideUnusableAmmoButton);
         buttonPanel.add(hideUnavailButton);
 
         var hideFilterPanel = Box.createHorizontalBox();
@@ -592,7 +595,8 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
         return (hideProtoButton.isSelected() && PROTOTYPE.passesFilter(equipment, getEntity()))
                 || (hideOneShotButton.isSelected() && ONE_SHOT.passesFilter(equipment, getEntity()))
                 || (hideTorpedoButton.isSelected() && TORPEDO.passesFilter(equipment, getEntity()))
-                || (hideAPButton.isSelected() && AP.passesFilter(equipment, getEntity()));
+                || (hideAPButton.isSelected() && AP.passesFilter(equipment, getEntity()))
+                || (hideUnusableAmmoButton.isSelected() && UNUSABLE_AMMO.passesFilter(equipment, getEntity()));
     }
 
     /**

--- a/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
@@ -65,8 +65,8 @@ public enum EquipmentDatabaseCategory {
             e -> (e instanceof Tank) || e.isSupportVehicle()),
 
     AMMO ("Ammo",
-            (eq, en) -> (eq instanceof AmmoType) && !(eq instanceof BombType)
-                    && UnitUtil.canUseAmmo(en, (AmmoType) eq, false),
+            (eq, en) -> (eq instanceof AmmoType) && !(eq instanceof BombType),
+//                    && UnitUtil.canUseAmmo(en, (AmmoType) eq, false),
             e -> e.getWeightClass() != EntityWeightClass.WEIGHT_SMALL_SUPPORT),
 
     OTHER ("Other",
@@ -111,8 +111,12 @@ public enum EquipmentDatabaseCategory {
                     || ((WeaponType) eq).getAmmoType() == AmmoType.T_SRM_TORPEDO),
             e -> !(e instanceof BattleArmor) && !(e instanceof Aero)),
 
-    UNAVAILABLE ("Unavailable")
+    UNAVAILABLE ("Unavailable"),
     // TODO: Provide MM.ITechManager.isLegal in static form
+
+    UNUSABLE_AMMO("Ammo w/o Weapon",
+            (eq, en) -> (eq instanceof AmmoType) && !(eq instanceof BombType)
+                    && !UnitUtil.canUseAmmo(en, (AmmoType) eq, false))
     ;
 
     private final static Set<EquipmentDatabaseCategory> showFilters = EnumSet.of(ENERGY, BALLISTIC, MISSILE,

--- a/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
@@ -66,7 +66,6 @@ public enum EquipmentDatabaseCategory {
 
     AMMO ("Ammo",
             (eq, en) -> (eq instanceof AmmoType) && !(eq instanceof BombType),
-//                    && UnitUtil.canUseAmmo(en, (AmmoType) eq, false),
             e -> e.getWeightClass() != EntityWeightClass.WEIGHT_SMALL_SUPPORT),
 
     OTHER ("Other",


### PR DESCRIPTION
This PR adds a filter toggle to the equipment database that will show all ammo instead of only ammo for weapons present on the unit. This is to facilitate creating ammo carrier units. (For technical reasons this toggle is present for all unit types even though most don't make good ammo trailers)

![image](https://github.com/MegaMek/megameklab/assets/17069663/1ef13304-ab9f-4129-9bb5-73075f9f2349)

Fixes #1216 
