### PR TITLE
Equipment Database: Also check MiscType for the prototype flag

### DIFF
--- a/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
@@ -99,8 +99,8 @@ public enum EquipmentDatabaseCategory {
             e -> e instanceof BattleArmor),
 
     PROTOTYPE ("Prototype",
-            (eq, en) -> (eq instanceof WeaponType) && eq.hasFlag(WeaponType.F_PROTOTYPE)
-                    || (eq instanceof MiscType) && eq.hasFlag(MiscType.F_PROTOTYPE),
+            (eq, en) -> ((eq instanceof WeaponType) && eq.hasFlag(WeaponType.F_PROTOTYPE))
+                    || ((eq instanceof MiscType) && eq.hasFlag(MiscType.F_PROTOTYPE)),
             e -> !(e instanceof BattleArmor)),
 
     ONE_SHOT ("One-Shot",

--- a/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
@@ -99,7 +99,8 @@ public enum EquipmentDatabaseCategory {
             e -> e instanceof BattleArmor),
 
     PROTOTYPE ("Prototype",
-            (eq, en) -> (eq instanceof WeaponType) && eq.hasFlag(WeaponType.F_PROTOTYPE),
+            (eq, en) -> (eq instanceof WeaponType) && eq.hasFlag(WeaponType.F_PROTOTYPE)
+                    || (eq instanceof MiscType) && eq.hasFlag(MiscType.F_PROTOTYPE),
             e -> !(e instanceof BattleArmor)),
 
     ONE_SHOT ("One-Shot",


### PR DESCRIPTION
This adds prototype filtering for MiscTypes. In other words, when prototype equipment is hidden, things like Proto Artemis or CASE-P are also hidden.