### PR TITLE
BA construction: Allow easier installation of DWP

### DIFF
--- a/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
@@ -370,8 +370,7 @@ public class BABuildView extends IView implements ActionListener, MouseListener 
                     && !eq.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK)
                     && !eq.getType().hasFlag(WeaponType.F_MISSILE)
                     && !(eq.getType() instanceof AmmoType)
-                    && !eq.isDWPMounted()
-                    && (getBattleArmor()).canMountDWP()) {
+                    && !eq.isDWPMounted()) {
                 for (Mounted m : getBattleArmor().getMisc()) {
                     // If this isn't a DWP or it's a full DWP, skip
                     if (!m.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK)
@@ -400,8 +399,7 @@ public class BABuildView extends IView implements ActionListener, MouseListener 
             // Should we allow mounting Ammo in a DWP?
             if ((eq.getType() instanceof AmmoType)
                     && getBattleArmor().hasWorkingMisc(MiscType.F_DETACHABLE_WEAPON_PACK)
-                    && !eq.isDWPMounted()
-                    && (getBattleArmor()).canMountDWP()) {
+                    && !eq.isDWPMounted()) {
                 for (final Mounted m : getBattleArmor().getMisc()) {
                     // If this isn't a DWP, skip
                     if (!m.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK)) {

--- a/megameklab/src/megameklab/ui/battleArmor/BAEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAEquipmentDatabaseView.java
@@ -66,9 +66,6 @@ class BAEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
 
     @Override
     protected boolean shouldShow(EquipmentType equipment) {
-        if (equipment.hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK) && !getBattleArmor().canMountDWP()) {
-            return false;
-        }
         if ((equipment instanceof MiscType)
                 && (equipment.hasFlag(MiscType.F_BA_MANIPULATOR)
                 || equipment.hasFlag(MiscType.F_PARTIAL_WING)


### PR DESCRIPTION
This relaxes how DWPs can be installed on BA in that DWP is no longer hidden in equipment and blocked from being used (install weapons to it) by the BA having not enough MP (which could be difficult to see for the users). Instead, in the accompanying PR for MM, BA tests are added to make BA invalid in that case among others.

Although it doesnt automatically set MP, I think it Fixes #275 