### PR TITLE
RFE #1156: make 'auto fill unhittables' and 'auto compact' saveable o…

### DIFF
--- a/megameklab/resources/megameklab/resources/Dialogs.properties
+++ b/megameklab/resources/megameklab/resources/Dialogs.properties
@@ -50,6 +50,10 @@ ConfigurationDialog.chkSummaryFormatTRO.text=Use TRO format for text export
 ConfigurationDialog.chkSummaryFormatTRO.tooltip=When checked, text exports are formatted in technical readout style, otherwise as a traditional MegaMek unit summary.
 ConfigurationDialog.chkSkipSavePrompts.text=Disable save prompts. Use at your own risk!
 ConfigurationDialog.chkSkipSavePrompts.tooltip=When checked, no safety dialogs warning about losing changes when switching unit or unit type will be shown.
+ConfigurationDialog.chkCritsAutofillUnhittables.text=Automatically fill unhittable crits
+ConfigurationDialog.chkCritsAutofillUnhittables.tooltip=Defaults to set.  When unset, unhittable crit items must be manually installed.
+ConfigurationDialog.chkCritsAutocompact.text=Automatically compact crit items
+ConfigurationDialog.chkCritsAutocompact.tooltip=Defaults to set.  When unset, critical entries will not be compacted automatically.
 
 RecordSheetTask.printing=Printing
 RecordSheetTask.exporting=Exporting

--- a/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
@@ -35,6 +35,8 @@ public class MiscSettingsPanel extends JPanel {
 
     private final JCheckBox chkSummaryFormatTRO = new JCheckBox();
     private final JCheckBox chkSkipSavePrompts = new JCheckBox();
+    private final JCheckBox chkCritsAutofillUnhittables = new JCheckBox();
+    private final JCheckBox chkCritsAutocompact = new JCheckBox();
 
     MiscSettingsPanel() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs");
@@ -47,11 +49,21 @@ public class MiscSettingsPanel extends JPanel {
         chkSkipSavePrompts.setToolTipText(resourceMap.getString("ConfigurationDialog.chkSkipSavePrompts.tooltip"));
         chkSkipSavePrompts.setSelected(CConfig.getBooleanParam(CConfig.MISC_SKIP_SAFETY_PROMPTS));
 
+        chkCritsAutofillUnhittables.setText(resourceMap.getString("ConfigurationDialog.chkCritsAutofillUnhittables.text"));
+        chkCritsAutofillUnhittables.setToolTipText(resourceMap.getString("ConfigurationDialog.chkCritsAutofillUnhittables.tooltip"));
+        chkCritsAutofillUnhittables.setSelected(CConfig.getBooleanParam(CConfig.MML_CRITS_AUTOFILL_UNHITTABLES));
+
+        chkCritsAutocompact.setText(resourceMap.getString("ConfigurationDialog.chkCritsAutocompact.text"));
+        chkCritsAutocompact.setToolTipText(resourceMap.getString("ConfigurationDialog.chkCritsAutocompact.tooltip"));
+        chkCritsAutocompact.setSelected(CConfig.getBooleanParam(CConfig.MML_CRITS_AUTOCOMPACT));
+
         JPanel gridPanel = new JPanel(new SpringLayout());
         gridPanel.add(chkSummaryFormatTRO);
         gridPanel.add(chkSkipSavePrompts);
+        gridPanel.add(chkCritsAutofillUnhittables);
+        gridPanel.add(chkCritsAutocompact);
 
-        SpringUtilities.makeCompactGrid(gridPanel, 2, 1, 0, 0, 15, 10);
+        SpringUtilities.makeCompactGrid(gridPanel, 4, 1, 0, 0, 15, 10);
         gridPanel.setBorder(new EmptyBorder(20, 30, 20, 30));
         setLayout(new FlowLayout(FlowLayout.LEFT));
         add(gridPanel);
@@ -61,6 +73,8 @@ public class MiscSettingsPanel extends JPanel {
         Map<String, String> miscSettings = new HashMap<>();
         miscSettings.put(CConfig.MISC_SUMMARY_FORMAT_TRO, String.valueOf(chkSummaryFormatTRO.isSelected()));
         miscSettings.put(CConfig.MISC_SKIP_SAFETY_PROMPTS, String.valueOf(chkSkipSavePrompts.isSelected()));
+        miscSettings.put(CConfig.MML_CRITS_AUTOFILL_UNHITTABLES, String.valueOf(chkCritsAutofillUnhittables.isSelected()));
+        miscSettings.put(CConfig.MML_CRITS_AUTOCOMPACT, String.valueOf(chkCritsAutocompact.isSelected()));
         return miscSettings;
     }
 }

--- a/megameklab/src/megameklab/ui/mek/BMBuildTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildTab.java
@@ -21,6 +21,7 @@ import megameklab.ui.EntitySource;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
 import megameklab.util.UnitUtil;
+import megameklab.util.CConfig;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
@@ -58,10 +59,10 @@ public class BMBuildTab extends ITab {
     private JComponent createButtonPanel() {
         autoFillUnHittables.addActionListener(e -> refresh());
         autoFillUnHittables.setToolTipText(resources.getString("BuildTab.autoFillUnhittables.tooltip"));
-        autoFillUnHittables.setSelected(true);
+        autoFillUnHittables.setSelected(CConfig.getBooleanParam(CConfig.MML_CRITS_AUTOFILL_UNHITTABLES));
         autoCompact.addActionListener(e -> refresh());
         autoCompact.setToolTipText(resources.getString("BuildTab.autoCompact.tooltip"));
-        autoCompact.setSelected(true);
+        autoCompact.setSelected(CConfig.getBooleanParam(CConfig.MML_CRITS_AUTOCOMPACT));
         autoSort.addActionListener(e -> refresh());
         autoSort.addActionListener(e -> autoCompact.setEnabled(!autoSort.isSelected()));
         autoSort.setToolTipText(resources.getString("BuildTab.autoSort.tooltip"));

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -1,13 +1,13 @@
 /*
  * MegaMekLab - Copyright (C) 2008
- * 
+ *
  * Original author - jtighe (torren@users.sourceforge.net)
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software
  * Foundation; either version 2 of the License, or (at your option) any later
  * version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
  * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
@@ -85,7 +85,7 @@ public class CConfig {
 
     public static final String MISC_SUMMARY_FORMAT_TRO = "useTROFormat";
     public static final String MISC_SKIP_SAFETY_PROMPTS = "skipSafetyPrompts";
-    
+
     public static final String CONFIG_SAVE_LOC = "Save-Location-Default";
     public static final String CONFIG_PLAF = "lookAndFeel";
 
@@ -105,6 +105,9 @@ public class CConfig {
     public static final String RS_SCALE_UNITS = "rs_scale_units";
 
     public static final String NAG_EQUIPMENT_CTRLCLICK = "nag_equipment_ctrlclick";
+
+    public static final String MML_CRITS_AUTOFILL_UNHITTABLES = "crits_autofill_unhittables";
+    public static final String MML_CRITS_AUTOCOMPACT = "crits_autocompact";
 
     /**
      * Player configuration values.
@@ -140,6 +143,8 @@ public class CConfig {
         defaults.setProperty(RS_SCALE_FACTOR, "1");
         defaults.setProperty(RS_SCALE_UNITS, RSScale.HEXES.toString());
         defaults.setProperty(NAG_EQUIPMENT_CTRLCLICK, Boolean.toString(true));
+        defaults.setProperty(MML_CRITS_AUTOFILL_UNHITTABLES, Boolean.toString(true));
+        defaults.setProperty(MML_CRITS_AUTOCOMPACT, Boolean.toString(true));
 
         return defaults;
     }
@@ -176,7 +181,7 @@ public class CConfig {
             LogManager.getLogger().error("", ex);
         }
     }
-    
+
     /**
      * Creates a new Config file, and directories, if it is missing.
      */
@@ -206,7 +211,7 @@ public class CConfig {
 
     /**
      * Get a config value, with a default value to be used if the value is not found.
-     * 
+     *
      * @param param      The key
      * @param defaultVal The value to return if the entry is not found
      * @return           The value associated with the key
@@ -221,10 +226,10 @@ public class CConfig {
         }
         return tparam;
     }
-    
+
     /**
      * Get a config value.
-     * 
+     *
      * @param param      The key
      * @return           The value associated with the key. If not found, an empty String is returned
      */


### PR DESCRIPTION
…ption

Problem:

  Some users want to turn off Auto Fill Unhittables and Auto Compact by
default, so that they can assign all criticals directly without having to reset or move auto-assigned items.

Solution:

  1. Add two new checkboxes to Misc Settings Panel for these options. A. Both are enabled by default. B. Both have suitable text and tooltips describing functionality.
  2. Have BMBuildTab read these CConfig values when instantiating the relevant buttons.

Testing:

  1. Tested new options: Checkboxes can be set/unset, saved, and loaded correctly.
  2. Tested with new Meks; default HS and added unhittable items are not filled or compacted.
  3. Tested with loaded mechs; changed items are not filled or compacted.