### PR TITLE
Mek crit view: Save toggle state for auto-fill, compact and sort (alternative to 1296)

### DIFF
--- a/megameklab/src/megameklab/ui/mek/BMBuildTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildTab.java
@@ -20,6 +20,7 @@ import megamek.common.Mounted;
 import megameklab.ui.EntitySource;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
+import megameklab.util.CConfig;
 import megameklab.util.UnitUtil;
 
 import javax.swing.*;
@@ -42,6 +43,9 @@ public class BMBuildTab extends ITab {
 
     public BMBuildTab(EntitySource eSource) {
         super(eSource);
+        autoFillUnHittables.setSelected(CConfig.getBooleanParam(CConfig.MEK_AUTOFILL));
+        autoSort.setSelected(CConfig.getBooleanParam(CConfig.MEK_AUTOSORT));
+        autoCompact.setSelected(CConfig.getBooleanParam(CConfig.MEK_AUTOCOMPACT));
         critView = new BMCriticalView(eSource, refresh);
         buildView = new BMBuildView(eSource, refresh, critView);
 
@@ -58,10 +62,8 @@ public class BMBuildTab extends ITab {
     private JComponent createButtonPanel() {
         autoFillUnHittables.addActionListener(e -> refresh());
         autoFillUnHittables.setToolTipText(resources.getString("BuildTab.autoFillUnhittables.tooltip"));
-        autoFillUnHittables.setSelected(true);
         autoCompact.addActionListener(e -> refresh());
         autoCompact.setToolTipText(resources.getString("BuildTab.autoCompact.tooltip"));
-        autoCompact.setSelected(true);
         autoSort.addActionListener(e -> refresh());
         autoSort.addActionListener(e -> autoCompact.setEnabled(!autoSort.isSelected()));
         autoSort.setToolTipText(resources.getString("BuildTab.autoSort.tooltip"));
@@ -111,6 +113,9 @@ public class BMBuildTab extends ITab {
     }
 
     public void refresh() {
+        CConfig.setParam(CConfig.MEK_AUTOFILL, Boolean.toString(autoFillUnHittables.isSelected()));
+        CConfig.setParam(CConfig.MEK_AUTOSORT, Boolean.toString(autoSort.isSelected()));
+        CConfig.setParam(CConfig.MEK_AUTOCOMPACT, Boolean.toString(autoCompact.isSelected()));
         autoFillUnHittables();
         autoCompactCrits();
         autoSortCrits();

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -106,6 +106,10 @@ public class CConfig {
 
     public static final String NAG_EQUIPMENT_CTRLCLICK = "nag_equipment_ctrlclick";
 
+    public static final String MEK_AUTOFILL = "mekAutofill";
+    public static final String MEK_AUTOSORT = "mekAutosort";
+    public static final String MEK_AUTOCOMPACT = "mekAutocompact";
+
     /**
      * Player configuration values.
      */
@@ -140,6 +144,9 @@ public class CConfig {
         defaults.setProperty(RS_SCALE_FACTOR, "1");
         defaults.setProperty(RS_SCALE_UNITS, RSScale.HEXES.toString());
         defaults.setProperty(NAG_EQUIPMENT_CTRLCLICK, Boolean.toString(true));
+        defaults.setProperty(MEK_AUTOFILL, Boolean.toString(true));
+        defaults.setProperty(MEK_AUTOSORT, Boolean.toString(true));
+        defaults.setProperty(MEK_AUTOCOMPACT, Boolean.toString(true));
 
         return defaults;
     }
@@ -149,7 +156,6 @@ public class CConfig {
      */
     public static void load() {
         ensureConfigFileExists();
-
         loadConfigFile();
     }
 


### PR DESCRIPTION
Saves the state of the toggles for auto-filling, compacting and sorting in the mek crit view whenever they're clicked. Same as #1296, only that it works without opening the configuration.