### PR TITLE
Fix #1230: 0 Max Bay Doors on Large Fixed-Wing Sup

### DIFF
--- a/megameklab/resources/megameklab/resources/Tabs.properties
+++ b/megameklab/resources/megameklab/resources/Tabs.properties
@@ -1,5 +1,6 @@
 TransportTab.lblCurrentBays.text=Current Bays
 TransportTab.lblMaxDoors.text=Maximum Doors:
+TransportTab.lblMinDoors.text=Minimum Doors:
 TransportTab.lblAvailableBays.text=Available Bays
 TransportTab.btnAddBay.text=Add Bay
 TransportTab.btnAddBay.tooltip=Add a new transport bay of the selected type to the vessel.

--- a/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
@@ -124,6 +124,11 @@ public class SVMainUI extends MegaMekLabMainUI {
 
     @Override
     public void refreshTransport() {
+        transportTab = new TransportTab(this);
+        transportTab.addRefreshedListener(this);
+        int idx = configPane.indexOfTab("Transport");
+        configPane.removeTabAt(idx);
+        configPane.insertTab("Transport", null, new TabScrollPane(transportTab), null,idx);
         transportTab.refresh();
     }
 

--- a/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
@@ -192,6 +192,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
     public void chassisChanged(String chassis) {
         getSV().setChassis(chassis);
         refresh.refreshHeader();
+        refresh.refreshTransport();
         refresh.refreshPreview();
     }
 


### PR DESCRIPTION
This fix adds support for maximum door counts for Fixed-Wing Support Vehicles, as well as a count of minimum doors required for all transport bays, based on TM errata 6.0.

This fix changes the Transport Tab refresh behavior: now, when the chassis type is changed in the Structure Tab, the Transport Tab will be completely re-initialized.  This is so that new Fixed Wing Support Vehicles properly display the door count information (currently it only displays when loaded from a file or the chache).

NOTE: depends on the same-name PR for MegaMek, which adds the 'minDoors' field for every Bay type and corrects the Max Door check in TestAero.java.  Do not pull prior to that PR being pulled.  PR is: https://github.com/MegaMek/megamek/pull/4691