### PR TITLE
Fix #1287: NPE when deleting multi-slot BA equip.

### DIFF
--- a/megameklab/src/megameklab/ui/battleArmor/BACriticalSuit.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BACriticalSuit.java
@@ -8,17 +8,17 @@ import megamek.common.Mounted;
 /**
  * Since BattleArmor is setup in a squad, the standard CriticalSlot system
  * isn't used.  For construction purposes, we keep track of criticals.  In MM,
- * for purposes and dealing with hits, the "locations" for BattleArmor must 
- * correspond to the troopers in the squad.  This means that the standard 
+ * for purposes and dealing with hits, the "locations" for BattleArmor must
+ * correspond to the troopers in the squad.  This means that the standard
  * Mounted.location can't really be used, and it causes problems with the
- * criticals as well.  Since these really only matter for constructions, a 
+ * criticals as well.  Since these really only matter for constructions, a
  * separate critical system is tracked in MML only for construction purposes.
  **/
 public class BACriticalSuit {
-    
+
     //store critical slots just like an entity
     protected CriticalSlot[][] crits; // [loc][slot]
-    
+
     BattleArmor ba;
 
     public BACriticalSuit(BattleArmor ba) {
@@ -51,7 +51,7 @@ public class BACriticalSuit {
 
         }
     }
-    
+
     public int locations() {
         return BattleArmor.MOUNT_NUM_LOCS;
     }
@@ -59,7 +59,7 @@ public class BACriticalSuit {
     public int getNumCriticals(int loc) {
         return crits[loc].length;
     }
-    
+
     public boolean canAddMounted(int loc, Mounted m) {
         int critsToAdd;
         if (m.getType().isSpreadable()) {
@@ -75,26 +75,29 @@ public class BACriticalSuit {
         }
         return critsAvailable >= critsToAdd;
     }
-    
+
     public void addMounted(int loc, Mounted m) {
         // Don't mount unmounted equipment
         if (loc == BattleArmor.MOUNT_LOC_NONE) {
             return;
         }
-        
+        if (m == null) {
+            return;
+        }
+
         // AP Weapons that are mounted in an AP Mount don't take up slots
-        if (m.isAPMMounted() && m.getLinkedBy() != null 
+        if (m.isAPMMounted() && m.getLinkedBy() != null
                 && m.getLinkedBy().getType().hasFlag(MiscType.F_AP_MOUNT)) {
             return;
         }
-        
+
         // Manipulators will always go in the last slot in its location, as they get a special slot
         // added for them
         if (m.getType().hasFlag(MiscType.F_BA_MANIPULATOR)) {
             int slot = crits[loc].length - 1;
             crits[loc][slot] = new CriticalSlot(m);
         }
-        
+
         int critsToAdd;
         if (m.getType().isSpreadable()) {
             critsToAdd = 1;

--- a/megameklab/src/megameklab/ui/util/BAASBMDropTargetCriticalList.java
+++ b/megameklab/src/megameklab/ui/util/BAASBMDropTargetCriticalList.java
@@ -128,7 +128,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                 if ((mount != null) && ((e.getModifiersEx() & InputEvent.SHIFT_DOWN_MASK) != 0)) {
                     changeOmniMounting(!mount.isOmniPodMounted());
                     return;
-                }                
+                }
 
                 if ((mount != null)
                         && !(((getUnit().getEntityType() & Entity.ETYPE_QUADVEE) == Entity.ETYPE_QUADVEE)
@@ -153,7 +153,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                             && !mount.isSquadSupportWeapon()
                             && mount.getLocation() == BattleArmor.LOC_SQUAD
                             && (getUnit() instanceof BattleArmor)
-                            && ((BattleArmor)getUnit()).getChassisType() != 
+                            && ((BattleArmor)getUnit()).getChassisType() !=
                                 BattleArmor.CHASSIS_TYPE_QUAD) {
                         info = new JMenuItem("Mount as squad support weapon");
                         info.addActionListener(evt -> {
@@ -164,7 +164,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                         });
                         popup.add(info);
                     }
-                    
+
                     // Adding ammo as a squad support mount is slightly different
                     if ((mount.getType() instanceof AmmoType)
                             && !mount.getType().hasFlag(WeaponType.F_MISSILE)
@@ -176,7 +176,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                         boolean enabled = false;
                         for (Mounted weapon : getUnit().getWeaponList()) {
                             WeaponType wtype = (WeaponType) weapon.getType();
-                            if (weapon.isSquadSupportWeapon() 
+                            if (weapon.isSquadSupportWeapon()
                                     && AmmoType.isAmmoValid(mount, wtype)) {
                                 enabled = true;
                             }
@@ -192,7 +192,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                         });
                         popup.add(info);
                     }
-                    
+
                     // Allow removing squad support weapon
                     if (mount.isSquadSupportWeapon()) {
                         info = new JMenuItem("Remove squad support weapon mount");
@@ -209,9 +209,9 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                         });
                         popup.add(info);
                     }
-                    
+
                     // Right-clicked on a DWP that has an attached weapon
-                    if (mount.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK) 
+                    if (mount.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK)
                             && (mount.getLinked() != null)) {
                         info = new JMenuItem("Remove attached weapon");
                         info.addActionListener(evt -> {
@@ -227,7 +227,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                         });
                         popup.add(info);
                     }
-                    
+
                     // Right-clicked on a AP Mount that has an attached weapon
                     if (mount.getType().hasFlag(MiscType.F_AP_MOUNT)
                             && (mount.getLinked() != null)) {
@@ -310,7 +310,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                             popup.add(info);
                         }
                     }
-                    
+
                     if (getUnit().isOmni() && !mount.getType().isOmniFixedOnly()) {
                         if (mount.isOmniPodMounted()) {
                             info = new JMenuItem("Change to fixed mount");
@@ -395,7 +395,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                         popup.add(info);
                     }
                 }
-                
+
                 if (popup.getComponentCount() > 0) {
                     popup.show(this, e.getX(), e.getY());
                 }
@@ -487,7 +487,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
         if (mounted == null) {
             return;
         }
-        
+
         // BattleArmor doesn't use the crit system, so we can just remove the mounted and be done
         if (getUnit() instanceof BattleArmor) {
             changeMountStatus(mounted, BattleArmor.MOUNT_LOC_NONE, false);
@@ -559,7 +559,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
             refresh.scheduleRefresh();
         }
     }
-    
+
     public int getCritLocation() {
         if (getUnit() instanceof BattleArmor) {
             String[] split = getName().split(":");

--- a/megameklab/src/megameklab/ui/util/CritListCellRenderer.java
+++ b/megameklab/src/megameklab/ui/util/CritListCellRenderer.java
@@ -46,15 +46,15 @@ public class CritListCellRenderer extends DefaultListCellRenderer {
         setText(split[0]);
         setToolTipText(null);
 
-        CriticalSlot cs;
+        CriticalSlot cs = null;
         if (split.length > 2) {
             int eqId = Integer.parseInt(split[2]);
-            cs = new CriticalSlot(unit.getEquipment(eqId));
+            /** safety against logic error where we try to redraw deleted equipment due to poor dupe slot handling **/
+            Mounted eq = unit.getEquipment(eqId);
+            cs = eq != null ? new CriticalSlot(eq) : null;
         } else if (split.length > 1) {
             cs = getCrit(Integer.parseInt(split[1]));
-        } else if (value.equals(EMPTY_CRITCELL_TEXT)) {
-            cs = null;
-        } else {
+        } else if (!value.equals(EMPTY_CRITCELL_TEXT)) {
             cs = getCrit(index);
         }
 
@@ -79,8 +79,8 @@ public class CritListCellRenderer extends DefaultListCellRenderer {
         }
 
         int loc = getCritLocation();
-        if ((cs != null) 
-                && UnitUtil.isLastCrit(unit, cs, index, loc) 
+        if ((cs != null)
+                && UnitUtil.isLastCrit(unit, cs, index, loc)
                 && UnitUtil.isPreviousCritEmpty(unit, cs, index, loc)) {
             setBorder(BorderFactory.createMatteBorder(1, 0, 1, 0, CritCellUtil.CRITCELL_BORDER_COLOR));
         } else if ((cs != null) && UnitUtil.isLastCrit(unit, cs, index, loc)) {


### PR DESCRIPTION
Problem:

  Deleting multi-slot equipment, or indeed deleting _any_ equipment
  while multi-slot equipment is installed in a suit, causes a Null
  Pointer Exception.

  This is due to the way CritListCellRenderer() creates new slot entries
  when refreshing; multi-slot items appear to return multiple indexes
  despite only occupying one equipment entry on the BA itself, which
  causes `unit.getEquipment(eqId);` to return a null Mounted entry.

Solution:

  Since A) this is specific to the MML BA criticals table and nothing
  else, B) incredibly annoying to debug, and C) of no impact whatsoever
  if we just ignore this problem, I've added a check to see if the eq
  check returns null or not.  This solves the NPE problem and I don't
  really see any reason to delve deeper into the multi-slots issue
  when they are purely there for the UI.

Testing:

  - Tested with multiple different 2+ slot items on BAs of applicable size; no further NPEs seen.

Close #1287