### PR TITLE
Fix class path in manifest

### DIFF
--- a/megameklab/build.gradle
+++ b/megameklab/build.gradle
@@ -110,8 +110,8 @@ jar {
     archiveFileName = "MegaMekLab.jar"
     manifest {
         attributes "Main-Class" : mainClassName
-        attributes "Class-Path" : "${mmJar.archiveFileName.get()} " + (project.sourceSets.main.runtimeClasspath.files
-                .findAll { it.name.endsWith(".jar") }
+        attributes "Class-Path" : "${lib}/${mmJar.archiveFileName.get()} " + (project.sourceSets.main.runtimeClasspath.files
+                .findAll { it.name.endsWith(".jar") && !it.name.toLowerCase().startsWith("megamek") }
                 .collect { "${lib}/${it.name}" }.join(' '))
         attributes "Add-Opens" : 'java.base/java.util java.base/java.util.concurrent'
         attributes "Build-Date" : LocalDateTime.now()


### PR DESCRIPTION
From the manifest currently:
```Class-Path: MegaMek.jar lib/megamek-0.49.15-SNAPSHOT.jar  lib/jaxb-runtime-4.0.1.jar```

The MegaMek.jar is in the lib directory rather than the top-level directory as expected by the manifest. There is no lib/megamek-0.49.15-SNAPSHOT.jar file. This is included from the list of dependencies. It used to be filtered out but the filter was removed by #1219, which did nothing to fix the actual issue.

I have restored the filter to remove the useless entry and fixed the path to the MegaMek.jar path, and tested it to be certain it works. After the change the manifest starts like this:
```Class-Path: lib/MegaMek.jar lib/jaxb-runtime-4.0.1.jar```

Fixes #1268