### PR TITLE
Fix MML #3761: update munitions equality tests

### DIFF
--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -3788,7 +3788,7 @@ public class UnitUtil {
                 munition = EnumSet.of(AmmoType.Munitions.M_STANDARD);
             }
             Optional<AmmoType> ammo = AmmoType.getMunitionsFor(fieldGun.getAmmoType()).stream()
-                    .filter(eq -> (eq.getMunitionType().contains(munition))
+                    .filter(eq -> (eq.getMunitionType().equals(munition))
                             && (eq.getRackSize() == fieldGun.getRackSize()))
                     .findFirst();
             if (ammo.isEmpty()) {


### PR DESCRIPTION
This will fix a subtle error where `.contains()` can be _called_ on one EnumSet from another but will always return false;
the proper method is `.containsAll()` or, in this case, `.equals()`.

See related PRs in MekHQ and MegaMek as well.