### PR TITLE
Allow unit role selection in MML

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -18,6 +18,8 @@ BasicInfoView.cbTechLevel.tooltip=<html>Filter options by rules level.<br/>If us
 BasicInfoView.txtManualBV.text=Manual BV:
 BasicInfoView.txtManualBV.tooltip=Alternative to the calculated Battle Value.
 BasicInfoView.cbTechBase.values=Inner Sphere,Clan,Mixed Inner Sphere,Mixed Clan
+BasicInfoView.txtRole.text=Role:
+BasicInfoView.txtRole.tooltip=The combat role of this unit.
 
 MekChassisView.baseType.values=Standard,Industrial,LAM,QuadVee
 MekChassisView.motiveType.values=Biped,Quad,Tripod

--- a/megameklab/src/megameklab/printing/PrintEntity.java
+++ b/megameklab/src/megameklab/printing/PrintEntity.java
@@ -203,7 +203,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
         // for C3 networks or pilot skills.
         setTextField(BV, NumberFormat.getInstance().format(getEntity()
                 .calculateBattleValue(!showPilotInfo(), !showPilotInfo())));
-        UnitRole role = UnitRoleHandler.getRoleFor(getEntity());
+        UnitRole role = getEntity().getRole();
         if (!options.showRole() || (role == UnitRole.UNDETERMINED)) {
             hideElement(LBL_ROLE, true);
             hideElement(ROLE, true);

--- a/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
@@ -642,4 +642,9 @@ public class BAStructureTab extends ITab implements ActionListener, BABuildListe
     public void mulIdChanged(int mulId) {
         getBattleArmor().setMulId(mulId);
     }
+
+    @Override
+    public void roleChanged(UnitRole role) {
+        getEntity().setUnitRole(role);
+    }
 }

--- a/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
@@ -810,9 +810,13 @@ public class CVStructureTab extends ITab implements CVBuildListener, ArmorAlloca
         refresh.refreshStatus();
     }
 
-
     @Override
     public void mulIdChanged(int mulId) {
         getTank().setMulId(mulId);
+    }
+
+    @Override
+    public void roleChanged(UnitRole role) {
+        getEntity().setUnitRole(role);
     }
 }

--- a/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
@@ -30,16 +30,7 @@ import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 
 import megamek.codeUtilities.MathUtility;
-import megamek.common.Aero;
-import megamek.common.CriticalSlot;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.LocationFullException;
-import megamek.common.Mounted;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TechConstants;
+import megamek.common.*;
 import megamek.common.verifier.TestAero;
 import megamek.common.verifier.TestEntity;
 import megameklab.ui.EntitySource;
@@ -675,5 +666,10 @@ public class ASStructureTab extends ITab implements AeroBuildListener, ArmorAllo
     @Override
     public void mulIdChanged(int mulId) {
         getAero().setMulId(mulId);
+    }
+
+    @Override
+    public void roleChanged(UnitRole role) {
+        getEntity().setUnitRole(role);
     }
 }

--- a/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
@@ -67,6 +67,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     private final CustomComboBox<Integer> cbTechBase = new CustomComboBox<>(i -> String.valueOf(techBaseNames[i]));
     private final JComboBox<SimpleTechLevel> cbTechLevel = new JComboBox<>();
     private final IntRangeTextField txtManualBV = new IntRangeTextField(3);
+    private final JComboBox<UnitRole> cbRole = new JComboBox<>();
     private final JLabel lblMulId = createLabel("lblMulId", "", labelSize);
     private final IntRangeTextField txtMulId = new IntRangeTextField(8);
     private final JButton browseMul = new JButton("Open MUL in Browser");
@@ -194,6 +195,16 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         add(txtManualBV, gbc);
         txtManualBV.addFocusListener(this);
 
+        gbc.gridx = 0;
+        gbc.gridy++;
+        add(createLabel(resourceMap, "lblRole", "BasicInfoView.txtRole.text",
+                "BasicInfoView.txtRole.tooltip", labelSize), gbc);
+        gbc.gridx = 1;
+        setFieldSize(txtManualBV, controlSize);
+        cbRole.setToolTipText(resourceMap.getString("BasicInfoView.txtRole.tooltip"));
+        add(cbRole, gbc);
+        cbRole.addActionListener(this);
+
         txtMulId.setMinimum(-1);
         lblFaction.setVisible(CConfig.getBooleanParam(CConfig.TECH_SHOW_FACTION));
         cbFaction.setVisible(CConfig.getBooleanParam(CConfig.TECH_SHOW_FACTION));
@@ -221,6 +232,13 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         if (en.getManualBV() >= 0) {
             setManualBV(en.getManualBV());
         }
+        cbRole.removeAllItems();
+        for (UnitRole role : UnitRole.values()) {
+            if (role.isAvailableTo(en)) {
+                cbRole.addItem(role);
+            }
+        }
+        cbRole.setSelectedItem(en.getRole());
         
         refreshFaction();
     }
@@ -502,6 +520,9 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
             refreshTechLevel();
         } else if (e.getSource() == cbTechLevel) {
             listeners.forEach(l -> l.techLevelChanged(getTechLevel()));
+        } else if (e.getSource() == cbRole) {
+            UnitRole newRole = cbRole.getSelectedItem() == null ? UnitRole.UNDETERMINED : (UnitRole) cbRole.getSelectedItem();
+            listeners.forEach(l -> l.roleChanged(newRole));
         }
         listeners.forEach(BuildListener::refreshSummary);
     }

--- a/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
@@ -19,6 +19,7 @@
 package megameklab.ui.generalUnit;
 
 import megamek.MMConstants;
+import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.common.*;
 import megameklab.ui.listeners.BuildListener;
 import megameklab.ui.util.CustomComboBox;
@@ -67,7 +68,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     private final CustomComboBox<Integer> cbTechBase = new CustomComboBox<>(i -> String.valueOf(techBaseNames[i]));
     private final JComboBox<SimpleTechLevel> cbTechLevel = new JComboBox<>();
     private final IntRangeTextField txtManualBV = new IntRangeTextField(3);
-    private final JComboBox<UnitRole> cbRole = new JComboBox<>();
+    private final MMComboBox<UnitRole> cbRole = new MMComboBox<>("Role Combo");
     private final JLabel lblMulId = createLabel("lblMulId", "", labelSize);
     private final IntRangeTextField txtMulId = new IntRangeTextField(8);
     private final JButton browseMul = new JButton("Open MUL in Browser");
@@ -204,6 +205,17 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         cbRole.setToolTipText(resourceMap.getString("BasicInfoView.txtRole.tooltip"));
         add(cbRole, gbc);
         cbRole.addActionListener(this);
+        // Show the role UNDETERMINED as an empty selection to differentiate it from NONE
+        // UNDETERMINED means that no role at all will be saved to the unit
+        cbRole.setRenderer(new DefaultListCellRenderer() {
+            @Override
+            public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+                if (value == UnitRole.UNDETERMINED) {
+                    value = " ";
+                }
+                return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+            }
+        });
 
         txtMulId.setMinimum(-1);
         lblFaction.setVisible(CConfig.getBooleanParam(CConfig.TECH_SHOW_FACTION));
@@ -521,7 +533,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         } else if (e.getSource() == cbTechLevel) {
             listeners.forEach(l -> l.techLevelChanged(getTechLevel()));
         } else if (e.getSource() == cbRole) {
-            UnitRole newRole = cbRole.getSelectedItem() == null ? UnitRole.UNDETERMINED : (UnitRole) cbRole.getSelectedItem();
+            UnitRole newRole = (cbRole.getSelectedItem() == null) ? UnitRole.UNDETERMINED : cbRole.getSelectedItem();
             listeners.forEach(l -> l.roleChanged(newRole));
         }
         listeners.forEach(BuildListener::refreshSummary);

--- a/megameklab/src/megameklab/ui/infantry/CIStructureTab.java
+++ b/megameklab/src/megameklab/ui/infantry/CIStructureTab.java
@@ -489,4 +489,8 @@ public class CIStructureTab extends ITab implements InfantryBuildListener {
         getInfantry().setMulId(mulId);
     }
 
+    @Override
+    public void roleChanged(UnitRole role) {
+        getEntity().setUnitRole(role);
+    }
 }

--- a/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
@@ -23,13 +23,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JPanel;
 
 import megamek.codeUtilities.MathUtility;
-import megamek.common.Aero;
-import megamek.common.Dropship;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.SimpleTechLevel;
+import megamek.common.*;
 import megamek.common.verifier.TestEntity;
 import megameklab.ui.EntitySource;
 import megameklab.ui.generalUnit.*;
@@ -588,5 +582,8 @@ public class DSStructureTab extends ITab implements DropshipBuildListener, Armor
         refresh.refreshPreview();
     }
 
-
+    @Override
+    public void roleChanged(UnitRole role) {
+        getEntity().setUnitRole(role);
+    }
 }

--- a/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
@@ -24,14 +24,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JPanel;
 
 import megamek.codeUtilities.MathUtility;
-import megamek.common.Aero;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.Jumpship;
-import megamek.common.SimpleTechLevel;
-import megamek.common.SpaceStation;
-import megamek.common.Warship;
+import megamek.common.*;
 import megamek.common.verifier.TestEntity;
 import megameklab.ui.EntitySource;
 import megameklab.ui.generalUnit.*;
@@ -653,4 +646,8 @@ public class WSStructureTab extends ITab implements AdvancedAeroBuildListener, A
         getJumpship().setMulId(mulId);
     }
 
+    @Override
+    public void roleChanged(UnitRole role) {
+        getEntity().setUnitRole(role);
+    }
 }

--- a/megameklab/src/megameklab/ui/listeners/BuildListener.java
+++ b/megameklab/src/megameklab/ui/listeners/BuildListener.java
@@ -16,6 +16,7 @@ package megameklab.ui.listeners;
 import megamek.common.EquipmentType;
 import megamek.common.FuelType;
 import megamek.common.SimpleTechLevel;
+import megamek.common.UnitRole;
 
 /**
  * Combined listener interface for the various subviews of the structure tab. Includes callbacks
@@ -35,6 +36,7 @@ public interface BuildListener {
     void mulIdChanged(int mulId);
     void techBaseChanged(boolean clan, boolean mixed);
     void techLevelChanged(SimpleTechLevel techLevel);
+    void roleChanged(UnitRole role);
 
     /**
      * Notifies of a change of the manually entered BV. When manualBV is 0 or less, the unit

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -616,6 +616,11 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
     }
 
     @Override
+    public void roleChanged(UnitRole role) {
+        getEntity().setUnitRole(role);
+    }
+
+    @Override
     public void updateTechLevel() {
         removeAllListeners();
         getMech().setTechLevel(panBasicInfo.getTechLevel().getCompoundTechLevel(panBasicInfo.useClanTechBase()));

--- a/megameklab/src/megameklab/ui/protoMek/PMStructureTab.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMStructureTab.java
@@ -32,18 +32,7 @@ import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 
 import megamek.codeUtilities.MathUtility;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.EquipmentType;
-import megamek.common.IArmorState;
-import megamek.common.ITechManager;
-import megamek.common.LocationFullException;
-import megamek.common.MiscType;
-import megamek.common.Mounted;
-import megamek.common.Protomech;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TechConstants;
+import megamek.common.*;
 import megamek.common.verifier.TestEntity;
 import megamek.common.verifier.TestProtomech;
 import megamek.common.verifier.TestProtomech.ProtomechArmor;
@@ -722,5 +711,10 @@ public class PMStructureTab extends ITab implements ProtomekBuildListener, Armor
     @Override
     public void mulIdChanged(int mulId) {
         getProtomech().setMulId(mulId);
+    }
+
+    @Override
+    public void roleChanged(UnitRole role) {
+        getEntity().setUnitRole(role);
     }
 }

--- a/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
@@ -816,4 +816,9 @@ public class SVStructureTab extends ITab implements SVBuildListener {
     public void mulIdChanged(int mulId) {
         getEntity().setMulId(mulId);
     }
+
+    @Override
+    public void roleChanged(UnitRole role) {
+        getEntity().setUnitRole(role);
+    }
 }


### PR DESCRIPTION
Requires MegaMek/megamek#4903

This adds a unit role dropdown to the basic unit info

![image](https://github.com/MegaMek/megameklab/assets/17069663/cb5f365e-01c9-44c1-b93f-58549aec5129)

Fixes #1332 
