### PR TITLE
Show exact weight during construction (for CV)

### DIFF
--- a/megameklab/src/megameklab/ui/combatVehicle/CVStatusBar.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVStatusBar.java
@@ -15,6 +15,7 @@
  */
 package megameklab.ui.combatVehicle;
 
+import megamek.client.ui.swing.calculationReport.CalculationReport;
 import megamek.common.Tank;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestTank;
@@ -105,7 +106,7 @@ public class CVStatusBar extends ITab {
         double tonnage = getTank().getWeight();
         double currentTonnage;
 
-        currentTonnage = testEntity.calculateWeight();
+        currentTonnage = testEntity.calculateWeightExact();
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getTank());
 
         tons.setText("Tonnage: " + currentTonnage + "/" + tonnage);
@@ -131,11 +132,13 @@ public class CVStatusBar extends ITab {
         testEntity = new TestTank(getTank(), entityVerifier.tankOption,
                 null);
 
-        currentTonnage = testEntity.calculateWeight();
+        currentTonnage = testEntity.calculateWeightExact();
 
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getTank());
-
-        tons.setText(String.format("Tonnage: %.1f/%.1f (%.1f Remaining)", currentTonnage, tonnage, tonnage - currentTonnage));
+        String current = CalculationReport.formatForReport(currentTonnage);
+        String full = CalculationReport.formatForReport(tonnage);
+        String remaining = CalculationReport.formatForReport(tonnage - currentTonnage);
+        tons.setText("Tonnage: " + current + " / " + full + ((currentTonnage != tonnage) ? " (" + remaining + " Remaining)" : ""));
         tons.setToolTipText("Current Tonnage/Max Tonnage");
         if (currentTonnage > tonnage) {
             tons.setForeground(Color.red);


### PR DESCRIPTION
Instead of the rounded weight value the CV status bar now shows the exact weight. This came up during construction of a tank with Clan MGs where the 0.25t was awkwardly rounded away.

Requires MegaMek/megamek#4973