### PR TITLE
Conventional infantry fixes

### DIFF
--- a/megameklab/src/megameklab/ui/infantry/CIStructureTab.java
+++ b/megameklab/src/megameklab/ui/infantry/CIStructureTab.java
@@ -56,6 +56,7 @@ public class CIStructureTab extends ITab implements InfantryBuildListener {
     public static final int T_MOUNT            = 4;
     public static final int T_AUGMENTATION     = 5;
 
+
     private BasicInfoView panBasicInfo;
     private CIPlatoonTypeView panPlatoonType;
     private CIWeaponView panWeapons;
@@ -424,6 +425,8 @@ public class CIStructureTab extends ITab implements InfantryBuildListener {
         getInfantry().setSquadSize(squadSize);
         getInfantry().autoSetInternal();
         panPlatoonType.setFromEntity(getInfantry());
+        refresh.refreshStatus();
+        refresh.refreshPreview();
     }
     
     @Override

--- a/megameklab/src/megameklab/ui/infantry/CIStructureTab.java
+++ b/megameklab/src/megameklab/ui/infantry/CIStructureTab.java
@@ -443,10 +443,11 @@ public class CIStructureTab extends ITab implements InfantryBuildListener {
     public void numSecondaryChanged(final int count) {
         if (getInfantry().getSecondaryWeapon() == null) {
             getInfantry().setSecondaryWeaponsPerSquad(0);
-        } else if (count == 0) {
-            UnitUtil.replaceMainWeapon(getInfantry(), null, true);
-            getInfantry().setSpecializations(getInfantry().getSpecializations() & ~Infantry.TAG_TROOPS);
         } else {
+            if (count == 0) {
+                UnitUtil.replaceMainWeapon(getInfantry(), null, true);
+                getInfantry().setSpecializations(getInfantry().getSpecializations() & ~Infantry.TAG_TROOPS);
+            }
             getInfantry().setSecondaryWeaponsPerSquad(count);
         }
         refresh.refreshStatus();


### PR DESCRIPTION
1. Refreshes the status bar and preview tab when the size of the unit changes.
2. When the number of secondary weapons is set to zero, the secondary weapon is removed but the secondary weapon count field is not being set. This results in one or more unarmed troopers in a squad.

Fixes #1005