### PR TITLE
Issue #1334: remove only specific OS/Infantry ammo

### DIFF
--- a/megameklab/src/megameklab/ui/combatVehicle/CVEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVEquipmentDatabaseView.java
@@ -59,9 +59,7 @@ class CVEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
                     loc = Tank.LOC_BODY;
                 }
                 getTank().addEquipment(mount, loc, false);
-                if ((equip instanceof WeaponType) && equip.hasFlag(WeaponType.F_ONESHOT)) {
-                    UnitUtil.removeOneShotAmmo(eSource.getEntity());
-                }
+                UnitUtil.removeHiddenAmmo(mount);
             } catch (LocationFullException ignored) {
                 // this can't happen, we add to Entity.LOC_NONE
             }

--- a/megameklab/src/megameklab/ui/fighterAero/ASEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASEquipmentDatabaseView.java
@@ -52,9 +52,7 @@ class ASEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
                 UnitUtil.setVariableSizeMiscTypeMinimumSize(mount);
                 int location = (equip instanceof AmmoType) ? Aero.LOC_FUSELAGE : Aero.LOC_NONE;
                 getAero().addEquipment(mount, location, false);
-                if ((equip instanceof WeaponType) && equip.hasFlag(WeaponType.F_ONESHOT)) {
-                    UnitUtil.removeOneShotAmmo(getAero());
-                }
+                UnitUtil.removeHiddenAmmo(mount);
             } catch (LocationFullException ignored) {
                 // location maximum is currently checked in menus and dragndrop
             }

--- a/megameklab/src/megameklab/ui/largeAero/LAEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LAEquipmentDatabaseView.java
@@ -74,9 +74,7 @@ class LAEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
                         mount = new Mounted(getAero(), equip);
                         UnitUtil.setVariableSizeMiscTypeMinimumSize(mount);
                         getAero().addEquipment(mount, Entity.LOC_NONE, false);
-                        if ((equip instanceof WeaponType) && equip.hasFlag(WeaponType.F_ONESHOT)) {
-                            UnitUtil.removeOneShotAmmo(eSource.getEntity());
-                        }
+                        UnitUtil.removeHiddenAmmo(mount);
                     }
                 } catch (LocationFullException ignored) {
                     // Shouldn't happen when adding to LOC_NONE

--- a/megameklab/src/megameklab/ui/mek/BMEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/mek/BMEquipmentDatabaseView.java
@@ -54,9 +54,7 @@ class BMEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
                 mount = new Mounted(getMech(), equip);
                 UnitUtil.setVariableSizeMiscTypeMinimumSize(mount);
                 getMech().addEquipment(mount, Entity.LOC_NONE, false);
-                if ((equip instanceof WeaponType) && equip.hasFlag(WeaponType.F_ONESHOT)) {
-                    UnitUtil.removeOneShotAmmo(eSource.getEntity());
-                }
+                UnitUtil.removeHiddenAmmo(mount);
             } catch (LocationFullException ignored) {
                 // this can't happen, we add to Entity.LOC_NONE
             }

--- a/megameklab/src/megameklab/ui/mek/BMStatusBar.java
+++ b/megameklab/src/megameklab/ui/mek/BMStatusBar.java
@@ -15,13 +15,13 @@
  */
 package megameklab.ui.mek;
 
-import megamek.client.ui.WrapLayout;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.*;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestMech;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
+import megamek.client.ui.WrapLayout;
 import megameklab.util.ImageHelper;
 import megameklab.util.UnitUtil;
 

--- a/megameklab/src/megameklab/ui/mek/BMStatusBar.java
+++ b/megameklab/src/megameklab/ui/mek/BMStatusBar.java
@@ -20,7 +20,6 @@ import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.*;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestMech;
-import megamek.utilities.DebugEntity;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
 import megameklab.util.ImageHelper;
@@ -28,7 +27,6 @@ import megameklab.util.UnitUtil;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
 import java.io.File;
 import java.text.DecimalFormat;
 
@@ -43,7 +41,7 @@ public class BMStatusBar extends ITab {
     private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File("data/mechfiles/UnitVerifierOptions.xml"));
     private TestMech testEntity;
     private final DecimalFormat formatter;
-    private final BMMainUI parentFrame;
+    private final JFrame parentFrame;
 
     private RefreshListener refresh;
 
@@ -56,7 +54,7 @@ public class BMStatusBar extends ITab {
         JButton showEquipmentDatabase = new JButton("Show Equipment Database");
         showEquipmentDatabase.addActionListener(evt -> parent.getFloatingEquipmentDatabase().setVisible(true));
         JButton btnValidate = new JButton("Validate Unit");
-        btnValidate.addActionListener(this::validate);
+        btnValidate.addActionListener(evt -> UnitUtil.showValidation(getMech(), getParentFrame()));
         JButton btnFluffImage = new JButton("Set Fluff Image");
         btnFluffImage.addActionListener(evt -> getFluffImage());
         invalid.setText("Invalid");
@@ -74,15 +72,6 @@ public class BMStatusBar extends ITab {
         add(invalid);
         add(cost);
         refresh();
-    }
-
-    private void validate(ActionEvent event) {
-        if (((event.getModifiers() & Event.SHIFT_MASK) != 0)
-                && (event.getModifiers() & Event.CTRL_MASK) != 0) {
-            DebugEntity.copyEquipmentState(getEntity());
-        } else {
-            UnitUtil.showValidation(getMech(), getParentFrame());
-        }
     }
 
     public void refresh() {

--- a/megameklab/src/megameklab/ui/mek/BMStatusBar.java
+++ b/megameklab/src/megameklab/ui/mek/BMStatusBar.java
@@ -15,18 +15,20 @@
  */
 package megameklab.ui.mek;
 
+import megamek.client.ui.WrapLayout;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.*;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestMech;
+import megamek.utilities.DebugEntity;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
-import megamek.client.ui.WrapLayout;
 import megameklab.util.ImageHelper;
 import megameklab.util.UnitUtil;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ActionEvent;
 import java.io.File;
 import java.text.DecimalFormat;
 
@@ -41,7 +43,7 @@ public class BMStatusBar extends ITab {
     private final EntityVerifier entityVerifier = EntityVerifier.getInstance(new File("data/mechfiles/UnitVerifierOptions.xml"));
     private TestMech testEntity;
     private final DecimalFormat formatter;
-    private final JFrame parentFrame;
+    private final BMMainUI parentFrame;
 
     private RefreshListener refresh;
 
@@ -54,7 +56,7 @@ public class BMStatusBar extends ITab {
         JButton showEquipmentDatabase = new JButton("Show Equipment Database");
         showEquipmentDatabase.addActionListener(evt -> parent.getFloatingEquipmentDatabase().setVisible(true));
         JButton btnValidate = new JButton("Validate Unit");
-        btnValidate.addActionListener(evt -> UnitUtil.showValidation(getMech(), getParentFrame()));
+        btnValidate.addActionListener(this::validate);
         JButton btnFluffImage = new JButton("Set Fluff Image");
         btnFluffImage.addActionListener(evt -> getFluffImage());
         invalid.setText("Invalid");
@@ -72,6 +74,15 @@ public class BMStatusBar extends ITab {
         add(invalid);
         add(cost);
         refresh();
+    }
+
+    private void validate(ActionEvent event) {
+        if (((event.getModifiers() & Event.SHIFT_MASK) != 0)
+                && (event.getModifiers() & Event.CTRL_MASK) != 0) {
+            DebugEntity.copyEquipmentState(getEntity());
+        } else {
+            UnitUtil.showValidation(getMech(), getParentFrame());
+        }
     }
 
     public void refresh() {

--- a/megameklab/src/megameklab/ui/protoMek/PMEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMEquipmentDatabaseView.java
@@ -49,18 +49,15 @@ class PMEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
             if ((equip instanceof MiscType) && UnitUtil.isFixedLocationSpreadEquipment(equip)) {
                 int location = TestEntity.getSystemWideLocation(eSource.getEntity());
                 Mounted mount = new Mounted(eSource.getEntity(), equip);
-                eSource.getEntity().addEquipment(mount, location, false);
+                getEntity().addEquipment(mount, location, false);
             } else {
                 if (equip instanceof AmmoType) {
                     addProtomechAmmo(equip, 1);
                     return;
                 }
                 Mounted mount = new Mounted(eSource.getEntity(), equip);
-                eSource.getEntity().addEquipment(mount, Entity.LOC_NONE, false);
-                if ((equip instanceof WeaponType) && (equip.hasFlag(WeaponType.F_ONESHOT)
-                        || (((WeaponType) equip).getAmmoType() == AmmoType.T_INFANTRY))) {
-                    UnitUtil.removeOneShotAmmo(eSource.getEntity());
-                }
+                getEntity().addEquipment(mount, Entity.LOC_NONE, false);
+                UnitUtil.removeHiddenAmmo(mount);
             }
         } catch (LocationFullException ex) {
             LogManager.getLogger().error("Location full while trying to add " + equip.getName());

--- a/megameklab/src/megameklab/ui/supportVehicle/SVEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVEquipmentDatabaseView.java
@@ -49,40 +49,36 @@ class SVEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
         boolean isMisc = equip instanceof MiscType;
         try {
             if (isMisc && equip.hasFlag(MiscType.F_TARGCOMP)) {
-                if (!UnitUtil.hasTargComp(eSource.getEntity())) {
-                    UnitUtil.updateTC(eSource.getEntity(), equip);
+                if (!UnitUtil.hasTargComp(getEntity())) {
+                    UnitUtil.updateTC(getEntity(), equip);
                 }
             } else if (isMisc && UnitUtil.isFixedLocationSpreadEquipment(equip)) {
-                    int location = TestEntity.getSystemWideLocation(eSource.getEntity());
-                    mount = new Mounted(eSource.getEntity(), equip);
-                    eSource.getEntity().addEquipment(mount, location, false);
+                    int location = TestEntity.getSystemWideLocation(getEntity());
+                    mount = new Mounted(getEntity(), equip);
+                    getEntity().addEquipment(mount, location, false);
             } else {
                 if (equip instanceof AmmoType) {
-                    if (eSource.getEntity().usesWeaponBays()) {
+                    if (getEntity().usesWeaponBays()) {
                         addLargeCraftAmmo(equip, count);
                         return;
-                    } else if (eSource.getEntity().isAero()) {
+                    } else if (getEntity().isAero()) {
                         addBodyAmmo(equip, count, Aero.LOC_FUSELAGE);
                         return;
-                    } else if (eSource.getEntity() instanceof Tank) {
+                    } else if (getEntity() instanceof Tank) {
                         addBodyAmmo(equip, count, Tank.LOC_BODY);
                         return;
                     }
                 }
                 for (int i = 0; i < count; i++) {
-                    mount = new Mounted(eSource.getEntity(), equip);
+                    mount = new Mounted(getEntity(), equip);
                     UnitUtil.setVariableSizeMiscTypeMinimumSize(mount);
-                    if ((eSource.getEntity().isFighter()
+                    if ((getEntity().isFighter()
                             && (equip instanceof MiscType)) && equip.hasFlag(MiscType.F_BLUE_SHIELD)) {
                         getAero().addEquipment(mount, Aero.LOC_FUSELAGE, false);
                     } else {
-                        eSource.getEntity().addEquipment(mount, Entity.LOC_NONE, false);
+                        getEntity().addEquipment(mount, Entity.LOC_NONE, false);
                     }
-
-                    if ((equip instanceof WeaponType) && (equip.hasFlag(WeaponType.F_ONESHOT)
-                            || (((WeaponType) equip).getAmmoType() == AmmoType.T_INFANTRY))) {
-                        UnitUtil.removeOneShotAmmo(eSource.getEntity());
-                    }
+                    UnitUtil.removeHiddenAmmo(mount);
                 }
             }
         } catch (LocationFullException ex) {

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -3399,7 +3399,7 @@ public class UnitUtil {
      * If the given Mounted is a one-shot launcher or infantry weapon, this method removes the hidden
      * ammo linked to it, if any. During construction, we have no use of hidden ammo. Cannot
      * use {@link #removeOneShotAmmo(Entity)} here as it removes all ammo that has
-     * no location (which is how it is kept when a unit is loaded from file) but during construction
+     * no location (which is how hidden ammo is kept when a unit is loaded from file) but during construction
      * normal ammo may not yet have been allocated and also have no location.
      *
      * @param mounted The weapon to remove linked hidden ammo

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -3275,7 +3275,7 @@ public class UnitUtil {
 
     /**
      * Makes the equipment mounted in one location identical to that in another location. Any equipment
-     * previously in the target location that is does not match the source location is removed and
+     * previously in the target location that does not match the source location is removed and
      * assigned to Entity.LOC_NONE. This does not handle split location equipment.
      *
      * @param entity          The unit being modified
@@ -3391,7 +3391,30 @@ public class UnitUtil {
         }
         entity.addEquipment(toAdd, toLoc, toCopy.isRearMounted());
         changeMountStatus(entity, toAdd, toLoc, Entity.LOC_NONE, toCopy.isRearMounted());
+        removeHiddenAmmo(toAdd);
         return toAdd;
+    }
+
+    /**
+     * If the given Mounted is a one-shot launcher or infantry weapon, this method removes the hidden
+     * ammo linked to it, if any. During construction, we have no use of hidden ammo. Cannot
+     * use {@link #removeOneShotAmmo(Entity)} here as it removes all ammo that has
+     * no location (which is how it is kept when a unit is loaded from file) but during construction
+     * normal ammo may not yet have been allocated and also have no location.
+     *
+     * @param mounted The weapon to remove linked hidden ammo
+     */
+    public static void removeHiddenAmmo(Mounted mounted) {
+        EquipmentType launcherType = mounted.getType();
+        if ((launcherType instanceof WeaponType) && (launcherType.hasFlag(WeaponType.F_ONESHOT)
+                || (((WeaponType) launcherType).getAmmoType() == AmmoType.T_INFANTRY))) {
+            Mounted oneShotAmmo = mounted.getLinked();
+            if (oneShotAmmo != null) {
+                mounted.getEntity().getEquipment().remove(oneShotAmmo);
+                mounted.getEntity().getAmmo().remove(oneShotAmmo);
+                mounted.setLinked(null);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
removeOneShotAmmo in UnitUtil removes all unallocated ammo but during construction all types of ammo may still be unallocated, not only OS ammo. This PR makes it so when adding an OS weapon or Infantry weapon on SV/PM only the ammo linked to that weapon is removed.

Fixes #1334 