### PR TITLE
StatusBar: correct free slot displays

### DIFF
--- a/megameklab/src/megameklab/ui/combatVehicle/CVStatusBar.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVStatusBar.java
@@ -53,8 +53,8 @@ public class CVStatusBar extends StatusBar {
 
     public void refreshSlots() {
         Tank tank = getTank();
-        int currentSlots = tank.getTotalSlots() - tank.getFreeSlots();
-        slots.setText(String.format(SLOTS_LABEL, currentSlots, tank.getTotalSlots()));
-        slots.setForeground(currentSlots > tank.getTotalSlots() ? GUIPreferences.getInstance().getWarningColor() : null);
+        int freeSlots = tank.getFreeSlots();
+        slots.setText(String.format(SLOTS_LABEL, freeSlots, tank.getTotalSlots()));
+        slots.setForeground((freeSlots < 0) ? GUIPreferences.getInstance().getWarningColor() : null);
     }
 }

--- a/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
+++ b/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
@@ -65,7 +65,7 @@ public class StatusBar extends ITab {
         invalid.setVisible(false);
 
         if (!getEntity().isConventionalInfantry()) {
-            JButton showEquipmentDatabase = new JButton("Show Equipment Database");
+            JButton showEquipmentDatabase = new JButton("Equipment Database");
             showEquipmentDatabase.addActionListener(evt -> parent.getFloatingEquipmentDatabase().setVisible(true));
             add(showEquipmentDatabase);
         }

--- a/megameklab/src/megameklab/ui/mek/BMStatusBar.java
+++ b/megameklab/src/megameklab/ui/mek/BMStatusBar.java
@@ -44,7 +44,7 @@ public class BMStatusBar extends StatusBar {
     public void refreshSlots() {
         int maxCrits = getTestEntity().totalCritSlotCount();
         int currentSlots = UnitUtil.countUsedCriticals(getMech());
-        slots.setText(String.format(SLOTS_LABEL, currentSlots, maxCrits));
+        slots.setText(String.format(SLOTS_LABEL, maxCrits - currentSlots, maxCrits));
         slots.setForeground(currentSlots > maxCrits ? GUIPreferences.getInstance().getWarningColor() : null);
     }
 

--- a/megameklab/src/megameklab/ui/protoMek/PMStatusBar.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMStatusBar.java
@@ -48,7 +48,7 @@ public class PMStatusBar extends StatusBar {
         long currentSlots = getProtomech().getEquipment().stream()
                 .filter(m -> TestProtomech.requiresSlot(m.getType())).count();
 
-        slots.setText(String.format(SLOTS_LABEL, currentSlots, maxCrits));
+        slots.setText(String.format(SLOTS_LABEL, maxCrits - currentSlots, maxCrits));
         slots.setForeground(currentSlots > maxCrits ? GUIPreferences.getInstance().getWarningColor() : null);
     }
 }

--- a/megameklab/src/megameklab/ui/supportVehicle/SVStatusBar.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVStatusBar.java
@@ -58,7 +58,7 @@ class SVStatusBar extends StatusBar {
         TestSupportVehicle testEntity = (TestSupportVehicle) getTestEntity();
         final int totalSlots = testEntity.totalSlotCount();
         final int currentSlots = testEntity.occupiedSlotCount();
-        slots.setText(String.format(SLOTS_LABEL, currentSlots, totalSlots));
+        slots.setText(String.format(SLOTS_LABEL, totalSlots - currentSlots, totalSlots));
         slots.setForeground(currentSlots > totalSlots ? GUIPreferences.getInstance().getWarningColor() : null);
     }
 }


### PR DESCRIPTION
The statusbars were showing the used slots instead of free slots when the label said "Free Slots:". Also change a button label to reduce its width.