### PR TITLE
Restrict cargo containers to industrial meks

### DIFF
--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -2690,7 +2690,7 @@ public class UnitUtil {
                         && ((unit.getEngine().getEngineType() == Engine.COMBUSTION_ENGINE)
                             || (unit.getEngine().getEngineType() == Engine.FUEL_CELL));
             }
-            if (eq.hasFlag(MiscType.F_ENVIRONMENTAL_SEALING)) {
+            if (eq.hasFlag(MiscType.F_ENVIRONMENTAL_SEALING) || eq.is("Cargo Container (10 tons)")) {
                 return unit.isIndustrial();
             }
 


### PR DESCRIPTION
BattleMeks may not mount cargo containers. Other unit types are not affected by the change.

Fixes #1309 