### PR TITLE
Handle no unit selection

### DIFF
--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -809,7 +809,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         unitLoadingDialog.setVisible(true);
         MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog);
         Entity chosenEntity = viewer.getChosenEntity();
-        if (null != chosenEntity) {
+        if (chosenEntity != null) {
             UnitUtil.showValidation(chosenEntity, owner.getFrame());
         }
         viewer.dispose();
@@ -820,7 +820,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         unitLoadingDialog.setVisible(true);
         MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog);
         Entity chosenEntity = viewer.getChosenEntity();
-        if (null != chosenEntity) {
+        if (chosenEntity != null) {
             new CostDisplayDialog(owner.getFrame(), chosenEntity).setVisible(true);
         }
         viewer.dispose();
@@ -832,7 +832,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog);
 
         Entity chosenEntity = viewer.getChosenEntity();
-        if (null != chosenEntity) {
+        if (chosenEntity != null) {
             UnitUtil.showUnitWeightBreakDown(chosenEntity, owner.getFrame());
         }
         viewer.dispose();

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -808,19 +808,22 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(owner.getFrame());
         unitLoadingDialog.setVisible(true);
         MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog);
-
-        Entity tempEntity = viewer.getChosenEntity();
-        if (null == tempEntity) {
-            return;
+        Entity chosenEntity = viewer.getChosenEntity();
+        if (null != chosenEntity) {
+            UnitUtil.showValidation(chosenEntity, owner.getFrame());
         }
-        UnitUtil.showValidation(tempEntity, owner.getFrame());
+        viewer.dispose();
     }
 
     private void jMenuGetUnitBreakdownFromCache_actionPerformed() {
         UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(owner.getFrame());
         unitLoadingDialog.setVisible(true);
         MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog);
-        new CostDisplayDialog(owner.getFrame(), viewer.getChosenEntity()).setVisible(true);
+        Entity chosenEntity = viewer.getChosenEntity();
+        if (null != chosenEntity) {
+            new CostDisplayDialog(owner.getFrame(), chosenEntity).setVisible(true);
+        }
+        viewer.dispose();
     }
 
     private void jMenuGetUnitWeightBreakdownFromCache_actionPerformed() {
@@ -828,11 +831,11 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         unitLoadingDialog.setVisible(true);
         MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog);
 
-        Entity tempEntity = viewer.getChosenEntity();
-        if (null == tempEntity) {
-            return;
+        Entity chosenEntity = viewer.getChosenEntity();
+        if (null != chosenEntity) {
+            UnitUtil.showUnitWeightBreakDown(chosenEntity, owner.getFrame());
         }
-        UnitUtil.showUnitWeightBreakDown(tempEntity, owner.getFrame());
+        viewer.dispose();
     }
 
     private void jMenuGetUnitBVFromFile_actionPerformed() {

--- a/megameklab/src/megameklab/ui/StartupGUI.java
+++ b/megameklab/src/megameklab/ui/StartupGUI.java
@@ -23,6 +23,7 @@ import megamek.client.ui.swing.widget.SkinXMLHandler;
 import megamek.client.ui.swing.widget.SkinnedJPanel;
 import megamek.common.Configuration;
 import megamek.common.Entity;
+import megamek.common.MechSummary;
 import megameklab.MMLConstants;
 import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
 import megameklab.ui.dialog.UiLoader;
@@ -251,16 +252,20 @@ public class StartupGUI extends SkinnedJPanel implements MenuBarOwner {
         unitLoadingDialog.setVisible(true);
         MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(previousFrame.getFrame(), unitLoadingDialog);
         Entity newUnit = viewer.getChosenEntity();
+        MechSummary mechSummary = viewer.getChosenMechSummary();
+        viewer.dispose();
+        if (mechSummary == null || newUnit == null) {
+            return;
+        }
+
         String fileName = viewer.getChosenMechSummary().getSourceFile().toString();
         if (fileName.toLowerCase().endsWith(".zip")) {
             fileName = viewer.getChosenMechSummary().getSourceFile().getAbsolutePath();
             fileName = fileName.substring(0, fileName.lastIndexOf(File.separatorChar) + 1);
             fileName = fileName + MenuBar.createUnitFilename(newUnit);
         }
-        viewer.setVisible(false);
-        viewer.dispose();
 
-        if ((newUnit == null) || !previousFrame.safetyPrompt()) {
+        if (!previousFrame.safetyPrompt()) {
             return;
         }
 

--- a/megameklab/src/megameklab/ui/StartupGUI.java
+++ b/megameklab/src/megameklab/ui/StartupGUI.java
@@ -254,7 +254,7 @@ public class StartupGUI extends SkinnedJPanel implements MenuBarOwner {
         Entity newUnit = viewer.getChosenEntity();
         MechSummary mechSummary = viewer.getChosenMechSummary();
         viewer.dispose();
-        if (mechSummary == null || newUnit == null) {
+        if ((mechSummary == null) || (newUnit == null)) {
             return;
         }
 

--- a/megameklab/src/megameklab/ui/dialog/PrintQueueDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/PrintQueueDialog.java
@@ -144,9 +144,8 @@ public class PrintQueueDialog extends AbstractMMLButtonDialog {
         UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parent);
         unitLoadingDialog.setVisible(true);
         MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parent, unitLoadingDialog, this::entitySelected);
-
-        viewer.setVisible(false);
         Entity entity = viewer.getChosenEntity();
+        viewer.dispose();
 
         if (entity != null) {
             units.add(entity);


### PR DESCRIPTION
This PR fixes some ungraceful exceptions when a unit file is to be selected but the unit selector is closed without a selection.

Fixes MegaMek/megameklab#1370