### PR TITLE
Crit cell display improvements

### DIFF
--- a/megameklab/src/megameklab/ui/util/CritCellUtil.java
+++ b/megameklab/src/megameklab/ui/util/CritCellUtil.java
@@ -96,7 +96,7 @@ public final class CritCellUtil {
             name += mounted.isSponsonTurretMounted() ? " (ST)" : "";
             name += mounted.isPintleTurretMounted() ? " (PT)" : "";
             name += mounted.isDWPMounted() ? " (DWP)" : "";
-            if (mounted.getType() instanceof AmmoType) {
+            if ((mounted.getType() instanceof AmmoType) && !mounted.is(EquipmentTypeLookup.COOLANT_POD)) {
                 name = mounted.getBaseShotsLeft() + " shot" + (mounted.getBaseShotsLeft() > 1 ? "s " : " ") + name;
             }
             if (entity.isOmni() && !mounted.getType().isOmniFixedOnly()) {

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -1185,6 +1185,9 @@ public class UnitUtil {
      */
     public static String getCritName(Entity unit, EquipmentType eq) {
         String name = eq.getName();
+        if (name.length() > 22) {
+            name = eq.getShortName();
+        }
         if (unit.isMixedTech()
                 && (eq.getTechLevel(unit.getTechLevelYear()) != TechConstants.T_ALLOWED_ALL)
                 && (eq.getTechLevel(unit.getTechLevelYear()) != TechConstants.T_TECH_UNKNOWN)) {


### PR DESCRIPTION
This slightly changes crit cell display (not for record sheets, only for construction) to
- not show "1 shot" for Coolant Pods (that are implemented as AmmoType)
- use the equipment short name if the standard name is longer than 22 characters (magic number). This affects only a handful of equipment like AES or HarJel III. The tooltip still shows the full equipment name

![image](https://github.com/MegaMek/megameklab/assets/17069663/70e92403-c178-4e0a-8ac7-47637008a2de)
