### PR TITLE
Allow subcapital weapons to be placed in corresponding capital weapon bay

### DIFF
--- a/megameklab/src/megameklab/ui/util/BayWeaponCriticalTree.java
+++ b/megameklab/src/megameklab/ui/util/BayWeaponCriticalTree.java
@@ -1221,7 +1221,8 @@ public class BayWeaponCriticalTree extends JTree {
      */
     private boolean canTakeEquipment(Mounted bay, Mounted eq) {
         if (eq.getType() instanceof WeaponType) {
-            if (((WeaponType) eq.getType()).getBayType() != bay.getType()) {
+            if ((((WeaponType) eq.getType()).getBayType(false) != bay.getType())
+                    && (((WeaponType) eq.getType()).getBayType(true) != bay.getType())) {
                 return false;
             }
             // find current av


### PR DESCRIPTION
Fixes #1086

Requires MegaMek/megamek#5081