### PR TITLE
Refresh transport tab when DS tonnage changes

### DIFF
--- a/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
@@ -373,6 +373,7 @@ public class DSStructureTab extends ITab implements DropshipBuildListener, Armor
         panCrew.setFromEntity(getSmallCraft());
         getSmallCraft().autoSetInternal();
         refresh();
+        refresh.refreshTransport();
         refresh.refreshPreview();
         refresh.refreshStatus();
     }


### PR DESCRIPTION
The maximum number of doors depends on the ship tonnage and needs to update. The JS/WS/SS structure tab is already doing this correctly.

Fixes #1183