### PR TITLE
Don't reassign armor when updating BA tech level

### DIFF
--- a/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
@@ -463,7 +463,6 @@ public class BAStructureTab extends ITab implements ActionListener, ChangeListen
                 != getBattleArmor().getArmorTechLevel(BattleArmor.LOC_SQUAD))) {
             armorTypeChanged(armor);
         }
-        armorTypeChanged(panArmor.getArmor());
         addAllListeners();
         refresh.refreshPreview();
     }


### PR DESCRIPTION
In updateTechLevel() after checking whether the currently assigned armor is still available (and reassigning to something that is available if necessary), the current armor type is reassigned to the BA regardless. I see no reason for this to be done, and it has the effect of removing any assigned critical slots.

Fixes #1185.