### PR TITLE
Mek Clan Chassis Name - MML updates, record sheet

### DIFF
--- a/megameklab/resources/megameklab/resources/Dialogs.properties
+++ b/megameklab/resources/megameklab/resources/Dialogs.properties
@@ -55,6 +55,8 @@ ConfigurationDialog.chkSkipSavePrompts.text=Disable save prompts. Use at your ow
 ConfigurationDialog.chkSkipSavePrompts.tooltip=When checked, no safety dialogs warning about losing changes when switching unit or unit type will be shown.
 ConfigurationDialog.startup.text=MML Startup:
 ConfigurationDialog.startup.tooltip=Depending on the startup type selected, MML will start in the main menu or, alternatively, directly load the most recent unit or start with a new unit instead of the main menu.
+ConfigurationDialog.mekChassis.text=Mek Chassis Arrangement:
+ConfigurationDialog.mekChassis.tooltip=Meks with a Clan and an IS chassis name will print their chassis in the selected arrangement. Meks with no clan chassis name will always just print their chassis.
 
 RecordSheetTask.printing=Printing
 RecordSheetTask.exporting=Exporting

--- a/megameklab/resources/megameklab/resources/Menu.properties
+++ b/megameklab/resources/megameklab/resources/Menu.properties
@@ -114,3 +114,9 @@ MMLStartUp.NEW_DROPSHIP=New SmallCraft/DropShip
 MMLStartUp.NEW_JUMPSHIP=New Advanced Aerospace
 MMLStartUp.NEW_SUPPORTVEE=New Support Vehicle
 MMLStartUp.NEW_PROTOMEK=New ProtoMek
+
+# The following values are used programatically by ClanISMekNameOrdering
+ClanISMekNameOrdering.CLAN_IS=Clan Name (IS Name)
+ClanISMekNameOrdering.IS_CLAN=IS Name (Clan Name)
+ClanISMekNameOrdering.CLAN_ONLY=Clan Name only
+ClanISMekNameOrdering.IS_ONLY=IS Name only

--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -1,5 +1,7 @@
 BasicInfoView.txtChassis.text=Chassis:
 BasicInfoView.txtChassis.tooltip=Units with the same chassis name are usually considered variants
+BasicInfoView.txtClanName.text=Clan Name:
+BasicInfoView.txtClanName.tooltip=The clan name of the Mek, such as Timber Wolf
 BasicInfoView.txtModel.text=Model:
 BasicInfoView.txtModel.tooltip=The name of this variant
 BasicInfoView.txtMulId.text=MUL ID:

--- a/megameklab/src/megameklab/printing/MekChassisArrangement.java
+++ b/megameklab/src/megameklab/printing/MekChassisArrangement.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megameklab.printing;
+
+import megamek.codeUtilities.StringUtility;
+import megamek.common.Entity;
+
+import java.util.ResourceBundle;
+
+/**
+ * This class represents the different types of arrangement of the chassis names of those Meks that have a Clan
+ * and an IS name such as the Mad Cat a.k.a. Timber Wolf. This is used to determine how to print those names
+ * on record sheets (but not elsewhere as we might not want this to be dependent on how the record sheets
+ * might be at any moment).
+ *
+ * @author Simon (Juliez)
+ */
+public enum MekChassisArrangement {
+
+    CLAN_IS,
+    IS_CLAN,
+    CLAN_ONLY,
+    IS_ONLY;
+
+    private final ResourceBundle resources = ResourceBundle.getBundle("megameklab.resources.Menu");
+
+    /** @return A display name for this ClanIsMekNameArrangement taken from the resources (possibly localised). */
+    public String getDisplayName() {
+        return resources.getString("ClanISMekNameOrdering." + name());
+    }
+
+    /**
+     * Parses the given String, returning the ClanIsMekNameArrangement fitting the String like the valueOf() method does,
+     * but returns CLAN_IS when it can't be parsed (instead of null).
+     *
+     * @param arrangementName A string giving one of the ClanIsMekNameArrangement values
+     * @return the MekChassisArrangement parsed from the string or CLAN_IS. Never returns null.
+     */
+    public static MekChassisArrangement parse(String arrangementName) {
+        try {
+            return valueOf(arrangementName);
+        } catch (IllegalArgumentException e) {
+            return CLAN_IS;
+        }
+    }
+
+    public String printChassis(Entity entity) {
+        if (StringUtility.isNullOrBlank(entity.getClanChassisName())) {
+            return entity.getChassis();
+        } else if (this == IS_ONLY) {
+            return entity.getChassis();
+        } else if (this == CLAN_ONLY) {
+            return entity.getClanChassisName();
+        } else if (this == CLAN_IS) {
+            return entity.getClanChassisName() + " (" + entity.getChassis() + ")";
+        } else {
+            return entity.getChassis() + " (" + entity.getClanChassisName() + ")";
+        }
+    }
+}

--- a/megameklab/src/megameklab/printing/PrintAero.java
+++ b/megameklab/src/megameklab/printing/PrintAero.java
@@ -201,13 +201,7 @@ public class PrintAero extends PrintEntity {
 
     @Override
     protected void drawFluffImage() {
-        String dir = ImageHelper.imageAero;
-        if (aero instanceof ConvFighter) {
-            dir = ImageHelper.imageConvFighter;
-        } else if (aero instanceof SmallCraft) {
-            dir = ImageHelper.imageSmallcraft;
-        }
-        File f = ImageHelper.getFluffFile(aero, dir);
+        File f = ImageHelper.getFluffFile(aero);
         if (null != f) {
             Element rect = getSVGDocument().getElementById(FLUFF_IMAGE);
             if (rect instanceof SVGRectElement) {

--- a/megameklab/src/megameklab/printing/PrintCapitalShip.java
+++ b/megameklab/src/megameklab/printing/PrintCapitalShip.java
@@ -369,17 +369,9 @@ public class PrintCapitalShip extends PrintDropship {
 
     @Override
     protected void drawFluffImage() {
-        String dir;
-        if (getEntity() instanceof Warship) {
-            dir = ImageHelper.imageWarship;
-        } else if (getEntity() instanceof SpaceStation) {
-            dir = ImageHelper.imageSpaceStation;
-        } else {
-            dir = ImageHelper.imageJumpship;
-        }
         Element rect = getSVGDocument().getElementById(FLUFF_IMAGE);
         if (rect instanceof SVGRectElement) {
-            embedImage(ImageHelper.getFluffFile(ship, dir),
+            embedImage(ImageHelper.getFluffFile(ship),
                     (Element) rect.getParentNode(), getRectBBox((SVGRectElement) rect), true);
         }
         hideElement(getSVGDocument().getElementById(NOTES));

--- a/megameklab/src/megameklab/printing/PrintDropship.java
+++ b/megameklab/src/megameklab/printing/PrintDropship.java
@@ -349,10 +349,9 @@ public class PrintDropship extends PrintAero {
 
     @Override
     protected void drawFluffImage() {
-        String dir = ImageHelper.imageDropship;
         Element rect = getSVGDocument().getElementById("fluffImage");
         if (rect instanceof SVGRectElement) {
-            embedImage(ImageHelper.getFluffFile(ship, dir),
+            embedImage(ImageHelper.getFluffFile(ship),
                     (Element) rect.getParentNode(), getRectBBox((SVGRectElement) rect), true);
         }
         hideElement(getSVGDocument().getElementById(NOTES));

--- a/megameklab/src/megameklab/printing/PrintEntity.java
+++ b/megameklab/src/megameklab/printing/PrintEntity.java
@@ -14,6 +14,7 @@
 package megameklab.printing;
 
 import megamek.client.generator.RandomNameGenerator;
+import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.eras.Era;
 import megamek.common.eras.Eras;
@@ -62,7 +63,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
 
     @Override
     public List<String> getBookmarkNames() {
-        return Collections.singletonList(getEntity().getShortNameRaw());
+        return Collections.singletonList(entityName());
     }
     
     /**
@@ -187,7 +188,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
     
     protected void writeTextFields() {
         setTextField(TITLE, getRecordSheetTitle().toUpperCase());
-        setTextField(TYPE, getEntity().getShortNameRaw());
+        setTextField(TYPE, entityName());
         setTextField(MP_WALK, formatWalk());
         setTextField(MP_RUN, formatRun());
         setTextField(MP_JUMP, formatJump());
@@ -596,5 +597,10 @@ public abstract class PrintEntity extends PrintRecordSheet {
         NumberFormat nf = NumberFormat.getNumberInstance(Locale.getDefault());
         return nf.format(getEntity().getCost(true)) + " C-bills";
     }
-    
+
+    private String entityName() {
+        return CConfig.getMekNameArrangement().printChassis(getEntity())
+                + (StringUtility.isNullOrBlank(getEntity().getModel()) ? "" : " " + getEntity().getModel());
+    }
+
 }

--- a/megameklab/src/megameklab/printing/PrintMech.java
+++ b/megameklab/src/megameklab/printing/PrintMech.java
@@ -540,7 +540,7 @@ public class PrintMech extends PrintEntity {
                 placeReferenceCharts(tables, rect.getParentNode(), bbox.getX(), bbox.getY(),
                         bbox.getWidth() + 6.0, bbox.getHeight() + 6.0);
             } else {
-                embedImage(ImageHelper.getFluffFile(mech, ImageHelper.imageMech),
+                embedImage(ImageHelper.getFluffFile(mech),
                         (Element) rect.getParentNode(), getRectBBox((SVGRectElement) rect), true);
             }
         }

--- a/megameklab/src/megameklab/printing/PrintSmallUnitSheet.java
+++ b/megameklab/src/megameklab/printing/PrintSmallUnitSheet.java
@@ -129,11 +129,11 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
         }
         File f = null;
         if (entities.get(0) instanceof BattleArmor) {
-            f = ImageHelper.getFluffFile(entities.get(0), ImageHelper.imageBattleArmor);
+            f = ImageHelper.getFluffFile(entities.get(0));
         } else if (entities.get(0) instanceof Infantry) {
-            f = ImageHelper.getFluffFile(entities.get(0), ImageHelper.imageInfantry);
+            f = ImageHelper.getFluffFile(entities.get(0));
         } else if (entities.get(0) instanceof Protomech) {
-            f = ImageHelper.getFluffFile(entities.get(0), ImageHelper.imageProto);
+            f = ImageHelper.getFluffFile(entities.get(0));
         }
         if (f != null) {
             Element rect = getSVGDocument().getElementById(FLUFF_IMAGE);

--- a/megameklab/src/megameklab/printing/PrintTank.java
+++ b/megameklab/src/megameklab/printing/PrintTank.java
@@ -193,11 +193,11 @@ public class PrintTank extends PrintEntity {
     protected void drawFluffImage() {
         File f;
         if (tank.getMovementMode().isMarine()) {
-            f = ImageHelper.getFluffFile(tank, ImageHelper.imageNaval);
+            f = ImageHelper.getFluffFile(tank);
         } else if (tank instanceof LargeSupportTank) {
-            f = ImageHelper.getFluffFile(tank, ImageHelper.imageLargeSupportVehicle);
+            f = ImageHelper.getFluffFile(tank);
         } else {
-            f = ImageHelper.getFluffFile(tank, ImageHelper.imageVehicle);
+            f = ImageHelper.getFluffFile(tank);
         }
         if (null != f) {
             Element rect = getSVGDocument().getElementById(FLUFF_IMAGE);

--- a/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
@@ -124,7 +124,7 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
     @Override
     public void refreshHeader() {
         String fileInfo = fileName.isBlank() ? "" : " (" + fileName + ")";
-        setTitle(getEntity().getChassis() + " " + getEntity().getModel() + fileInfo);
+        setTitle(getEntity().getFullChassis() + " " + getEntity().getModel() + fileInfo);
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -943,7 +943,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
                 loadImageFileChooser.setCurrentDirectory(new File(fullPath));
                 loadImageFileChooser.setSelectedFile(new File(imageName));
             } else {
-                loadImageFileChooser.setCurrentDirectory(new File(ImageHelper.fluffPath));
+                loadImageFileChooser.setCurrentDirectory(Configuration.fluffImagesDir());
                 loadImageFileChooser.setSelectedFile(new File(getUnitMainUi().getEntity().getChassis()
                         + ' ' + getUnitMainUi().getEntity().getModel() + ".png"));
             }

--- a/megameklab/src/megameklab/ui/dialog/settings/ExportSettingsPanel.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/ExportSettingsPanel.java
@@ -18,6 +18,8 @@
  */
 package megameklab.ui.dialog.settings;
 
+import megamek.client.ui.baseComponents.MMComboBox;
+import megameklab.printing.MekChassisArrangement;
 import megameklab.printing.PaperSize;
 import megameklab.ui.util.IntRangeTextField;
 import megameklab.ui.util.SpringUtilities;
@@ -30,6 +32,7 @@ import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 /**
@@ -52,6 +55,8 @@ class ExportSettingsPanel extends JPanel {
     private final JCheckBox chkTacOpsHeat = new JCheckBox();
     private final JComboBox<String> cbRSScale = new JComboBox<>();
     private final IntRangeTextField txtScale = new IntRangeTextField(3);
+    private final MMComboBox<MekChassisArrangement> mekChassis =
+            new MMComboBox<>("Mek Names", MekChassisArrangement.values());
 
     ExportSettingsPanel() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Dialogs");
@@ -129,6 +134,17 @@ class ExportSettingsPanel extends JPanel {
         chkTacOpsHeat.setToolTipText(resourceMap.getString("ConfigurationDialog.chkTacOpsHeat.tooltip"));
         chkTacOpsHeat.setSelected(CConfig.getBooleanParam(CConfig.RS_TAC_OPS_HEAT));
 
+        mekChassis.setRenderer(mekNameArrangementRenderer);
+        mekChassis.setSelectedItem(CConfig.getMekNameArrangement());
+        mekChassis.setToolTipText(resourceMap.getString("ConfigurationDialog.mekChassis.tooltip"));
+        JLabel startUpLabel = new JLabel(resourceMap.getString("ConfigurationDialog.mekChassis.text"));
+        startUpLabel.setToolTipText(resourceMap.getString("ConfigurationDialog.mekChassis.tooltip"));
+
+        JPanel mekNameLine = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        mekNameLine.add(startUpLabel);
+        mekNameLine.add(Box.createHorizontalStrut(5));
+        mekNameLine.add(mekChassis);
+
         for (RSScale val : RSScale.values()) {
             cbRSScale.addItem(val.fullName);
         }
@@ -161,8 +177,9 @@ class ExportSettingsPanel extends JPanel {
         gridPanel.add(chkShowRole);
         gridPanel.add(chkHeatProfile);
         gridPanel.add(chkTacOpsHeat);
+        gridPanel.add(mekNameLine);
         gridPanel.add(scalePanel);
-        SpringUtilities.makeCompactGrid(gridPanel, 13, 1, 0, 0, 15, 10);
+        SpringUtilities.makeCompactGrid(gridPanel, 14, 1, 0, 0, 15, 10);
         gridPanel.setBorder(new EmptyBorder(20, 30, 20, 30));
         setLayout(new FlowLayout(FlowLayout.LEFT));
         add(gridPanel);
@@ -184,6 +201,8 @@ class ExportSettingsPanel extends JPanel {
         recordSheetSettings.put(CConfig.RS_TAC_OPS_HEAT, Boolean.toString(chkTacOpsHeat.isSelected()));
         recordSheetSettings.put(CConfig.RS_SCALE_UNITS, RSScale.values()[cbRSScale.getSelectedIndex()].toString());
         recordSheetSettings.put(CConfig.RS_SCALE_FACTOR, Integer.toString(txtScale.getIntVal(getDefaultScale())));
+        recordSheetSettings.put(CConfig.RS_MEK_NAMES,
+                Objects.requireNonNullElse(mekChassis.getSelectedItem(), MekChassisArrangement.CLAN_IS).name());
         return recordSheetSettings;
     }
 
@@ -200,5 +219,16 @@ class ExportSettingsPanel extends JPanel {
         } else {
             return 1;
         }
+    }
+
+    DefaultListCellRenderer mekNameArrangementRenderer = new DefaultListCellRenderer() {
+        @Override
+        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+            return super.getListCellRendererComponent(list, displayName(value), index, isSelected, cellHasFocus);
+        }
+    };
+
+    private String displayName(Object value) {
+        return (value instanceof MekChassisArrangement) ? ((MekChassisArrangement) value).getDisplayName() : "";
     }
 }

--- a/megameklab/src/megameklab/ui/dialog/settings/SettingsDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/SettingsDialog.java
@@ -45,10 +45,10 @@ public class SettingsDialog extends AbstractMMLButtonDialog {
     @Override
     protected Container createCenterPane() {
         JTabbedPane panMain = new JTabbedPane();
-        panMain.addTab(resources.getString("ConfigurationDialog.misc.title"), miscSettingsPanel);
-        panMain.addTab(resources.getString("ConfigurationDialog.colorCodes.title"), colorPreferences);
-        panMain.addTab(resources.getString("ConfigurationDialog.techProgression.title"), techSettings);
-        panMain.addTab(resources.getString("ConfigurationDialog.printing.title"), exportSettingsPanel);
+        panMain.addTab(resources.getString("ConfigurationDialog.misc.title"), new SettingsScrollPane(miscSettingsPanel));
+        panMain.addTab(resources.getString("ConfigurationDialog.colorCodes.title"), new SettingsScrollPane(colorPreferences));
+        panMain.addTab(resources.getString("ConfigurationDialog.techProgression.title"), new SettingsScrollPane(techSettings));
+        panMain.addTab(resources.getString("ConfigurationDialog.printing.title"), new SettingsScrollPane(exportSettingsPanel));
         return panMain;
     }
 
@@ -77,5 +77,13 @@ public class SettingsDialog extends AbstractMMLButtonDialog {
     @Override
     protected void cancelAction() {
         CConfig.loadConfigFile();
+    }
+
+    private static class SettingsScrollPane extends JScrollPane {
+        SettingsScrollPane(Component view) {
+            super(view);
+            setBorder(null);
+            getVerticalScrollBar().setUnitIncrement(16);
+        }
     }
 }

--- a/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
@@ -59,7 +59,11 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     private String[] techBaseNames;
     private TechAdvancement baseTA;
 
+    private final ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
     private final JTextField txtChassis = new JTextField(5);
+    private final JTextField txtClanName = new JTextField(5);
+    private final JLabel lblClanName = createLabel(resourceMap, "lblClanName", "BasicInfoView.txtClanName.text",
+            "BasicInfoView.txtClanName.tooltip", labelSize);
     private final JTextField txtModel = new JTextField(5);
     private final IntRangeTextField txtYear = new IntRangeTextField(3);
     private final FactionComboBox cbFaction = new FactionComboBox();
@@ -85,7 +89,6 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     //endregion Constructors
 
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
         techBaseNames = resourceMap.getString("BasicInfoView.cbTechBase.values").split(",");
 
         setLayout(new GridBagLayout());
@@ -103,6 +106,15 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         add(txtChassis, gbc);
         setFieldSize(txtChassis, controlSize);
         txtChassis.addFocusListener(this);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        add(lblClanName, gbc);
+        gbc.gridx = 1;
+        txtClanName.setToolTipText(resourceMap.getString("BasicInfoView.txtModel.tooltip"));
+        add(txtClanName, gbc);
+        setFieldSize(txtClanName, controlSize);
+        txtClanName.addFocusListener(this);
 
         gbc.gridx = 0;
         gbc.gridy++;
@@ -228,6 +240,9 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         txtYear.setMinimum(Math.max(baseTA.getIntroductionDate(), ITechnology.DATE_PS));
         refreshTechBase();
         setChassis(en.getChassis());
+        txtClanName.setText(en.getClanChassisName());
+        txtClanName.setVisible(en instanceof Mech);
+        lblClanName.setVisible(en instanceof Mech);
         setModel(en.getModel());
         txtMulId.setText(en.getMulId() + "");
         browseMul.setVisible(en.hasMulId());
@@ -259,6 +274,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
 
     public void setAsCustomization() {
         txtChassis.setEnabled(false);
+        txtClanName.setEnabled(false);
         txtYear.setEnabled(false);
     }
 
@@ -495,6 +511,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     public void focusLost(FocusEvent e) {
         if (e.getSource() == txtChassis) {
             listeners.forEach(l -> l.chassisChanged(getChassis()));
+        } else if (e.getSource() == txtClanName) {
+            listeners.forEach(l -> l.clanNameChanged(txtClanName.getText()));
         } else if (e.getSource() == txtModel) {
             listeners.forEach(l -> l.modelChanged(getModel()));
         } else if (e.getSource() == txtMulId) {

--- a/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
+++ b/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
@@ -144,7 +144,7 @@ public class StatusBar extends ITab {
 
     private void getFluffImage() {
         FileDialog fDialog = new FileDialog(getParentFrame(), "Image Path", FileDialog.LOAD);
-        fDialog.setDirectory(new File(ImageHelper.fluffPath).getAbsolutePath() + File.separatorChar + ImageHelper.imageMech + File.separatorChar);
+        fDialog.setDirectory(Configuration.fluffImagesDir().toString());
         fDialog.setLocationRelativeTo(this);
         fDialog.setVisible(true);
         if (fDialog.getFile() != null) {

--- a/megameklab/src/megameklab/ui/listeners/BuildListener.java
+++ b/megameklab/src/megameklab/ui/listeners/BuildListener.java
@@ -29,6 +29,9 @@ public interface BuildListener {
 
     void refreshSummary();
     void chassisChanged(String chassis);
+
+    default void clanNameChanged(String clanName) { }
+
     void modelChanged(String model);
     void yearChanged(int year);
     void updateTechLevel();

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -551,6 +551,13 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
     }
 
     @Override
+    public void clanNameChanged(String clanName) {
+        getMech().setClanChassisName(clanName);
+        refresh.refreshHeader();
+        refresh.refreshPreview();
+    }
+
+    @Override
     public void modelChanged(String model) {
         getMech().setModel(model);
         refresh.refreshHeader();

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -16,6 +16,7 @@
 package megameklab.util;
 
 import megamek.common.Configuration;
+import megameklab.printing.MekChassisArrangement;
 import megameklab.ui.MMLStartUp;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.MenuBarOwner;
@@ -99,6 +100,7 @@ public final class CConfig {
     public static final String RS_CONDENSED_REFERENCE = "rs_condensed_reference";
     public static final String RS_SCALE_FACTOR = "rs_scale_factor";
     public static final String RS_SCALE_UNITS = "rs_scale_units";
+    public static final String RS_MEK_NAMES = "rs_mek_names";
 
     public static final String NAG_EQUIPMENT_CTRLCLICK = "nag_equipment_ctrlclick";
     public static final String NAG_IMPORT_SETTINGS = "nag_import_settings";
@@ -127,6 +129,7 @@ public final class CConfig {
         defaults.setProperty(RS_SHOW_PILOT_DATA, Boolean.toString(true));
         defaults.setProperty(RS_SCALE_FACTOR, "1");
         defaults.setProperty(RS_SCALE_UNITS, RSScale.HEXES.toString());
+        defaults.setProperty(RS_MEK_NAMES, MekChassisArrangement.IS_CLAN.name());
         defaults.setProperty(NAG_EQUIPMENT_CTRLCLICK, Boolean.toString(true));
         defaults.setProperty(MEK_AUTOFILL, Boolean.toString(true));
         defaults.setProperty(MEK_AUTOSORT, Boolean.toString(true));
@@ -422,6 +425,10 @@ public final class CConfig {
 
     public static MMLStartUp getStartUpType() {
         return MMLStartUp.parse(CConfig.getParam(CConfig.MISC_STARTUP));
+    }
+
+    public static MekChassisArrangement getMekNameArrangement() {
+        return MekChassisArrangement.parse(CConfig.getParam(CConfig.RS_MEK_NAMES));
     }
 
     public static void resetWindowPositions() {

--- a/megameklab/src/megameklab/util/ImageHelper.java
+++ b/megameklab/src/megameklab/util/ImageHelper.java
@@ -53,14 +53,16 @@ public final class ImageHelper {
         // UserDir matches
         String userDir = PreferenceManager.getClientPreferences().getUserDir();
         if (!userDir.isBlank() && new File(userDir).isDirectory()) {
-            var fluffPath = new File(userDir, fluffDir.toString());
+            var fluffUserDir = new File(userDir, fluffDir.toString());
             for (String ext : FluffImageHelper.EXTENSIONS_FLUFF_IMAGE_FORMATS) {
-                fileCandidates.add(new File(fluffPath, unit.getFullChassis() + ext));
+                fileCandidates.add(new File(fluffUserDir, unit.getChassis() + ext));
+                fileCandidates.add(new File(fluffUserDir, unit.getFullChassis() + ext));
             }
         }
 
         // Chassis matches
         for (String ext : FluffImageHelper.EXTENSIONS_FLUFF_IMAGE_FORMATS) {
+            fileCandidates.add(new File(fluffDir, unit.getChassis() + ext));
             fileCandidates.add(new File(fluffDir, unit.getFullChassis() + ext));
         }
 

--- a/megameklab/src/megameklab/util/ImageHelper.java
+++ b/megameklab/src/megameklab/util/ImageHelper.java
@@ -15,31 +15,17 @@
  */
 package megameklab.util;
 
+import megamek.client.ui.swing.util.FluffImageHelper;
+import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.annotations.Nullable;
+import megamek.common.preference.PreferenceManager;
 
-import javax.swing.*;
-import java.awt.*;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
-public class ImageHelper {
-    public static String fluffPath = "./data/images/fluff/"; // TODO : Remove inline file path
-    public static String imagePath = "./data/images/"; // TODO : Remove inline file path
-
-    public static String imageMech = "Mech";
-    public static String imageAero = "Fighter";
-    public static String imageBattleArmor = "BattleArmor";
-    public static String imageConvFighter = "ConvFighter";
-    public static String imageInfantry = "Infantry";
-    public static String imageVehicle = "Vehicle";
-    public static String imageNaval = "Naval";
-    public static String imageLargeSupportVehicle = "LargeSupportVehicle";
-    public static String imageProto = "ProtoMek";
-    public static String imageSmallcraft = "Small Craft";
-    public static String imageDropship = "DropShip";
-    public static String imageJumpship = "JumpShip";
-    public static String imageWarship = "WarShip";
-    public static String imageSpaceStation = "Space Station";
+public final class ImageHelper {
 
     /**
      * Checks for a fluff image for the unit starting with any file explicitly associated with the
@@ -47,159 +33,45 @@ public class ImageHelper {
      * unit with an image format extension.
      * 
      * @param unit The unit to find a fluff image for
-     * @param dir  The directory to check for a default image based on unit name
      * @return     A file to use for the fluff image, or null if no file is found.
      */
-    public static @Nullable File getFluffFile(Entity unit, String dir) {
-        String path = new File(fluffPath).getAbsolutePath();
-        File f;
-        
+    public static @Nullable File getFluffFile(Entity unit) {
+        List<File> fileCandidates = new ArrayList<>();
+        var fluffDir = new File(Configuration.fluffImagesDir(), FluffImageHelper.getImagePath(unit));
+
+        // MML Path matches (??)
         if (!unit.getFluff().getMMLImagePath().isBlank()) {
-            f = new File(unit.getFluff().getMMLImagePath());
-            if (f.exists()) {
-                return f;
-            }
-            f = new File(path, unit.getFluff().getMMLImagePath());
-            if (f.exists()) {
-                return f;
+            fileCandidates.add(new File(unit.getFluff().getMMLImagePath()));
+            fileCandidates.add(new File(fluffDir, unit.getFluff().getMMLImagePath()));
+        }
+
+        // Internal fluff path matches
+        for (String ext : FluffImageHelper.EXTENSIONS_FLUFF_IMAGE_FORMATS) {
+            fileCandidates.add(new File(fluffDir, unit.getShortNameRaw() + ext));
+        }
+
+        // UserDir matches
+        String userDir = PreferenceManager.getClientPreferences().getUserDir();
+        if (!userDir.isBlank() && new File(userDir).isDirectory()) {
+            var fluffPath = new File(userDir, fluffDir.toString());
+            for (String ext : FluffImageHelper.EXTENSIONS_FLUFF_IMAGE_FORMATS) {
+                fileCandidates.add(new File(fluffPath, unit.getFullChassis() + ext));
             }
         }
 
-        path = new File(path, dir).getAbsolutePath();
-        final String [] EXTENSIONS = { ".png", ".PNG", ".jpg", ".JPG", ".jpeg", ".JPEG", ".gif", ".GIF" };
-        for (String ext : EXTENSIONS) {
-            f = new File(path, unit.getShortNameRaw() + ext);
-            if (f.exists()) {
-                return f;
-            }
+        // Chassis matches
+        for (String ext : FluffImageHelper.EXTENSIONS_FLUFF_IMAGE_FORMATS) {
+            fileCandidates.add(new File(fluffDir, unit.getFullChassis() + ext));
         }
-        for (String ext : EXTENSIONS) {
-            f = new File(path, unit.getChassis() + ext);
-            if (f.exists()) {
-                return f;
+
+        // Fallback
+        fileCandidates.add(new File(fluffDir, "hud.png"));
+
+        for (File possibleFile : fileCandidates) {
+            if (possibleFile.exists() && !possibleFile.isDirectory()) {
+                return possibleFile;
             }
-        }
-        f = new File(path, "hud.png");
-        if (f.exists()) {
-            return f;
         }
         return null;
-    }
-
-    public static @Nullable Image getFluffImage(String image) {
-        if ((image == null) || image.isBlank()) {
-            return null;
-        }
-
-        String path = new File(fluffPath).getAbsolutePath() + File.separatorChar + image;
-
-        if (!(new File(path).exists())) {
-            path = new File(image).getAbsolutePath();
-            if (!(new File(path).exists())) {
-                return null;
-            }
-        }
-        return new ImageIcon(path).getImage();
-    }
-
-    public static Image getFluffImage(Entity unit, String dir) {
-        String path = new File(fluffPath).getAbsolutePath()
-                + File.separatorChar + dir + File.separatorChar;
-
-        Image fluff = ImageHelper.getFluffImage(unit.getFluff().getMMLImagePath());
-
-        if (fluff == null) {
-            fluff = ImageHelper.getFluffPNG(unit, path);
-        }
-
-        if (fluff == null) {
-            fluff = ImageHelper.getFluffJPG(unit, path);
-        }
-
-        if (fluff == null) {
-            fluff = ImageHelper.getFluffGIF(unit, path);
-        }
-
-        if (fluff == null) {
-            fluff = new ImageIcon(path + "hud.png").getImage();
-        }
-
-        return fluff;
-    }
-
-    public static Image getFluffPNG(Entity unit, String path) {
-        Image fluff = null;
-
-        String fluffFile = path + unit.getChassis() + " " + unit.getModel() + ".png";
-        if (new File(fluffFile.toLowerCase()).exists()) {
-            fluff = new ImageIcon(fluffFile).getImage();
-        }
-
-        if (fluff == null) {
-            fluffFile = path + unit.getModel() + ".png";
-            if (new File(fluffFile.toLowerCase()).exists()) {
-                fluff = new ImageIcon(fluffFile).getImage();
-            }
-        }
-
-        if (fluff == null) {
-            fluffFile = path + unit.getChassis() + ".png";
-            if (new File(fluffFile.toLowerCase()).exists()) {
-                fluff = new ImageIcon(fluffFile).getImage();
-            }
-        }
-
-        return fluff;
-    }
-
-    public static Image getFluffJPG(Entity unit, String path) {
-        Image fluff = null;
-
-        String fluffFile = path + unit.getChassis() + " " + unit.getModel() + ".jpg";
-        if (new File(fluffFile.toLowerCase()).exists()) {
-            fluff = new ImageIcon(fluffFile).getImage();
-        }
-
-        if (fluff == null) {
-            fluffFile = path + unit.getModel() + ".jpg";
-            if (new File(fluffFile.toLowerCase()).exists()) {
-                fluff = new ImageIcon(fluffFile).getImage();
-            }
-        }
-
-        if (fluff == null) {
-            fluffFile = path + unit.getChassis() + ".jpg";
-            if (new File(fluffFile.toLowerCase()).exists()) {
-                fluff = new ImageIcon(fluffFile).getImage();
-            }
-        }
-
-        return fluff;
-    }
-
-    public static Image getFluffGIF(Entity unit, String path) {
-        Image fluff = null;
-
-        String fluffFile = path + unit.getChassis() + " " + unit.getModel()
-                + ".gif";
-        if (new File(fluffFile.toLowerCase()).exists()) {
-            fluff = new ImageIcon(fluffFile).getImage();
-        }
-
-        if (fluff == null) {
-            fluffFile = path + unit.getModel() + ".gif";
-            if (new File(fluffFile.toLowerCase()).exists()) {
-                fluff = new ImageIcon(fluffFile).getImage();
-            }
-        }
-
-        if (fluff == null) {
-            fluffFile = path + unit.getChassis() + ".gif";
-            if (new File(fluffFile.toLowerCase()).exists()) {
-                fluff = new ImageIcon(fluffFile).getImage();
-            }
-        }
-
-        return fluff;
     }
 }


### PR DESCRIPTION
This has adaptations for MegaMek/megamek#5107
On Meks, there is now a field to set the clan chassis name (such as Timber Wolf)
Also, this adds a config setting for record sheets to arrange the name of Clan meks with a dual name such as Mad Cat (Timber Wolf) in various ways.
There are adaptations to MML's ImageHelper (essentially the same as MM's FluffImageHelper), most of which was not used and was adapted to reuse MM's fluff stuff more.