### PR TITLE
StatusBar: calculate the correct total max weight for BA

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
+++ b/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
@@ -25,6 +25,7 @@ import megamek.client.ui.dialogs.WeightDisplayDialog;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.calculationReport.CalculationReport;
 import megamek.common.*;
+import megamek.common.verifier.TestBattleArmor;
 import megamek.common.verifier.TestEntity;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.util.ITab;
@@ -112,6 +113,9 @@ public class StatusBar extends ITab {
      */
     protected void refreshWeight() {
         double tonnage = getEntity().getWeight();
+        if (getEntity() instanceof BattleArmor) {
+            tonnage = getBattleArmor().getTrooperWeight() * getBattleArmor().getSquadSize();
+        }
         double currentTonnage = testEntity.calculateWeight();
         currentTonnage += UnitUtil.getUnallocatedAmmoTonnage(getEntity());
         String current = CalculationReport.formatForReport(currentTonnage);


### PR DESCRIPTION
As the title says, adds a max weight calculation for BA to the StatusBar as entity.getWeight doesn't return the correct result. 