### PR TITLE
Gradle build JVM thrashing fix.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: build --stacktrace --scan
+        arguments: build --stacktrace --max-workers=1 --scan
         build-root-directory: megameklab
 
     # If the build step fails, try to upload any test logs in case it was a unit test failure.

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: build --stacktrace --scan
+        arguments: build --stacktrace --max-workers=1 --scan
         build-root-directory: megameklab
       
     # If the build step fails, try to upload any test logs in case it was a unit test failure.

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: clean build -x test --continue --stacktrace --scan
+        arguments: clean build -x test --continue --stacktrace --max-workers=1 --scan
         build-root-directory: megameklab
 
     - name: Upload Test Logs on Failure

--- a/.github/workflows/nightly-maven-ci.yml
+++ b/.github/workflows/nightly-maven-ci.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: clean build --continue --stacktrace --scan
+        arguments: clean build --continue --stacktrace --max-workers=1 --scan
         build-root-directory: megameklab
 
     - name: Upload Test Logs on Failure


### PR DESCRIPTION
Github action fix for Gradle JVM memory thrashing that can occur for builds the depend on megamek. 

I was able to re-create the JVM thrashing and fix by doing a clean build with a clean (not pre-compiled) dependent megamek project.

See MegaMek/mekhq#3785