### PR TITLE
Correct vtol hit location table subtext

### DIFF
--- a/megameklab/data/images/recordsheets/templates_iso/tables_vtol.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/tables_vtol.svg
@@ -124,31 +124,35 @@
         ></text
       ></g
       ><g transform="translate(0,140.600)"
-      ><text x="6.000" y="7.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="301.630" lengthAdjust="spacingAndGlyphs"
-        >*A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on the VTOL. For each such attack, apply</text
-        ><text x="6.000" y="14.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="301.630" lengthAdjust="spacingAndGlyphs"
+      ><text x="6.000" y="7.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="301.630"
+        >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on the VTOL. For each such attack, apply</text
+        ><text x="6.000" y="14.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="301.630"
         >damage normally to the armor in that section. The attacking player then immediately rolls once on the VTOL Combat Vehicle</text
         ><text fill="#231f20" x="6.000" y="21.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal;mml-field-width:16892.987" text-anchor="start">Critical Hits Table, below.</text>
+
+
+  <g transform="translate (0, 4)">
+  <text x="6.000" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="143">† Damage Value / 10 (round up); see Rotor Hits, p. 197, </text>
         
-        <text x="6.000" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="143" lengthAdjust="spacingAndGlyphs">† Damage Value / 10 (round up); see Rotor Hits, p. 197, </text>
+        <text x="150" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:italic" textLength="37.320">Total Warfare.</text>
         
-        <text x="150" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:italic" textLength="37.320" lengthAdjust="spacingAndGlyphs">Total Warfare.</text>
+        <text x="190" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="117.320"> Additionally, damage to rotors slows down the</text>
         
-        <text x="190" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="117.320" lengthAdjust="spacingAndGlyphs"> Additionally, damage to rotors slows down the</text>
-        
-        <text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="301.630" lengthAdjust="spacingAndGlyphs"
+        <text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="301.630"
         >VTOL. Each hit reduces the VTOL’s Cruising MP by 1, meaning that the controlling player must also recalculate Flank MP;</text
-        ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="301.630" lengthAdjust="spacingAndGlyphs"
+        ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="301.630"
         >multiply the new Cruising MP by 1.5 and round up. As with all damage, such movement penalties do not apply until the end</text
         ><text fill="#231f20" x="6.000" y="49.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal;mml-field-width:2953591.811" text-anchor="start"
         >of the phase in which the damage occurred.</text
-        ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="301.630" lengthAdjust="spacingAndGlyphs"
-        >‡ A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on the VTOL. For each such attack, apply</text
-        ><text x="6.000" y="63.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="301.630" lengthAdjust="spacingAndGlyphs"
-        >damage normally to the armor in that section. The attacking player then immediately rolls once on the VTOL Combat Vehicle</text
-        ><text fill="#231f20" x="6.000" y="70.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal;mml-field-width:16934.482" text-anchor="start"
-        >Critical Hits Table, below.</text
-      ></g
+        >
+  </g>
+
+  <g transform="translate (0, 8)">
+  <text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal"
+        >‡ If the VTOL has no turret, a turret strike hits Rotors†</text
+        >
+  </g>
+</g
     ></g
     ><g transform="translate (321.630 3.000)"
     ><g

--- a/megameklab/data/images/recordsheets/templates_us/tables_vtol.svg
+++ b/megameklab/data/images/recordsheets/templates_us/tables_vtol.svg
@@ -124,33 +124,36 @@
         ></text
       ></g
       ><g transform="translate(0,125.600)"
-      ><text x="6.000" y="7.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="311.320" lengthAdjust="spacingAndGlyphs"
-        >*A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on the VTOL. For each such attack, apply</text
-        ><text x="6.000" y="14.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="311.320" lengthAdjust="spacingAndGlyphs"
+      ><text x="6.000" y="7.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="311.320"
+        >* A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on the VTOL. For each such attack, apply</text
+        ><text x="6.000" y="14.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="311.320"
         >damage normally to the armor in that section. The attacking player then immediately rolls once on the VTOL Combat Vehicle</text
         >
-        
+
         <text fill="#231f20" x="6.000" y="21.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal;mml-field-width:16892.987" text-anchor="start">Critical Hits Table, below.</text>
-        
-        <text x="6.000" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="143" lengthAdjust="spacingAndGlyphs">† Damage Value / 10 (round up); see Rotor Hits, p. 197, </text>
-        
-        <text x="150" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:italic" textLength="38.320" lengthAdjust="spacingAndGlyphs">Total Warfare.</text>
-        
-        <text x="193" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="123.320" lengthAdjust="spacingAndGlyphs"> Additionally, damage to rotors slows down the</text>
-        
-        <text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="311.320" lengthAdjust="spacingAndGlyphs"
+
+  <g transform="translate (0, 4)">
+        <text x="6.000" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="143">† Damage Value / 10 (round up); see Rotor Hits, p. 197, </text>
+
+        <text x="150" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:italic" textLength="38.320" >Total Warfare.</text>
+
+        <text x="193" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="123.320" > Additionally, damage to rotors slows down the</text>
+
+        <text x="6.000" y="35.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="311.320"
         >VTOL. Each hit reduces the VTOL’s Cruising MP by 1, meaning that the controlling player must also recalculate Flank MP;</text
-        ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="311.320" lengthAdjust="spacingAndGlyphs"
+        ><text x="6.000" y="42.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="311.320"
         >multiply the new Cruising MP by 1.5 and round up. As with all damage, such movement penalties do not apply until the end</text
         ><text fill="#231f20" x="6.000" y="49.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal;mml-field-width:3047847.104" text-anchor="start"
         >of the phase in which the damage occurred.</text
-        ><text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="311.320" lengthAdjust="spacingAndGlyphs"
-        >‡ A result of 2 or 12 (or an 8 if the attack strikes the side) may inflict a critical hit on the VTOL. For each such attack, apply</text
-        ><text x="6.000" y="63.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal" textLength="311.320" lengthAdjust="spacingAndGlyphs"
-        >damage normally to the armor in that section. The attacking player then immediately rolls once on the VTOL Combat Vehicle</text
-        ><text fill="#231f20" x="6.000" y="70.000" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal;mml-field-width:16934.482" text-anchor="start"
-        >Critical Hits Table, below.</text
-      ></g
+        >
+  </g>
+  <g transform="translate (0, 8)">
+    <text x="6.000" y="56.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:5.700px;font-weight:normal;font-style:normal"
+        >‡ If the VTOL has no turret, a turret strike hits Rotors†</text
+        >
+
+  </g>
+</g
     ></g
     ><g transform="translate (331.320 3.000)"
     ><g


### PR DESCRIPTION
Fixes #1400 

The location table was correct (TO:AR p.203) but the subtexts were not. 

![image](https://github.com/MegaMek/megameklab/assets/17069663/3a850c15-524a-4d43-a2be-617ce15accc4)
