### PR TITLE
Revert to the normal "-" character in RS heat table movement penalties

### DIFF
--- a/megameklab/src/megameklab/printing/PrintMech.java
+++ b/megameklab/src/megameklab/printing/PrintMech.java
@@ -643,8 +643,7 @@ public class PrintMech extends PrintEntity {
     }
 
     private String formatHeatMovementPenalty(int penalty) {
-        // 2212 is the Unicode Minus Sign; has much better length than '-'; supported by most fonts
-        String penaltyString = "\u2212" + CConfig.formatScale(penalty, true) + " Movement";
+        String penaltyString = "-" + CConfig.formatScale(penalty, true) + " Movement";
         if (CConfig.scaleUnits() == RSScale.HEXES) {
             penaltyString += " Points";
         }


### PR DESCRIPTION
CGL request: Removes the unicode character 2212 (a longer dash that aligned better with a plus) from the RS heat tables.