### PR TITLE
Remove misc heat duplication in the status bar

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
+++ b/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
@@ -230,16 +230,6 @@ public class StatusBar extends ITab {
             heat += weaponHeat;
         }
 
-        if (getEntity().hasWorkingMisc(MiscType.F_STEALTH, -1)
-                || getEntity().hasWorkingMisc(MiscType.F_VOIDSIG, -1)
-                || getEntity().hasWorkingMisc(MiscType.F_NULLSIG, -1)) {
-            heat += 10;
-        }
-
-        if (getEntity().hasWorkingMisc(MiscType.F_CHAMELEON_SHIELD, -1)) {
-            heat += 6;
-        }
-
         for (Mounted m : getEntity().getMisc()) {
             heat += m.getType().getHeat();
 

--- a/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
+++ b/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
@@ -25,12 +25,10 @@ import megamek.client.ui.dialogs.WeightDisplayDialog;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.calculationReport.CalculationReport;
 import megamek.common.*;
-import megamek.common.verifier.TestBattleArmor;
 import megamek.common.verifier.TestEntity;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
-import megameklab.util.ImageHelper;
 import megameklab.util.UnitUtil;
 
 import javax.swing.*;


### PR DESCRIPTION
Fixes #1421 
The explicit heat additions were unnecessary as the code below adds heat for all misc equipment