### PR TITLE
MekUtil: fix automatic placement of armors without crit requirement

### DIFF
--- a/megameklab/src/megameklab/util/MekUtil.java
+++ b/megameklab/src/megameklab/util/MekUtil.java
@@ -940,6 +940,7 @@ public final class MekUtil {
      */
     public static boolean isFMU(Mounted equipment) {
         return (equipment != null)
+                && equipment.getType().getCriticals(equipment.getEntity()) > 0
                 && !equipment.getType().isHittable()
                 && (equipment.getType() instanceof MiscType)
                 && !equipment.getType().hasFlag(MiscType.F_CASE)


### PR DESCRIPTION
I think the recent ArmorType change made all armors unhittable and spreadable, even those without crit requirements. This updates a test so that when they don't need crits, they don't get automatically placed in locations.

Fixes #1419 