### PR TITLE
Debug helper update

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
+++ b/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2023, 2024 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -25,17 +25,18 @@ import megamek.client.ui.dialogs.WeightDisplayDialog;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.calculationReport.CalculationReport;
 import megamek.common.*;
-import megamek.common.verifier.TestBattleArmor;
 import megamek.common.verifier.TestEntity;
+import megamek.utilities.DebugEntity;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
-import megameklab.util.ImageHelper;
 import megameklab.util.UnitUtil;
 
 import javax.swing.*;
 import javax.swing.border.MatteBorder;
 import java.awt.*;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
 import java.io.File;
 import java.text.DecimalFormat;
 
@@ -63,7 +64,7 @@ public class StatusBar extends ITab {
         formatter = new DecimalFormat();
 
         JButton btnValidate = new JButton("Validate Unit");
-        btnValidate.addActionListener(evt -> UnitUtil.showValidation(getEntity(), getParentFrame()));
+        btnValidate.addActionListener(validationListener);
 
         JButton btnFluffImage = new JButton("Set Fluff Image");
         btnFluffImage.addActionListener(evt -> getFluffImage());
@@ -173,6 +174,14 @@ public class StatusBar extends ITab {
     public void addRefreshedListener(RefreshListener refreshListener) {
         refresh = refreshListener;
     }
+
+    private final ActionListener validationListener = e -> {
+        if ((e.getModifiers() & Event.CTRL_MASK) != 0) {
+            DebugEntity.copyEquipmentState(getEntity());
+        } else {
+            UnitUtil.showValidation(getEntity(), getParentFrame());
+        }
+    };
 
     /**
      * Returns an estimated value of the total heat generation for Meks and Aeros (0 for other types).


### PR DESCRIPTION
![image](https://github.com/MegaMek/megameklab/assets/17069663/d55367ce-96da-40be-8b8a-958b7998f758)

When the "Validate" button in the status bar is clicked with CTRL held, instead of the validation dialog the internal state of the entity (DebugEntity.copyEquipmentState() is copied to the clipboard for inspection in a text editor. The example shows the current problem of two different armor types currently being loaded (one should be structure). I've intentionally not added a tooltip or something; this is purely for debugging. There is an accompanying MM PR that updates a few string outputs to improve clarity.

![image](https://github.com/MegaMek/megameklab/assets/17069663/fbeb7e85-a594-44e8-a12d-547b5cc71f86)
