### PR TITLE
Dependency cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,9 +47,6 @@ ext {
 
 def localProperties = file('properties_local.gradle')
 
-dependencies {
-    implementation 'org.mockito:mockito-core:5.2.0'
-}
 if (localProperties.exists()) {
     apply from: localProperties
 }

--- a/megameklab/build.gradle
+++ b/megameklab/build.gradle
@@ -51,7 +51,7 @@ dependencies {
         exclude group: 'com.sun.media', module: 'jai-codec'
         exclude group: 'xml-apis'
     }
-    implementation 'org.mockito:mockito-core:5.2.0'
+    testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
 
     runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.2'

--- a/megameklab/unittests/megameklab/ui/util/EquipmentTableModelTest.java
+++ b/megameklab/unittests/megameklab/ui/util/EquipmentTableModelTest.java
@@ -14,8 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.mockito.Mockito.*;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -58,7 +56,7 @@ class EquipmentTableModelTest {
     @Test
     void testGetValueAtForAll() throws EntityLoadingException {
         // Test getValue() in EquipmentTableModel; the exercises conversions and lookups
-        ArrayList<String> testItems = new ArrayList<String>(Arrays.asList(
+        ArrayList<String> testItems = new ArrayList<>(Arrays.asList(
                 "/Kirghiz C.blk",                                           // ASF
                 "/Beast Infantry (Elephant)(Laser Rifle_Support PPC).blk",  // Beast Inf
                 "/Black Wolf BA (ER Pulse) (Sqd5).blk",                     // BA, Clan
@@ -92,7 +90,7 @@ class EquipmentTableModelTest {
         // Test reading damage strings for ASF weapons
         String fname = "/Kirghiz C.blk";
         Entity te = configureFromFilename(fname);
-        assertEquals(true, te.isAero());
+        assertTrue(te.isAero());
         for (Mounted weapon: te.getWeaponList()) {
             WeaponType weaponType = (WeaponType) weapon.getType();
             String dString = EquipmentTableModel.getDamageString(weaponType, te.isAero());
@@ -112,7 +110,7 @@ class EquipmentTableModelTest {
         // Test reading damage strings for CI weapons
         String fname = "/Jump Squad (LRM).blk";
         Entity te = configureFromFilename(fname);
-        assertEquals(false, te.isAero());
+        assertFalse(te.isAero());
         for (Mounted weapon: te.getWeaponList()) {
             WeaponType weaponType = (WeaponType) weapon.getType();
             String dString = EquipmentTableModel.getDamageString(weaponType, te.isAero());
@@ -128,13 +126,12 @@ class EquipmentTableModelTest {
         // Test reading damage strings for CI weapons
         String fname = "/Long Tom Cannon Turret (Quad).blk";
         Entity te = configureFromFilename(fname);
-        assertEquals(false, te.isAero());
+        assertFalse(te.isAero());
         for (Mounted weapon: te.getWeaponList()) {
             WeaponType weaponType = (WeaponType) weapon.getType();
             String dString = EquipmentTableModel.getDamageString(weaponType, te.isAero());
             // Confirm can convert to double
-            assertEquals(Integer.toString(weaponType.getRackSize())+"A",
-                    dString);
+            assertEquals(weaponType.getRackSize() + "A", dString);
         }
     }
 }


### PR DESCRIPTION
Fixes some problems in #1433 and cleans up test code.
The dependency block in the build file in the project root does nothing, as there is no source code there.
Mockito should use testImplementation instead of implementation because it is not needed on the classpath when running MML, and should not be added to the libraries in the packaged distribution.