### PR TITLE
Fix integer overflow in determining maximum number of bay doors

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
@@ -337,7 +337,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
             }
             return Math.max(total, 0);
         } else {
-            return Integer.MAX_VALUE - 1;
+            return Integer.MAX_VALUE;
         }
     }
 
@@ -860,7 +860,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                 int doors = (Integer) modelInstalled.getValueAt(row, column);
                 SpinnerNumberModel model = new SpinnerNumberModel(doors,
                         (isInfantry) ? 0 : 1,
-                        doorsAvailable() + doors, 1);
+                        getEntity().isAero() ? doorsAvailable() + doors : Integer.MAX_VALUE, 1);
                 spinner.removeChangeListener(this);
                 spinner.setModel(model);
                 spinner.addChangeListener(this);


### PR DESCRIPTION
When assigning the maximum value to the spinner for number of bay doors it adds the current number of doors on the bay to the number available for assignment. This works fine for aerospace units, which have maximum number based on weight, but support vehicles have no such maximum. The number of available doors is Integer.MAX_VALUE (I'm not sure what the -1 was for, but it prevented the issue from popping up as long as there was only one door). When added to the number of doors currently, it can result in integer overflow so that the maximum is a negative number. This causes an IllegalArgumentException because it doesn't meet the requirement that min <= value <= max.

Fixes #1242