### PR TITLE
Revert to use ETYPE_AERO in MML

### DIFF
--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -179,7 +179,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
             final JMenuItem miSwitchToFighter = new JMenuItem(resources.getString("miSwitchToFighter.text"));
             miSwitchToFighter.setName("miSwitchToFighter");
             miSwitchToFighter.setMnemonic(KeyEvent.VK_A);
-            miSwitchToFighter.addActionListener(evt -> owner.newUnit(Entity.ETYPE_AEROSPACEFIGHTER));
+            miSwitchToFighter.addActionListener(evt -> owner.newUnit(Entity.ETYPE_AERO));
             switchUnitTypeMenu.add(miSwitchToFighter);
         }
 
@@ -1058,7 +1058,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         } else if (en.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
             getUnitMainUi().createNewUnit(Entity.ETYPE_JUMPSHIP);
         } else if (owner.getEntity() instanceof Aero) {
-            getUnitMainUi().createNewUnit(Entity.ETYPE_AEROSPACEFIGHTER, en.isPrimitive());
+            getUnitMainUi().createNewUnit(Entity.ETYPE_AERO, en.isPrimitive());
         } else if (owner.getEntity() instanceof BattleArmor) {
             getUnitMainUi().createNewUnit(Entity.ETYPE_BATTLEARMOR);
         } else if (owner.getEntity() instanceof Infantry) {

--- a/megameklab/src/megameklab/ui/dialog/UiLoader.java
+++ b/megameklab/src/megameklab/ui/dialog/UiLoader.java
@@ -76,7 +76,7 @@ public class UiLoader {
         } else if (newUnit.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
             new UiLoader(Entity.ETYPE_JUMPSHIP, newUnit.isPrimitive(), false, newUnit, fileName).show();
         } else if ((newUnit instanceof Aero) && !(newUnit instanceof FixedWingSupport)) {
-            new UiLoader(Entity.ETYPE_AEROSPACEFIGHTER, newUnit.isPrimitive(), false, newUnit, fileName).show();
+            new UiLoader(Entity.ETYPE_AERO, newUnit.isPrimitive(), false, newUnit, fileName).show();
         } else if (newUnit instanceof BattleArmor) {
             new UiLoader(Entity.ETYPE_BATTLEARMOR, false, false, newUnit, fileName).show();
         } else if (newUnit instanceof Infantry) {

--- a/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
@@ -43,7 +43,7 @@ public class ASMainUI extends MegaMekLabMainUI {
 
     public ASMainUI(boolean primitive) {
         super();
-        createNewUnit(Entity.ETYPE_AEROSPACEFIGHTER, primitive);
+        createNewUnit(Entity.ETYPE_AERO, primitive);
         finishSetup();
     }
 
@@ -88,7 +88,7 @@ public class ASMainUI extends MegaMekLabMainUI {
     @Override
     public void createNewUnit(long entityType, boolean isPrimitive, boolean isIndustrial, Entity oldEntity) {
 
-        if (entityType == Entity.ETYPE_AEROSPACEFIGHTER) {
+        if (entityType == Entity.ETYPE_AERO) {
             setEntity(new AeroSpaceFighter());
             getEntity().setTechLevel(TechConstants.T_IS_TW_NON_BOX);
         } else if (entityType == Entity.ETYPE_CONV_FIGHTER) {


### PR DESCRIPTION
This reverts some use of ETYPE_AEROSPACEFIGHTER in MML, as it was no longer calling up the ASF UI for ASF units (It was not used consistently enough). Since the etypes are, in MML, only used to signal the UI that is to be loaded and have no direct connection to the actual etype in the units I reverted to the old AERO etype.