### PR TITLE
Fix NPE in armor type lookup for industrial.

### DIFF
--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -502,8 +502,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
     private void createArmorMountsAndSetArmorType(int at, int aTechLevel) {
         getMech().setArmorTechLevel(aTechLevel);
         getMech().setArmorType(at);
-        final EquipmentType armor = EquipmentType.get(EquipmentType.getArmorTypeName(at,
-                TechConstants.isClan(aTechLevel)));
+        final EquipmentType armor = ArmorType.of(at, TechConstants.isClan(aTechLevel));
         int armorCount = armor.getCriticals(getMech());
 
         if (armorCount < 1) {


### PR DESCRIPTION
The trailing space on the name of industrial armor (which I still don't know the reason for, but there was a comment that says it's deliberate) is causing a failure when using a name lookup. Leaving the space out of the lookup names causes a failure when loading from mtf files, so the long term solution may be to add additional lookup names. Or remove the trailing space and see if anything breaks.

Fixes #1440 