### PR TITLE
Fix infantry weapon resetting on year change

### DIFF
--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -1950,7 +1950,7 @@ public class UnitUtil {
         if (unit instanceof Infantry) {
             Infantry pbi = (Infantry) unit;
             if ((null != pbi.getPrimaryWeapon())
-                    && techManager.isLegal(pbi.getPrimaryWeapon())) {
+                    && !techManager.isLegal(pbi.getPrimaryWeapon())) {
                 dirty = true;
                 InfantryUtil.replaceMainWeapon((Infantry) unit,
                         (InfantryWeapon) EquipmentType


### PR DESCRIPTION
Fixes #1432 

If the weapon became illegal with the year change, it actually *wouldn't* be reset.