### PR TITLE
If 'Use game year' enabled, use that year for unit search

### DIFF
--- a/megameklab/src/megameklab/ui/dialog/MegaMekLabUnitSelectorDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/MegaMekLabUnitSelectorDialog.java
@@ -52,6 +52,9 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
         gameTechLevel = TechConstants.T_SIMPLE_UNOFFICIAL;
         allowPickWithoutClose = false;
         eraBasedTechLevel = CConfig.getBooleanParam(CConfig.TECH_PROGRESSION);
+        if (CConfig.getBooleanParam(CConfig.TECH_USE_YEAR)) {
+            allowedYear = CConfig.getIntParam(CConfig.TECH_YEAR);
+        }
         initialize();
         run();
         setVisible(true);
@@ -130,7 +133,7 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
     @Override
     protected void select(boolean close) {
         chosenEntity = getSelectedEntity();
-        
+
         if (close) {
             setVisible(false);
         } else if (entityPickCallback != null) {


### PR DESCRIPTION
If a game year is set and variable tech level is enabled, use that year for tech level in unit search. 
This _only_ affects the calculated tech level, it doesn't hide units that only exist after the given year. 