### PR TITLE
Reset CI field guns when setting tech level to Standard

### DIFF
--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -1961,6 +1961,9 @@ public class UnitUtil {
                 dirty = true;
                 InfantryUtil.replaceMainWeapon((Infantry) unit, null, true);
             }
+            if (techManager.getTechLevel().ordinal() <= SimpleTechLevel.STANDARD.ordinal() && pbi.hasFieldWeapon()) {
+                InfantryUtil.replaceFieldGun(pbi, null, 0);
+            }
         }
         return dirty;
     }


### PR DESCRIPTION
Partially addresses #1466 by making it so MML cannot be used to create illegal units as described in that issue.

Units created before this patch which have field guns at the Standard tech level will still be considered legal and load as Standard units. I'm not sure how this could be fixed, I tried updating `Infantry::addSystemTechAdvancement` to add a tech advancement with Advanced when field guns were present, but this didn't seem to do anything at all.