### PR TITLE
Industrial tripod cockpit

### DIFF
--- a/megameklab/src/megameklab/printing/reference/GroundToHitMods.java
+++ b/megameklab/src/megameklab/printing/reference/GroundToHitMods.java
@@ -64,9 +64,7 @@ public class GroundToHitMods extends ReferenceTable {
         addRow("", bundle.getString("skidding"), "+1");
         if (((Mech) entity).getCockpitType() == Mech.COCKPIT_PRIMITIVE_INDUSTRIAL) {
             addRow("", bundle.getString("noFireCon"), "+2");
-        } else if ((((Mech) entity).getCockpitType() == Mech.COCKPIT_PRIMITIVE)
-                || (((Mech) entity).getCockpitType() == Mech.COCKPIT_INDUSTRIAL)
-                || (((Mech) entity).getCockpitType() == Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL)) {
+        } else if (((Mech) entity).hasAdvancedFireControl()) {
             addRow("", bundle.getString("basicFireCon"), "+1");
         }
     }

--- a/megameklab/src/megameklab/printing/reference/GroundToHitMods.java
+++ b/megameklab/src/megameklab/printing/reference/GroundToHitMods.java
@@ -64,7 +64,7 @@ public class GroundToHitMods extends ReferenceTable {
         addRow("", bundle.getString("skidding"), "+1");
         if (((Mech) entity).getCockpitType() == Mech.COCKPIT_PRIMITIVE_INDUSTRIAL) {
             addRow("", bundle.getString("noFireCon"), "+2");
-        } else if (((Mech) entity).hasAdvancedFireControl()) {
+        } else if (!((Mech) entity).hasAdvancedFireControl()) {
             addRow("", bundle.getString("basicFireCon"), "+1");
         }
     }

--- a/megameklab/src/megameklab/ui/mek/BMChassisView.java
+++ b/megameklab/src/megameklab/ui/mek/BMChassisView.java
@@ -101,7 +101,7 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
     final private TechComboBox<EquipmentType> cbStructure = new TechComboBox<>(EquipmentType::getName);
     final private TechComboBox<Engine> cbEngine = new TechComboBox<>(e -> e.getEngineName().replaceAll("^\\d+ ", ""));
     final private CustomComboBox<Integer> cbGyro = new CustomComboBox<>(Mech::getGyroTypeShortString);
-    final private CustomComboBox<Integer> cbCockpit = new CustomComboBox<>(i -> cockpitName(i, isIndustrial()));
+    final private CustomComboBox<Integer> cbCockpit = new CustomComboBox<>(i -> Mech.getCockpitTypeString(i, isIndustrial()));
     final private TechComboBox<EquipmentType> cbEnhancement = new TechComboBox<>(EquipmentType::getName);
     final private JCheckBox chkFullHeadEject = new JCheckBox();
     final private JButton btnResetChassis = new JButton();
@@ -555,17 +555,6 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
         }
     }
 
-    private static String cockpitName(int index, boolean industrial) {
-        if (industrial) {
-            if (index == Mech.COCKPIT_STANDARD) {
-                return Mech.getCockpitTypeString(Mech.COCKPIT_INDUSTRIAL) + " (Adv. FireCon)";
-            } else if (index == Mech.COCKPIT_PRIMITIVE) {
-                return Mech.getCockpitTypeString(Mech.COCKPIT_PRIMITIVE_INDUSTRIAL) + " (Adv. FireCon)";
-            }
-        }
-        return Mech.getCockpitTypeString(index);
-    }
-    
     private void refreshEnhancement() {
         cbEnhancement.removeActionListener(this);
         EquipmentType prev = (EquipmentType) cbEnhancement.getSelectedItem();

--- a/megameklab/src/megameklab/ui/mek/BMChassisView.java
+++ b/megameklab/src/megameklab/ui/mek/BMChassisView.java
@@ -509,8 +509,13 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
         cbCockpit.removeActionListener(this);
         Integer prev = (Integer) cbCockpit.getSelectedItem();
         cbCockpit.removeAllItems();
-        if ((getBaseTypeIndex() == BASE_TYPE_STANDARD) && (getMotiveTypeIndex() == MOTIVE_TYPE_TRIPOD)) {
-            cbCockpit.addItem(isSuperheavy()? Mech.COCKPIT_SUPERHEAVY_TRIPOD : Mech.COCKPIT_TRIPOD);
+        if (((getBaseTypeIndex() == BASE_TYPE_STANDARD) || getBaseTypeIndex() == BASE_TYPE_INDUSTRIAL)
+                && (getMotiveTypeIndex() == MOTIVE_TYPE_TRIPOD)) {
+            if (isIndustrial()) {
+                cbCockpit.addItem(isSuperheavy() ?
+                        Mech.COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL : Mech.COCKPIT_TRIPOD_INDUSTRIAL);
+            }
+            cbCockpit.addItem(isSuperheavy() ? Mech.COCKPIT_SUPERHEAVY_TRIPOD : Mech.COCKPIT_TRIPOD);
         } else if (getBaseTypeIndex() == BASE_TYPE_LAM) {
             cbCockpit.addItem(Mech.COCKPIT_STANDARD);
             cbCockpit.addItem(Mech.COCKPIT_SMALL);

--- a/megameklab/src/megameklab/ui/mek/BMMainUI.java
+++ b/megameklab/src/megameklab/ui/mek/BMMainUI.java
@@ -137,8 +137,6 @@ public class BMMainUI extends MegaMekLabMainUI {
         mech.addEngineCrits();
         if (isPrimitive) {
             mech.addPrimitiveCockpit();
-        } else if (isIndustrial) {
-            mech.addIndustrialCockpit();
         } else if (Entity.ETYPE_QUADVEE == entityType) {
             mech.addQuadVeeCockpit();
         } else {

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -686,8 +686,22 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
             }
             if (tonnage > 100) {
                 getMech().setGyroType(Mech.GYRO_SUPERHEAVY);
+                if (getMech().isTripodMek()) {
+                    cockpitChanged(getMech().hasAdvancedFireControl() ?
+                            Mech.COCKPIT_SUPERHEAVY_TRIPOD : Mech.COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL);
+                } else {
+                    cockpitChanged(getMech().hasAdvancedFireControl() ?
+                            Mech.COCKPIT_SUPERHEAVY : Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL);
+                }
             } else {
                 getMech().setGyroType(Mech.GYRO_STANDARD);
+                if (getMech().isTripodMek()) {
+                    cockpitChanged(getMech().hasAdvancedFireControl() ?
+                            Mech.COCKPIT_TRIPOD : Mech.COCKPIT_TRIPOD_INDUSTRIAL);
+                } else {
+                    cockpitChanged(getMech().hasAdvancedFireControl() ?
+                            Mech.COCKPIT_STANDARD : Mech.COCKPIT_INDUSTRIAL);
+                }
             }
         }
         getMech().setWeight(tonnage);

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -312,8 +312,12 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
                 break;
             default:
                 clearCritsForCockpit(false, false);
+                int cockpitType = getMech().getCockpitType();
                 getMech().addCockpit();
+                // addCockpit sets the criticals but also sets the type to the default.
+                getMech().setCockpitType(cockpitType);
         }
+
         // For LAMs we want to put the landing gear in the first available slot after the engine and gyro.
         if (getMech().hasETypeFlag(Entity.ETYPE_LAND_AIR_MECH)) {
             int lgSlot = 10;


### PR DESCRIPTION
Makes a distinction between tripod industrial mechs with and without active fire control. Also fixes a couple of bugs I noticed during testing, involving cockpit type not updating when switching an industrial mech to tripod or switching between standard weight and superheavy.

Requires Megamek/megamek#5291.

Fixes #1315
Fixes #1371