### PR TITLE
MML portion of fix for MHQ 3803: Fixed WOB.pm/PM mismatch

### DIFF
--- a/megameklab/data/forcegenerator/factions.xml
+++ b/megameklab/data/forcegenerator/factions.xml
@@ -67,7 +67,7 @@
 	<faction key='CIR' name='Circinus Federation' minor='false' clan='false' periphery='true'>
 		<years>2785-3081</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
-		<parentFaction>Periphery.MW,WOB.pm</parentFaction>
+		<parentFaction>Periphery.MW,WOB.PM</parentFaction>
 	</faction>
 	<faction key='CLAN' name='Clan - General' minor='false' clan='true' periphery='false'>
 		<years>2807-</years>


### PR DESCRIPTION
Fix case error in Circinus Federation parent faction "WOB.pm" (should be "WOB.PM").

Testing:

- Ran all 3 projects' unit tests
- Ran MekHQ with campaign save and custom units from MegaMek/mekhq#3803 and confirmed proper operation.