### PR TITLE
Fix #5252: critical assignment tab eq list missing keywords like "Ammo" and "[Half]" or "[Full]"

### DIFF
--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -1143,7 +1143,8 @@ public class UnitUtil {
      */
     public static String getCritName(Entity unit, EquipmentType eq) {
         String name = eq.getName();
-        if (name.length() > 22) {
+        // Only shorten non-ammo; getShortName leaves off "Ammo" and "[Half]" that we want
+        if (name.length() > 22 && !(eq instanceof AmmoType) ) {
             name = eq.getShortName();
         }
         if (unit.isMixedTech()


### PR DESCRIPTION
Don't use the `.getShortName()` value for AmmoType instances in the Equipment List of the Crits tab.

Testing:
- Added offending ammo types from the bug to new units.
- Ran all three projects' unit tests.

Close MegaMek/megamek#5252