### PR TITLE
Fix conventional fighter return table column header

### DIFF
--- a/megameklab/data/images/recordsheets/templates_iso/fighter_conventional_default.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/fighter_conventional_default.svg
@@ -1504,6 +1504,8 @@
                                                                                       ></g
                                                                                       ><g transform="translate (0.000 32.536)"
                                                                                       ><text text-anchor="middle" style="font-family:Eurostile;font-size:5.700px;font-weight:bold;font-style:normal"
+                                                                                        ><tspan x="40.000" y="0.000"
+                                                                                          >SAFE THRUST</tspan
                                                                                         ><tspan x="122.733" y="0.000"
                                                                                           >TURNS BEFORE RETURN</tspan
                                                                                         ></text


### PR DESCRIPTION
Minor formatting error: the "Fighter Return Table" at the bottom-right of the CF sheet template, taken originally from _AeroTech 2: Revised_, is missing a column header.

Testing:
- None.  This is just a formatting fix.