### PR TITLE
Add discord-formatted export support

### DIFF
--- a/megameklab/resources/megameklab/resources/Menu.properties
+++ b/megameklab/resources/megameklab/resources/Menu.properties
@@ -46,6 +46,8 @@ htmlUnitExportMenu.text=To HTML
 textUnitExportMenu.text=To Text
 # Clipboard Unit Export Menu
 clipboardUnitExportMenu.text=To Clipboard
+# Discord Clipboard Unit Export Menu
+discordClipboardUnitExportMenu.text=To Clipboard For Discord
 ## Print Menu
 printMenu.text=Print
 miPrintUnitQueue.text=Queue Units to Print...

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -20,6 +20,7 @@ import megamek.client.ui.dialogs.WeightDisplayDialog;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.common.*;
+import megamek.common.MechView.ViewFormatting;
 import megamek.common.annotations.Nullable;
 import megamek.common.loaders.BLKFile;
 import megamek.common.templates.TROView;
@@ -347,6 +348,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         exportMenu.add(createHTMLUnitExportMenu());
         exportMenu.add(createTextUnitExportMenu());
         exportMenu.add(createClipboardUnitExportMenu());
+        exportMenu.add(createDiscordClipboardUnitExportMenu());
 
         return exportMenu;
     }
@@ -413,7 +415,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         final JMenuItem miExportCurrentUnitToHTML = new JMenuItem(resources.getString("CurrentUnit.text"));
         miExportCurrentUnitToHTML.setName("miExportCurrentUnitToHTML");
         miExportCurrentUnitToHTML.setMnemonic(KeyEvent.VK_U);
-        miExportCurrentUnitToHTML.addActionListener(evt -> exportSummary(true));
+        miExportCurrentUnitToHTML.addActionListener(evt -> exportSummary(ViewFormatting.Html));
         miExportCurrentUnitToHTML.setEnabled(isUnitGui());
         htmlUnitExportMenu.add(miExportCurrentUnitToHTML);
 
@@ -431,7 +433,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         final JMenuItem miExportCurrentUnitToText = new JMenuItem(resources.getString("CurrentUnit.text"));
         miExportCurrentUnitToText.setName("miExportCurrentUnitToText");
         miExportCurrentUnitToText.setMnemonic(KeyEvent.VK_U);
-        miExportCurrentUnitToText.addActionListener(evt -> exportSummary(false));
+        miExportCurrentUnitToText.addActionListener(evt -> exportSummary(ViewFormatting.None));
         miExportCurrentUnitToText.setEnabled(isUnitGui());
         textUnitExportMenu.add(miExportCurrentUnitToText);
 
@@ -451,7 +453,29 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         miExportCurrentUnitToClipboard.setMnemonic(KeyEvent.VK_U);
         miExportCurrentUnitToClipboard.addActionListener(evt -> {
             warnOnInvalid();
-            StringSelection stringSelection = new StringSelection(entitySummaryText(false));
+            StringSelection stringSelection = new StringSelection(entitySummaryText(ViewFormatting.None));
+            Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, this);
+        });
+        miExportCurrentUnitToClipboard.setEnabled(isUnitGui());
+        clipboardUnitExportMenu.add(miExportCurrentUnitToClipboard);
+
+        return clipboardUnitExportMenu;
+    }
+
+    /**
+     * @return the created Clipboard Unit Export menu
+     */
+    private JMenu createDiscordClipboardUnitExportMenu() {
+        final JMenu clipboardUnitExportMenu = new JMenu(resources.getString("discordClipboardUnitExportMenu.text"));
+        clipboardUnitExportMenu.setName("discordClipboardUnitExportMenu");
+        clipboardUnitExportMenu.setMnemonic(KeyEvent.VK_D);
+
+        final JMenuItem miExportCurrentUnitToClipboard = new JMenuItem(resources.getString("CurrentUnit.text"));
+        miExportCurrentUnitToClipboard.setName("miExportCurrentUnitToClipboard");
+        miExportCurrentUnitToClipboard.setMnemonic(KeyEvent.VK_U);
+        miExportCurrentUnitToClipboard.addActionListener(evt -> {
+            warnOnInvalid();
+            StringSelection stringSelection = new StringSelection(entitySummaryText(ViewFormatting.Discord));
             Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, this);
         });
         miExportCurrentUnitToClipboard.setEnabled(isUnitGui());
@@ -1111,24 +1135,24 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         }
     }
 
-    private String entitySummaryText(boolean html) {
-        if (CConfig.getBooleanParam(CConfig.MISC_SUMMARY_FORMAT_TRO)) {
-            TROView view = TROView.createView(owner.getEntity(), html);
+    private String entitySummaryText(ViewFormatting formatting) {
+        if (CConfig.getBooleanParam(CConfig.MISC_SUMMARY_FORMAT_TRO) && formatting != ViewFormatting.Discord) {
+            TROView view = TROView.createView(owner.getEntity(), formatting);
             return view.processTemplate();
         } else {
-            MechView view = new MechView(owner.getEntity(), !html, false, html);
+            MechView view = new MechView(owner.getEntity(), formatting == ViewFormatting.None, false, formatting);
             return view.getMechReadout();
         }
     }
 
-    private void exportSummary(boolean html) {
+    private void exportSummary(ViewFormatting formatting) {
         warnOnInvalid();
 
         String unitName = owner.getEntity().getChassis() + ' ' + owner.getEntity().getModel();
 
         MMLFileChooser fileChooser = new MMLFileChooser();
         fileChooser.setDialogTitle(resources.getString("dialog.saveAs.title"));
-        fileChooser.setSelectedFile(new File(unitName + (html ? ".html" : ".txt")));
+        fileChooser.setSelectedFile(new File(unitName + (formatting == ViewFormatting.Html ? ".html" : ".txt")));
         int result = fileChooser.showSaveDialog(owner.getFrame());
         if ((result != JFileChooser.APPROVE_OPTION) || (fileChooser.getSelectedFile() == null)) {
             return;
@@ -1136,7 +1160,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
 
         try (FileOutputStream fos = new FileOutputStream(fileChooser.getSelectedFile());
              PrintStream ps = new PrintStream(fos)) {
-            ps.println(entitySummaryText(html));
+            ps.println(entitySummaryText(formatting));
         } catch (Exception ex) {
             PopupMessages.showFileWriteError(owner.getFrame(), ex.getMessage());
             LogManager.getLogger().error("", ex);

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -20,7 +20,7 @@ import megamek.client.ui.dialogs.WeightDisplayDialog;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.common.*;
-import megamek.common.MechView.ViewFormatting;
+import megamek.common.ViewFormatting;
 import megamek.common.annotations.Nullable;
 import megamek.common.loaders.BLKFile;
 import megamek.common.templates.TROView;
@@ -415,7 +415,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         final JMenuItem miExportCurrentUnitToHTML = new JMenuItem(resources.getString("CurrentUnit.text"));
         miExportCurrentUnitToHTML.setName("miExportCurrentUnitToHTML");
         miExportCurrentUnitToHTML.setMnemonic(KeyEvent.VK_U);
-        miExportCurrentUnitToHTML.addActionListener(evt -> exportSummary(ViewFormatting.Html));
+        miExportCurrentUnitToHTML.addActionListener(evt -> exportSummary(ViewFormatting.HTML));
         miExportCurrentUnitToHTML.setEnabled(isUnitGui());
         htmlUnitExportMenu.add(miExportCurrentUnitToHTML);
 
@@ -433,7 +433,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         final JMenuItem miExportCurrentUnitToText = new JMenuItem(resources.getString("CurrentUnit.text"));
         miExportCurrentUnitToText.setName("miExportCurrentUnitToText");
         miExportCurrentUnitToText.setMnemonic(KeyEvent.VK_U);
-        miExportCurrentUnitToText.addActionListener(evt -> exportSummary(ViewFormatting.None));
+        miExportCurrentUnitToText.addActionListener(evt -> exportSummary(ViewFormatting.NONE));
         miExportCurrentUnitToText.setEnabled(isUnitGui());
         textUnitExportMenu.add(miExportCurrentUnitToText);
 
@@ -453,7 +453,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         miExportCurrentUnitToClipboard.setMnemonic(KeyEvent.VK_U);
         miExportCurrentUnitToClipboard.addActionListener(evt -> {
             warnOnInvalid();
-            StringSelection stringSelection = new StringSelection(entitySummaryText(ViewFormatting.None));
+            StringSelection stringSelection = new StringSelection(entitySummaryText(ViewFormatting.NONE));
             Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, this);
         });
         miExportCurrentUnitToClipboard.setEnabled(isUnitGui());
@@ -475,7 +475,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         miExportCurrentUnitToClipboard.setMnemonic(KeyEvent.VK_U);
         miExportCurrentUnitToClipboard.addActionListener(evt -> {
             warnOnInvalid();
-            StringSelection stringSelection = new StringSelection(entitySummaryText(ViewFormatting.Discord));
+            StringSelection stringSelection = new StringSelection(entitySummaryText(ViewFormatting.DISCORD));
             Toolkit.getDefaultToolkit().getSystemClipboard().setContents(stringSelection, this);
         });
         miExportCurrentUnitToClipboard.setEnabled(isUnitGui());
@@ -1136,11 +1136,11 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
     }
 
     private String entitySummaryText(ViewFormatting formatting) {
-        if (CConfig.getBooleanParam(CConfig.MISC_SUMMARY_FORMAT_TRO) && formatting != ViewFormatting.Discord) {
+        if (CConfig.getBooleanParam(CConfig.MISC_SUMMARY_FORMAT_TRO) && formatting != ViewFormatting.DISCORD) {
             TROView view = TROView.createView(owner.getEntity(), formatting);
             return view.processTemplate();
         } else {
-            MechView view = new MechView(owner.getEntity(), formatting == ViewFormatting.None, false, formatting);
+            MechView view = new MechView(owner.getEntity(), formatting == ViewFormatting.NONE, false, formatting);
             return view.getMechReadout();
         }
     }
@@ -1152,7 +1152,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
 
         MMLFileChooser fileChooser = new MMLFileChooser();
         fileChooser.setDialogTitle(resources.getString("dialog.saveAs.title"));
-        fileChooser.setSelectedFile(new File(unitName + (formatting == ViewFormatting.Html ? ".html" : ".txt")));
+        fileChooser.setSelectedFile(new File(unitName + (formatting == ViewFormatting.HTML ? ".html" : ".txt")));
         int result = fileChooser.showSaveDialog(owner.getFrame());
         if ((result != JFileChooser.APPROVE_OPTION) || (fileChooser.getSelectedFile() == null)) {
             return;

--- a/megameklab/src/megameklab/ui/generalUnit/PreviewTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/PreviewTab.java
@@ -24,7 +24,7 @@ import megamek.client.ui.swing.MechViewPanel;
 import megamek.client.ui.swing.alphaStrike.ConfigurableASCardPanel;
 import megamek.client.ui.swing.calculationReport.FlexibleCalculationReport;
 import megamek.common.Entity;
-import megamek.common.MechView;
+import megamek.common.ViewFormatting;
 import megamek.common.alphaStrike.conversion.ASConverter;
 import megamek.common.templates.TROView;
 import megameklab.ui.EntitySource;
@@ -60,7 +60,7 @@ public class PreviewTab extends ITab {
         selectedUnit.recalculateTechAdvancement();
         TROView troView = null;
         try {
-            troView = TROView.createView(selectedUnit, MechView.ViewFormatting.Html);
+            troView = TROView.createView(selectedUnit, ViewFormatting.HTML);
         } catch (Exception e) {
             LogManager.getLogger().error("", e);
             // error unit didn't load right. this is bad news.

--- a/megameklab/src/megameklab/ui/generalUnit/PreviewTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/PreviewTab.java
@@ -24,6 +24,7 @@ import megamek.client.ui.swing.MechViewPanel;
 import megamek.client.ui.swing.alphaStrike.ConfigurableASCardPanel;
 import megamek.client.ui.swing.calculationReport.FlexibleCalculationReport;
 import megamek.common.Entity;
+import megamek.common.MechView;
 import megamek.common.alphaStrike.conversion.ASConverter;
 import megamek.common.templates.TROView;
 import megameklab.ui.EntitySource;
@@ -59,7 +60,7 @@ public class PreviewTab extends ITab {
         selectedUnit.recalculateTechAdvancement();
         TROView troView = null;
         try {
-            troView = TROView.createView(selectedUnit, true);
+            troView = TROView.createView(selectedUnit, MechView.ViewFormatting.Html);
         } catch (Exception e) {
             LogManager.getLogger().error("", e);
             // error unit didn't load right. this is bad news.


### PR DESCRIPTION
Closes #1513 

![image](https://github.com/MegaMek/megameklab/assets/29113974/b40bb1af-2bbc-43a3-bcd4-1f50ac438de2)

Currently just adapts the HTML formatting to Discord by applying bold and underline as appropriate, colors are technically supported but they're only used by the HTML export when the unit has damage.

Suggestions for sprinkling in additional colors welcome in a separate issue. 

Depends on MegaMek/megamek#5533