### PR TITLE
Don't print Edge abilities of pilots

### DIFF
--- a/megameklab/src/megameklab/printing/PrintEntity.java
+++ b/megameklab/src/megameklab/printing/PrintEntity.java
@@ -44,6 +44,7 @@ import java.util.*;
 import java.util.List;
 
 import static megamek.common.EquipmentType.*;
+import static megamek.common.options.PilotOptions.EDGE_ADVANTAGES;
 
 /**
  * Base class for printing Entity record sheets
@@ -261,6 +262,10 @@ public abstract class PrintEntity extends PrintRecordSheet {
                 PilotOptions spas = getEntity().getCrew().getOptions();
                 for (Enumeration<IOptionGroup> optionGroups = spas.getGroups(); optionGroups.hasMoreElements();) {
                     IOptionGroup optiongroup = optionGroups.nextElement();
+                    if (optiongroup.getKey().equals(EDGE_ADVANTAGES)) {
+                        // Don't print Edge abilities, only SPAs and Cybernetics
+                        continue;
+                    }
                     if (spas.count(optiongroup.getKey()) > 0) {
                         for (Enumeration<IOption> options = optiongroup.getOptions(); options.hasMoreElements();) {
                             IOption option = options.nextElement();


### PR DESCRIPTION
Now that edge abilities are all on by default, printing record sheets from a MUL looks like this: 
![image](https://github.com/MegaMek/megameklab/assets/29113974/dd2b4fff-5adb-4df6-8089-75f6fa9f2457)
