### PR TITLE
Fix to-hit modifier for pilot damage on aerospace record sheets.

### DIFF
--- a/megameklab/resources/megameklab/printing/reference/ControlRollTable.properties
+++ b/megameklab/resources/megameklab/printing/reference/ControlRollTable.properties
@@ -15,6 +15,7 @@ modifiers=Modifiers
 pilotDamage=Pilot damage
 crewDamage=Crew damage
 avionicsDamage=Avionics damage
+avionicsDestroyed=Avionics destroyed
 lifeSupportDamage=Life support damage
 aboveSafeThrust=Above safe thrust
 atmosphericOperations=Atmospheric operations

--- a/megameklab/src/megameklab/printing/reference/AeroToHitMods.java
+++ b/megameklab/src/megameklab/printing/reference/AeroToHitMods.java
@@ -78,9 +78,9 @@ public class AeroToHitMods extends ReferenceTable {
         addRow("", bundle.getString("excessThrust"), "+2");
         addRow("", bundle.getString("outOfControl"), "+2");
         if (entity.isFighter() && !entity.isSupportVehicle()) {
-            addRow("", bundle.getString("pilotDamage"), "+2");
+            addRow("", bundle.getString("pilotDamage"), "+1" + bundle.getString("perHit"));
         } else {
-            addRow("", bundle.getString("crewDamage"), "+2");
+            addRow("", bundle.getString("crewDamage"), "+1" + bundle.getString("perHit"));
         }
         if (entity instanceof Jumpship) {
             addRow("", bundle.getString("cicDamage"), "+2" + bundle.getString("perHit"));

--- a/megameklab/src/megameklab/printing/reference/ControlRollTable.java
+++ b/megameklab/src/megameklab/printing/reference/ControlRollTable.java
@@ -71,7 +71,8 @@ public class ControlRollTable extends ReferenceTable {
             addRow("", bundle.getString("pilotDamage"), "", "+1" + bundle.getString("perHit"));
         }
         addRow("", bundle.getString("avionicsDamage"), "", "+1" + bundle.getString("perHit"));
-        addRow("", bundle.getString("lifeSupportDamage"), "", "+1" + bundle.getString("perHit"));
+        addRow("", bundle.getString("avionicsDestroyed"), "", "+5");
+        addRow("", bundle.getString("lifeSupportDamage"), "", "+2");
         if (entity.getWalkMP() > 0) {
             addRow("", bundle.getString("aboveSafeThrust"), "", "+1");
         }


### PR DESCRIPTION
The optional reference tables on aerospace record sheets shows the hit modifier for pilot/crew damage as +2, but it should be +1/hit.