### PR TITLE
Fix 1533: Filter out space bomb artillery (only Arrow IV Bombs for now)

### DIFF
--- a/megameklab/src/megameklab/ui/infantry/CIFieldGunView.java
+++ b/megameklab/src/megameklab/ui/infantry/CIFieldGunView.java
@@ -14,10 +14,8 @@
 package megameklab.ui.infantry;
 
 import megamek.client.ui.models.XTableColumnModel;
-import megamek.common.AmmoType;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.WeaponType;
+import megamek.common.*;
+import megamek.common.weapons.artillery.ArrowIV;
 import megamek.common.weapons.artillery.ArtilleryCannonWeapon;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
 import megamek.common.weapons.autocannons.*;
@@ -42,7 +40,7 @@ import java.util.Enumeration;
 
 /**
  * Shows options for infantry field guns/field artillery
- * 
+ *
  * @author Neoancient
  */
 public class CIFieldGunView extends IView implements ActionListener {
@@ -301,10 +299,10 @@ public class CIFieldGunView extends IView implements ActionListener {
                 EquipmentTableModel equipModel = entry.getModel();
                 EquipmentType etype = equipModel.getType(entry.getIdentifier());
                 if ((nType == T_ALL)
-                        || ((nType == T_GUN) 
+                        || ((nType == T_GUN)
                                 && !(etype instanceof ArtilleryWeapon)
                                 && !(etype instanceof ArtilleryCannonWeapon))
-                        || ((nType == T_ARTILLERY) && etype instanceof ArtilleryWeapon)
+                        || ((nType == T_ARTILLERY) && etype instanceof ArtilleryWeapon && !(etype.hasFlag(AmmoType.F_SPACE_BOMB)))
                         || ((nType == T_ARTILLERY_CANNON) && etype instanceof ArtilleryCannonWeapon)
                         ) {
                     if (null != eSource.getTechManager()


### PR DESCRIPTION
Currently Arrow IV bombs are listed as a valid field artillery option for CI units (because they are, technically, artillery).

Fix filters out any artillery weapons that also have the Space Bomb flag (currently only the AIV bombs).

Testing:
- Manually checked CI field artillery options before and after fix.
- Ran all three projects' unit tests.

Close #1533 