### PR TITLE
Row shading for procedurally generated reference tables

### DIFF
--- a/megameklab/src/megameklab/printing/PrintRecordSheet.java
+++ b/megameklab/src/megameklab/printing/PrintRecordSheet.java
@@ -311,7 +311,6 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
         }
         subFonts((SVGDocument) getSVGDocument());
         subColorElements();
-        shadeTableRows();
         SVGGeneratorContext context = SVGGeneratorContext.createDefault(getSVGDocument());
         svgGenerator = new SVGGraphics2D(context, false);
         double ratio = Math.min(pageFormat.getImageableWidth() / (options.getPaperSize().pxWidth - 36),
@@ -335,6 +334,7 @@ public abstract class PrintRecordSheet implements Printable, IdConstants {
             }
         }
         processImage(pageIndex - firstPage, pageFormat);
+        shadeTableRows();
         return true;
     }
 

--- a/megameklab/src/megameklab/printing/reference/AeroToHitMods.java
+++ b/megameklab/src/megameklab/printing/reference/AeroToHitMods.java
@@ -36,13 +36,13 @@ public class AeroToHitMods extends ReferenceTable {
     }
 
     private void addMods() {
-        addRow(bundle.getString("range"), "", "");
+        addRow(SECTION_HEADER + bundle.getString("range"), "", "");
         addRow("", bundle.getString("short"), "+0");
         addRow("", bundle.getString("medium"), "+2");
         addRow("", bundle.getString("long"), "+4");
         addRow("", bundle.getString("extreme"), "+6");
 
-        addRow(bundle.getString("targetInterveningConditions"), "", "");
+        addRow(SECTION_HEADER + bundle.getString("targetInterveningConditions"), "", "");
         addRow("", bundle.getString("attackAgainstAft"), "+0");
         addRow("", bundle.getString("attackAgainstSide"), "+2");
         addRow("", bundle.getString("attackAgainstNose"), "+1");
@@ -74,7 +74,7 @@ public class AeroToHitMods extends ReferenceTable {
         }
         addRow("", bundle.getString("targetEvading"), bundle.getString("variable"));
 
-        addRow(bundle.getString("attackerConditions"), "", "");
+        addRow(SECTION_HEADER + bundle.getString("attackerConditions"), "", "");
         addRow("", bundle.getString("excessThrust"), "+2");
         addRow("", bundle.getString("outOfControl"), "+2");
         if (entity.isFighter() && !entity.isSupportVehicle()) {

--- a/megameklab/src/megameklab/printing/reference/ControlRollTable.java
+++ b/megameklab/src/megameklab/printing/reference/ControlRollTable.java
@@ -40,9 +40,9 @@ public class ControlRollTable extends ReferenceTable {
     }
 
     private void addMods() {
-        addRow(bundle.getString("situation"), "", "", "");
+        addRow(SECTION_HEADER + bundle.getString("situation"), "", "", "");
         if (entity.getWalkMP() > 0) {
-            addRow("", bundle.getString("movement"), "", "");
+            addRow(NO_SHADE, bundle.getString("movement"), "", "");
             if (atmosphereOnly) {
                 addRow("", "", bundle.getString("exceedCeiling"), "");
             }
@@ -56,14 +56,14 @@ public class ControlRollTable extends ReferenceTable {
                 addRow("", "", bundle.getString("descending3plus") + "", "");
             }
         }
-        addRow("", bundle.getString("damage"), "", "");
+        addRow(NO_SHADE, bundle.getString("damage"), "", "");
         addRow("", "", bundle.getString("avionicsCritical"), "");
         addRow("", "", bundle.getString("controlCritical"), "");
         if (!spaceOnly) {
             addRow("", "", bundle.getString("damagedInAtmosphere"), "");
         }
 
-        addRow(bundle.getString("modifiers"), "", "", "");
+        addRow(SECTION_HEADER + bundle.getString("modifiers"), "", "", "");
         if ((entity instanceof SmallCraft) || (entity instanceof Jumpship)
                 || entity.isSupportVehicle()) {
             addRow("", bundle.getString("crewDamage"), "", "+1" + bundle.getString("perHit"));

--- a/megameklab/src/megameklab/printing/reference/DrivingSkillRollMods.java
+++ b/megameklab/src/megameklab/printing/reference/DrivingSkillRollMods.java
@@ -40,20 +40,17 @@ public class DrivingSkillRollMods extends ReferenceTable {
     }
 
     private void addMods() {
-        addRow(bundle.getString("unitActions"), "", "", "");
+        addRow(SECTION_HEADER + bundle.getString("unitActions"), "", "", "");
         if (entity.getMovementMode().equals(EntityMovementMode.HOVER)
                 || entity.getMovementMode().equals(EntityMovementMode.VTOL)
                 || entity.getMovementMode().equals(EntityMovementMode.WIGE)) {
-            addRow("", bundle.getString("flankingMovement"), "",
+            addRow(NO_SHADE, bundle.getString("flankingMovement") + "\n" + bundle.getString("afterFacingChange"), "",
                     bundle.getString("possibleSideslip"));
-            addRow("", bundle.getString("afterFacingChange"), "", "");
-            addRow(bundle.getString("sideslipMovement"), "", "", "");
+            addRow(SECTION_HEADER + bundle.getString("sideslipMovement"), "", "", "");
         } else {
-            addRow("", bundle.getString("flankingMovement"), "",
+            addRow(NO_SHADE, bundle.getString("flankingMovement") + "\n" + bundle.getString("afterFacingChange") + "\n" + bundle.getString("onPavement"), "",
                     bundle.getString("possibleSkid"));
-            addRow("", bundle.getString("afterFacingChange"), "", "");
-            addRow("", bundle.getString("onPavement"), "", "");
-            addRow(bundle.getString("skiddingMovement"), "", "", "");
+            addRow(SECTION_HEADER + bundle.getString("skiddingMovement"), "", "", "");
         }
         addRow("", bundle.getString("hexesMovedInTurn"), "", "");
         addRow("", "", "0-2", "-1");
@@ -63,12 +60,12 @@ public class DrivingSkillRollMods extends ReferenceTable {
         addRow("", "", "11-17", "+3");
         addRow("", "", "18-24", "+4");
         addRow("", "", "25+", "+5");
-        addRow(bundle.getString("enteringLeavingBuilding"), "", "", "");
+        addRow(SECTION_HEADER + bundle.getString("enteringLeavingBuilding"), "", "", "");
         addRow("", bundle.getString("lightBuilding"), "", "0");
         addRow("", bundle.getString("mediumBuilding"), "", "+1");
         addRow("", bundle.getString("heavyBuilding"), "", "+2");
         addRow("", bundle.getString("hardenedBuilding"), "", "+3");
-        addRow("", bundle.getString("hexesMovedInTurn"), "", "");
+        addRow(SECTION_HEADER, bundle.getString("hexesMovedInTurn"), "", "");
         addRow("", "", "1-2", "0");
         addRow("", "", "3-4", "+1");
         addRow("", "", "5-6", "+2");

--- a/megameklab/src/megameklab/printing/reference/GroundToHitMods.java
+++ b/megameklab/src/megameklab/printing/reference/GroundToHitMods.java
@@ -51,7 +51,7 @@ public class GroundToHitMods extends ReferenceTable {
     }
 
     private void addMekAttackerMods() {
-        addRow(bundle.getString("attacker"), "", "");
+        addRow(SECTION_HEADER + bundle.getString("attacker"), "", "");
         addRow("", bundle.getString("stationary"), "+0");
         addRow("", bundle.getString("walked"), "+1");
         addRow("", bundle.getString("ran"), "+2");
@@ -70,7 +70,7 @@ public class GroundToHitMods extends ReferenceTable {
     }
 
     private void addVeeAttackerMods() {
-        addRow(bundle.getString("attacker"), "", "");
+        addRow(SECTION_HEADER + bundle.getString("attacker"), "", "");
         addRow("", bundle.getString("stationary"), "+0");
         addRow("", bundle.getString("cruised"), "+1");
         addRow("", bundle.getString("flanked"), "+2");
@@ -88,7 +88,7 @@ public class GroundToHitMods extends ReferenceTable {
     }
 
     private void addTerrainMods() {
-        addRow(bundle.getString("terrain"), "", "");
+        addRow(SECTION_HEADER + bundle.getString("terrain"), "", "");
         String hexName;
         if (CConfig.scaleUnits().equals(RSScale.HEXES)) {
             hexName = "hex";
@@ -102,7 +102,7 @@ public class GroundToHitMods extends ReferenceTable {
     }
 
     private void addTargetMods() {
-        addRow(bundle.getString("target"), "", "");
+        addRow(SECTION_HEADER + bundle.getString("target"), "", "");
         if (CConfig.scaleUnits().equals(RSScale.HEXES)) {
             addRow("", bundle.getString("proneAdjacent"), "-2");
         } else {
@@ -138,7 +138,7 @@ public class GroundToHitMods extends ReferenceTable {
     }
 
     private void addDamageMods() {
-        addRow(bundle.getString("damage"), "", "");
+        addRow(SECTION_HEADER + bundle.getString("damage"), "", "");
         addRow("", bundle.getString("sensorHit"), "+2");
         addRow("", bundle.getString("shoulderHit"), "+4");
         addRow("", bundle.getString("armActuator"), "+1");

--- a/megameklab/src/megameklab/printing/reference/MovementCost.java
+++ b/megameklab/src/megameklab/printing/reference/MovementCost.java
@@ -78,8 +78,8 @@ public class MovementCost extends ReferenceTable {
     }
 
     private void addGroundMods() {
-        addRow(bundle.getString("costToEnterAnyHex"), "", "", "1");
-        addRow(bundle.getString("terrainCost"), "", "", "");
+        addRow(SECTION_HEADER + bundle.getString("costToEnterAnyHex"), "", "", "1");
+        addRow(SECTION_HEADER + bundle.getString("terrainCost"), "", "", "");
         if (entity.isSupportVehicle() && !entity.hasMisc(MiscType.F_OFF_ROAD)) {
             addRow("", bundle.getString("clear"), "", "+1");
         } else {
@@ -135,19 +135,19 @@ public class MovementCost extends ReferenceTable {
             addRow("", bundle.getString("hardenedBuilding"), "", "+4");
         }
         if (entity.getMovementMode().equals(EntityMovementMode.VTOL)) {
-            addRow(bundle.getString("levelChangeUpOrDown"), "", "", bundle.getString("1perLevel"));
+            addRow(SECTION_HEADER + bundle.getString("levelChangeUpOrDown"), "", "", bundle.getString("1perLevel"));
         } else if ((entity instanceof Tank) || (entity instanceof Protomech)) {
-            addRow(bundle.getString("levelChangeUpOrDown"), "", "", "");
+            addRow(SECTION_HEADER + bundle.getString("levelChangeUpOrDown"), "", "", "");
             addRow("", bundle.getString("1level"), "",
                     (entity instanceof Protomech) ? "+1" : "+2");
             addRow("", bundle.getString("2plusLevels"), "", bundle.getString("prohibited"));
         } else {
-            addRow(bundle.getString("levelChangeUpOrDown"), "", "", "");
+            addRow(SECTION_HEADER + bundle.getString("levelChangeUpOrDown"), "", "", "");
             addRow("", bundle.getString("1level"), "", "+1");
             addRow("", bundle.getString("2levels"), "", "+2");
             addRow("", bundle.getString("3plusLevels"), "", bundle.getString("prohibited"));
         }
-        addRow(bundle.getString("additionalMovementActions"), "", "", "");
+        addRow(SECTION_HEADER + bundle.getString("additionalMovementActions"), "", "", "");
         addRow("", bundle.getString("facingChange"), "", bundle.getString("1perHexside"));
         if (entity instanceof Mech) {
             addRow("", bundle.getString("dropToGround"), "", "1");
@@ -164,30 +164,30 @@ public class MovementCost extends ReferenceTable {
     }
 
     private void addNavalMods() {
-        addRow(bundle.getString("water"), "", "", "");
+        addRow(SECTION_HEADER + bundle.getString("water"), "", "", "");
         addRow("", bundle.getString("depth0"), "", bundle.getString("prohibited"));
         addRow("", bundle.getString("depth1plus"), "", "1");
         if (entity.getMovementMode().equals(EntityMovementMode.SUBMARINE)) {
-            addRow(bundle.getString("levelChangeUpOrDown"), "", "", bundle.getString("1perLevel"));
+            addRow(SECTION_HEADER + bundle.getString("levelChangeUpOrDown"), "", "", bundle.getString("1perLevel"));
         }
-        addRow(bundle.getString("additionalMovementActions"), "", "", "");
+        addRow(SECTION_HEADER + bundle.getString("additionalMovementActions"), "", "", "");
         addRow("", bundle.getString("facingChange"), "", bundle.getString("1perHexside"));
     }
 
     private void addAerialMods() {
-        addRow(bundle.getString("costToEnterAirborne"), "", "", "1");
+        addRow(SECTION_HEADER + bundle.getString("costToEnterAirborne"), "", "", "1");
         addRow("", bundle.getString("woods"), "", bundle.getString("prohibited"));
         addRow("", "", bundle.getString("exceptAlongRoad"), "");
         addRow("", bundle.getString("building"), "", bundle.getString("prohibited"));
         if (entity.getMovementMode().equals(EntityMovementMode.VTOL)) {
-            addRow(bundle.getString("levelChangeUpOrDown"), "", "", bundle.getString("1perLevel"));
+            addRow(SECTION_HEADER + bundle.getString("levelChangeUpOrDown"), "", "", bundle.getString("1perLevel"));
         } else if (entity.getMovementMode().equals(EntityMovementMode.WIGE)) {
-            addRow(bundle.getString("levelChange"), "", "", "");
+            addRow(SECTION_HEADER + bundle.getString("levelChange"), "", "", "");
             addRow("", bundle.getString("up1level"), "", "+0");
             addRow("", bundle.getString("up2plusLevels"), "", bundle.getString("prohibited"));
             addRow("", bundle.getString("down1plusLevels"), "", "+0");
         }
-        addRow(bundle.getString("additionalMovementActions"), "", "", "");
+        addRow(SECTION_HEADER + bundle.getString("additionalMovementActions"), "", "", "");
         addRow("", bundle.getString("facingChange"), "", bundle.getString("1perHexside"));
         if (entity.getMovementMode().equals(EntityMovementMode.WIGE)) {
             addRow("", bundle.getString("liftOff"), "", "5");
@@ -196,11 +196,11 @@ public class MovementCost extends ReferenceTable {
     }
 
     private void addRailMods() {
-        addRow(bundle.getString("costToEnterAnyHex"), "", "", "1");
-        addRow(bundle.getString("maximumChange"), "", "",
+        addRow(SECTION_HEADER + bundle.getString("costToEnterAnyHex"), "", "", "1");
+        addRow(SECTION_HEADER + bundle.getString("maximumChange"), "", "",
                 entity.isSuperHeavy() ? "+/- 1 MP" : "+/- 2 MP");
         if (entity.isTractor()) {
-            addRow(bundle.getString("trailerWeight"), "", "", bundle.getString("cruiseMP"));
+            addRow(SECTION_HEADER + bundle.getString("trailerWeight"), "", "", bundle.getString("cruiseMP"));
             addRow("", "<=" + formatWeightThreshold(0.5), "", String.valueOf(entity.getWalkMP()));
             addRow("", "<=" + formatWeightThreshold(2.0), "",
                     String.valueOf(Math.max(2, entity.getWalkMP() - Math.min(3, entity.getWalkMP() * 2 / 3))));
@@ -247,10 +247,10 @@ public class MovementCost extends ReferenceTable {
         // This only includes ground mechanized
         int mechanizedCount = wheeledCount + hoverCount + trackedCount;
 
-        addRow(bundle.getString("move"), "", "", bundle.getString("cost"),
+        addRow(SECTION_HEADER + bundle.getString("move"), "", "", bundle.getString("cost"),
                 bundle.getString("prohibited"));
-        addRow(bundle.getString("costToEnterAnyHex"), "", "", "1");
-        addRow(bundle.getString("terrainCost"), "", "", "");
+        addRow(SECTION_HEADER + bundle.getString("costToEnterAnyHex"), "", "", "1");
+        addRow(SECTION_HEADER + bundle.getString("terrainCost"), "", "", "");
         addRow("", bundle.getString("clear"), "", "+0");
         addRow("", bundle.getString("paved"), "", "+0");
         addRow("", bundle.getString("road"), "", "+0");

--- a/megameklab/src/megameklab/printing/reference/ProtomekSpecialHitLocation.java
+++ b/megameklab/src/megameklab/printing/reference/ProtomekSpecialHitLocation.java
@@ -26,7 +26,7 @@ public class ProtomekSpecialHitLocation extends ReferenceTable {
     }
 
     private void addRows() {
-        addRow(bundle.getString("2d6Result"), bundle.getString("hitLocation"));
+        setHeaders(bundle.getString("2d6Result"), bundle.getString("hitLocation"));
         addRow("2", bundle.getString("mainGun"));
         addRow("3", bundle.getString("legs"));
         addRow("4", bundle.getString("legs"));

--- a/megameklab/src/megameklab/printing/reference/ReferenceTable.java
+++ b/megameklab/src/megameklab/printing/reference/ReferenceTable.java
@@ -147,7 +147,31 @@ public abstract class ReferenceTable extends ReferenceTableBase {
             g.appendChild(text);
             ypos += rowSpacing + lineHeight * (lineCount - 1);
         }
-        for (List<String> row : data) {
+
+        int rowParity = 0;
+
+        for (int i = 0, dataSize = data.size(); i < dataSize; i++) {
+            List<String> row = data.get(i);
+
+            boolean sectionHeader = false;
+            boolean noShade = false;
+            if (!row.isEmpty() && row.get(0).startsWith(SECTION_HEADER)) {
+                sectionHeader = true;
+                row.set(0, row.get(0).replace(SECTION_HEADER, ""));
+            }
+            if (!row.isEmpty() && row.get(0).startsWith(NO_SHADE)) {
+                noShade = true;
+                row.set(0, row.get(0).replace(NO_SHADE, ""));
+            }
+
+            if (sectionHeader || noShade) {
+                rowParity = (i + 1) % 2;
+            } else {
+                if (i % 2 == rowParity) {
+                    g.appendChild(createShadeElement(0, ypos - fontSize / 3 - rowSpacing / 2, width * 0.97, rowSpacing * lineCount(row)));
+                }
+            }
+
             for (int c = 0; c < row.size(); c++) {
                 if (c == colOffsets.size()) {
                     break;
@@ -155,7 +179,7 @@ public abstract class ReferenceTable extends ReferenceTableBase {
                 String[] lines = row.get(c).split("\\n");
                 for (int l = 0; l < lines.length; l++) {
                     g.appendChild(createTextElement(width * colOffsets.get(c), ypos + rowSpacing * l,
-                            lines[l], fontSize, fontWeight.getOrDefault(c, SVGConstants.SVG_NORMAL_VALUE),
+                            lines[l], fontSize, fontWeight.getOrDefault(c, sectionHeader ? SVGConstants.SVG_BOLD_VALUE : SVGConstants.SVG_NORMAL_VALUE),
                             PrintRecordSheet.FILL_BLACK, anchor.getOrDefault(c, defaultAnchor), false, null));
                 }
             }

--- a/megameklab/src/megameklab/printing/reference/ReferenceTableBase.java
+++ b/megameklab/src/megameklab/printing/reference/ReferenceTableBase.java
@@ -33,6 +33,15 @@ abstract public class ReferenceTableBase {
     private static final double STROKE_WIDTH = 1.6;
     static final double PADDING = 3.0;
 
+    /*
+     * If the first item of a table row starts with SECTION_HEADER, it will be skipped past in table shading and will be bolded
+     */
+    protected static final String SECTION_HEADER = "$SECT$";
+    /*
+     * If the first item of a table row starts with SECTION_HEADER, it will be skipped past in table shading
+     */
+    protected static final String NO_SHADE = "$NOSHADE$";
+
     protected final ResourceBundle bundle = ResourceBundle.getBundle(getClass().getName());
     final PrintRecordSheet sheet;
 
@@ -123,6 +132,20 @@ abstract public class ReferenceTableBase {
                     String.valueOf(textLength));
         }
         t.setTextContent(text);
+
+        return t;
+    }
+
+    protected Element createShadeElement(double x, double y, double width, double height) {
+        final Element t = sheet.getSVGDocument().createElementNS(svgNS, SVGConstants.SVG_RECT_TAG);
+        t.setAttribute(SVGConstants.SVG_X_ATTRIBUTE, String.valueOf(x));
+        t.setAttribute(SVGConstants.SVG_Y_ATTRIBUTE, String.valueOf(y));
+        t.setAttribute(SVGConstants.SVG_STYLE_ATTRIBUTE, "fill:#BBBBBB");
+        t.setAttribute(SVGConstants.SVG_WIDTH_ATTRIBUTE, String.valueOf(width));
+        t.setAttribute(SVGConstants.SVG_HEIGHT_ATTRIBUTE, String.valueOf(height));
+        t.setAttribute("class", "tableshading");
+        t.setAttribute(SVGConstants.SVG_ID_ATTRIBUTE, UUID.randomUUID().toString());
+
 
         return t;
     }


### PR DESCRIPTION
Previously row shading only existed for tables baked into the svgs of record sheet tables. 

This pr adds row shading for all the reference tables which are proceduraly generated. 

Care was taken to ensure the more unusually laid-out tables are shaded properly, but it's possible I missed something and will likely ask the QA testers to generate record sheets for all sorts of units and make sure they look ok with shading.

Shaded rows look like this:
![image](https://github.com/user-attachments/assets/686d34c2-08f9-4a6b-8fc5-6708203a25ac)

The example is for vehicles, but all unit types are supported. 