### PR TITLE
Replace vehicle fluff art with cluster table when condensed reference tables enabled

### DIFF
--- a/megameklab/resources/megameklab/printing/reference/ClusterHitsTable.properties
+++ b/megameklab/resources/megameklab/printing/reference/ClusterHitsTable.properties
@@ -1,5 +1,6 @@
 title=CLUSTER HITS TABLE
 dieRoll2d6=Die Roll\n(2D6)
+2d6=2D6
 artemisIV.note=Artemis IV FCS: +2
 artemisV.note=Artemis V FCS: +3
 artemisProto.note=Prototype Artemis FCS: +1

--- a/megameklab/src/megameklab/printing/PrintCompositeTankSheet.java
+++ b/megameklab/src/megameklab/printing/PrintCompositeTankSheet.java
@@ -205,7 +205,7 @@ public class PrintCompositeTankSheet extends PrintRecordSheet {
         } else {
             list.add(new NotesTable(this, 12));
         }
-        ClusterHitsTable table = new ClusterHitsTable(this, tank1);
+        ClusterHitsTable table = new ClusterHitsTable(this, tank1, false);
         if (table.required()) {
             list.add(table);
         }

--- a/megameklab/src/megameklab/printing/PrintMech.java
+++ b/megameklab/src/megameklab/printing/PrintMech.java
@@ -815,7 +815,7 @@ public class PrintMech extends PrintEntity {
         list.add(new PunchLocation(this));
         list.add(new KickLocation(this));
         list.add(new MekFallTable(this));
-        ClusterHitsTable table = new ClusterHitsTable(this);
+        ClusterHitsTable table = new ClusterHitsTable(this, false);
         if (table.required()) {
             list.add(table);
         }

--- a/megameklab/src/megameklab/printing/PrintSmallUnitSheet.java
+++ b/megameklab/src/megameklab/printing/PrintSmallUnitSheet.java
@@ -159,7 +159,7 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
             list.add(new AntiMekAttackTable(this));
             list.add(new SwarmAttackHitLocation(this));
         }
-        ClusterHitsTable table = new ClusterHitsTable(this, entities);
+        ClusterHitsTable table = new ClusterHitsTable(this, entities, false);
         if (table.required() && table.columnCount() <= 10) {
             list.add(table);
         }
@@ -169,7 +169,7 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
     @Override
     protected void addReferenceCharts(PageFormat pageFormat) {
         super.addReferenceCharts(pageFormat);
-        ClusterHitsTable clusterTable = new ClusterHitsTable(this, entities);
+        ClusterHitsTable clusterTable = new ClusterHitsTable(this, entities, false);
         if (clusterTable.columnCount() > 10) {
             printBottomTable(clusterTable, pageFormat);
         } else {

--- a/megameklab/src/megameklab/printing/PrintTank.java
+++ b/megameklab/src/megameklab/printing/PrintTank.java
@@ -19,6 +19,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.svg.SVGRectElement;
 
 import java.awt.*;
+import java.awt.geom.Rectangle2D;
 import java.awt.print.PageFormat;
 import java.io.File;
 import java.util.*;
@@ -192,13 +193,22 @@ public class PrintTank extends PrintEntity {
 
     @Override
     protected void drawFluffImage() {
-        Image fluffImage = getFluffImage();
-        if (null != fluffImage) {
-            Element rect = getSVGDocument().getElementById(FLUFF_IMAGE);
-            if (rect instanceof SVGRectElement) {
-                embedImage(fluffImage, (Element) rect.getParentNode(), getRectBBox((SVGRectElement) rect), true);
+        Element rect = getSVGDocument().getElementById(FLUFF_IMAGE);
+        if (rect instanceof SVGRectElement) {
+            if (!options.showCondensedReferenceCharts()) {
+                Image fluffImage = getFluffImage();
+                if (null != fluffImage) {
+                    embedImage(fluffImage, (Element) rect.getParentNode(), getRectBBox((SVGRectElement) rect), true);
+                    hideElement(getSVGDocument().getElementById(NOTES));
+                }
+            } else {
+                Rectangle2D bbox = getRectBBox((SVGRectElement) rect);
+                placeReferenceCharts(
+                        List.of(new ClusterHitsTable(this, true)),
+                        rect.getParentNode(), bbox.getX() - 3.0, bbox.getY() - 6.0,
+                        bbox.getWidth() + 6.0, bbox.getHeight() + 12.0);
+                hideElement(getSVGDocument().getElementById(NOTES));
             }
-            hideElement(getSVGDocument().getElementById(NOTES));
         }
     }
 
@@ -212,7 +222,7 @@ public class PrintTank extends PrintEntity {
         List<ReferenceTable> list = new ArrayList<>();
         list.add(new GroundToHitMods(this));
         list.add(new MovementCost(this));
-        ClusterHitsTable table = new ClusterHitsTable(this);
+        ClusterHitsTable table = new ClusterHitsTable(this, false);
         if (table.required()) {
             list.add(table);
         }

--- a/megameklab/src/megameklab/printing/PrintTank.java
+++ b/megameklab/src/megameklab/printing/PrintTank.java
@@ -202,9 +202,13 @@ public class PrintTank extends PrintEntity {
                     hideElement(getSVGDocument().getElementById(NOTES));
                 }
             } else {
+                var table = new ClusterHitsTable(this, true);
+                if (!table.required()) {
+                    return;
+                }
                 Rectangle2D bbox = getRectBBox((SVGRectElement) rect);
                 placeReferenceCharts(
-                        List.of(new ClusterHitsTable(this, true)),
+                        List.of(table),
                         rect.getParentNode(), bbox.getX() - 3.0, bbox.getY() - 6.0,
                         bbox.getWidth() + 6.0, bbox.getHeight() + 12.0);
                 hideElement(getSVGDocument().getElementById(NOTES));

--- a/megameklab/src/megameklab/printing/reference/ClusterHitsTable.java
+++ b/megameklab/src/megameklab/printing/reference/ClusterHitsTable.java
@@ -17,6 +17,9 @@ import megamek.common.*;
 import megamek.common.weapons.missiles.MissileWeapon;
 import megameklab.printing.PrintEntity;
 import megameklab.printing.PrintRecordSheet;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.*;
 
@@ -24,22 +27,26 @@ import java.util.*;
  * Table showing the relevant columns of the cluster hits table
  */
 public class ClusterHitsTable extends ReferenceTable {
+    private static final Logger log = LogManager.getLogger(ClusterHitsTable.class);
     protected final Set<Integer> clusterSizes = new TreeSet<>();
     protected boolean hasATM;
     protected boolean hasHAG;
+    protected boolean condensed;
 
-    public ClusterHitsTable(PrintEntity sheet) {
-        this(sheet, sheet.getEntity());
+    public ClusterHitsTable(PrintEntity sheet, boolean condensed) {
+        this(sheet, sheet.getEntity(), condensed);
     }
 
-    public ClusterHitsTable(PrintRecordSheet sheet, Entity entity) {
+    public ClusterHitsTable(PrintRecordSheet sheet, Entity entity, boolean condensed) {
         super(sheet);
+        this.condensed = condensed;
         calculateClusterSizes(entity);
         addTable(entity);
     }
 
-    public ClusterHitsTable(PrintRecordSheet sheet, List<Entity> entities) {
+    public ClusterHitsTable(PrintRecordSheet sheet, List<Entity> entities, boolean condensed) {
         super(sheet);
+        this.condensed = condensed;
         for (Entity en : entities) {
             calculateClusterSizes(en);
         }
@@ -59,7 +66,11 @@ public class ClusterHitsTable extends ReferenceTable {
             }
             setColOffsets(offsets);
             List<String> headers = new ArrayList<>();
-            headers.add(bundle.getString("dieRoll2d6"));
+            if (!condensed) {
+                headers.add(bundle.getString("dieRoll2d6"));
+            } else {
+                headers.add(bundle.getString("2d6"));
+            }
             for (int size : clusterSizes) {
                 headers.add(String.valueOf(size));
             }

--- a/megameklab/src/megameklab/printing/reference/MekLocationAndClusterTable.java
+++ b/megameklab/src/megameklab/printing/reference/MekLocationAndClusterTable.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class MekLocationAndClusterTable extends ClusterHitsTable {
 
     public MekLocationAndClusterTable(PrintEntity sheet) {
-        super(sheet);
+        super(sheet, true);
     }
 
     @Override


### PR DESCRIPTION
Similar to the current feature which replaces Mek fluff art with a table including hit location and cluster tables, this does a similar thing for vehicles.

Since vehicle sheets already come with hit location tables, this only includes cluster tables.

These look like this:

![image](https://github.com/user-attachments/assets/23692e6b-f7d8-4eac-8db2-57e9ffd3eb16)
