### PR TITLE
Add missing 'CHASSIS' key to some Thunderbolt MTF files

### DIFF
--- a/megameklab/data/mechfiles/mechs/3085u/Phoenix/Thunderbolt TDR-7SE.mtf
+++ b/megameklab/data/mechfiles/mechs/3085u/Phoenix/Thunderbolt TDR-7SE.mtf
@@ -167,7 +167,7 @@ history:The Thunderbolt, a BattleMech with a service record spanning over seven 
 
 manufacturer:Earthwerks Ltd.
 primaryfactory:Tikonov
-systemmanufacturer:Earthwerks TDR IIa Endo Steel
+systemmanufacturer:CHASSIS:Earthwerks TDR IIa Endo Steel
 systemmanufacturer:ENGINE:Magna 260
 systemmanufacturer:ARMOR:Starshield A
 systemmanufacturer:COMMUNICATIONS:Neil 8000 with ECM

--- a/megameklab/data/mechfiles/mechs/3085u/Phoenix/Thunderbolt TDR-9M.mtf
+++ b/megameklab/data/mechfiles/mechs/3085u/Phoenix/Thunderbolt TDR-9M.mtf
@@ -165,7 +165,7 @@ history:The Thunderbolt, a BattleMech with a service record spanning over seven 
 
 manufacturer:Earthwerks-FWL, Inc.
 primaryfactory:Keystone
-systemmanufacturer:Earthwerks TDR IIa Endo Steel
+systemmanufacturer:CHASSIS:Earthwerks TDR IIa Endo Steel
 systemmanufacturer:ENGINE:Magna 260
 systemmanufacturer:ARMOR:Ryerson 150 with CASE
 systemmanufacturer:JUMPJET:Chilton 465 Jump Jets

--- a/megameklab/data/mechfiles/mechs/3085u/Phoenix/Thunderbolt TDR-9NAIS.mtf
+++ b/megameklab/data/mechfiles/mechs/3085u/Phoenix/Thunderbolt TDR-9NAIS.mtf
@@ -167,7 +167,7 @@ history:The Thunderbolt, a BattleMech with a service record spanning over seven 
 
 manufacturer:Refit (NAIS)
 primaryfactory:New Avalon
-systemmanufacturer:Earthwerks TDR IIa Endo Steel
+systemmanufacturer:CHASSIS:Earthwerks TDR IIa Endo Steel
 systemmanufacturer:ENGINE:Vox 325 XL
 systemmanufacturer:ARMOR:Ryerson 150
 systemmanufacturer:COMMUNICATIONS:Neil 8000

--- a/megameklab/data/mechfiles/mechs/3085u/Phoenix/Thunderbolt TDR-9Nr.mtf
+++ b/megameklab/data/mechfiles/mechs/3085u/Phoenix/Thunderbolt TDR-9Nr.mtf
@@ -170,7 +170,7 @@ history:The Thunderbolt, a BattleMech with a service record spanning over seven 
 
 manufacturer:Refit
 primaryfactory:New Avalon	
-systemmanufacturer:Earthwerks TDR IIa Endo Steel
+systemmanufacturer:CHASSIS:Earthwerks TDR IIa Endo Steel
 systemmanufacturer:ENGINE:Vox 325 XL
 systemmanufacturer:ARMOR:Ryerson 150
 systemmanufacturer:COMMUNICATIONS:Neil 8000 with ECM

--- a/megameklab/data/mechfiles/mechs/3085u/Phoenix/Thunderbolt TDR-9T.mtf
+++ b/megameklab/data/mechfiles/mechs/3085u/Phoenix/Thunderbolt TDR-9T.mtf
@@ -168,7 +168,7 @@ history:The Thunderbolt, a BattleMech with a service record spanning over seven 
 
 manufacturer:Vandenberg Mechanized Industries
 primaryfactory:Pinard
-systemmanufacturer:Earthwerks TDR IIa Endo Steel
+systemmanufacturer:CHASSIS:Earthwerks TDR IIa Endo Steel
 systemmanufacturer:ENGINE:Magna 390 XL
 systemmanufacturer:ARMOR:Ryerson 150 with CASE
 systemmanufacturer:COMMUNICATIONS:Neil 8000

--- a/megameklab/data/mechfiles/mechs/Rec Guides ilClan/Vol 15/Thunderbolt TDR-7M.mtf
+++ b/megameklab/data/mechfiles/mechs/Rec Guides ilClan/Vol 15/Thunderbolt TDR-7M.mtf
@@ -170,7 +170,7 @@ history:The Thunderbolt, a BattleMech with a service record spanning over seven 
 
 manufacturer:Earthwerks-FWL, Inc.
 primaryfactory:Keystone
-systemmanufacturer:Earthwerks TDR IIa Endo Steel
+systemmanufacturer:CHASSIS:Earthwerks TDR IIa Endo Steel
 systemmanufacturer:ENGINE:Magna 260
 systemmanufacturer:ARMOR:Starshield A with CASE
 systemmanufacturer:COMMUNICATIONS:Neil 8000

--- a/megameklab/data/mechfiles/mechs/Rec Guides ilClan/Vol 15/Thunderbolt TDR-7S.mtf
+++ b/megameklab/data/mechfiles/mechs/Rec Guides ilClan/Vol 15/Thunderbolt TDR-7S.mtf
@@ -172,7 +172,7 @@ history:The Thunderbolt, a BattleMech with a service record spanning over seven 
 
 manufacturer:Trellshire Heavy Industries
 primaryfactory:Adelaide
-systemmanufacturer:Earthwerks TDR IIa Endo Steel
+systemmanufacturer:CHASSIS:Earthwerks TDR IIa Endo Steel
 systemmanufacturer:ENGINE:Magna 260
 systemmanufacturer:ARMOR:Starshield A with CASE II
 systemmanufacturer:COMMUNICATIONS:Neil 8000

--- a/megameklab/data/mechfiles/mechs/Rec Guides ilClan/Vol 15/Thunderbolt TDR-8M.mtf
+++ b/megameklab/data/mechfiles/mechs/Rec Guides ilClan/Vol 15/Thunderbolt TDR-8M.mtf
@@ -167,7 +167,7 @@ history:The Thunderbolt, a BattleMech with a service record spanning over seven 
 
 manufacturer:Earthwerks-FWL, Inc.
 primaryfactory:Keystone
-systemmanufacturer:Earthwerks TDR IIa Endo Steel
+systemmanufacturer:CHASSIS:Earthwerks TDR IIa Endo Steel
 systemmanufacturer:ENGINE:Magna 260
 systemmanufacturer:ARMOR:Starshield A with CASE
 systemmanufacturer:COMMUNICATIONS:Neil 8000


### PR DESCRIPTION
This PR adds the string `CHASSIS` to the `systemmanufacturer` key of the following MTF files:

* Thunderbolt_TDR-7M
* Thunderbolt_TDR-7S
* Thunderbolt_TDR-7SE
* Thunderbolt_TDR-8M
* Thunderbolt_TDR-9M
* Thunderbolt_TDR-9NAIS
* Thunderbolt_TDR-9Nr
* Thunderbolt_TDR-9T

I encountered this issue while working on my  [MTF to JSON converter](https://github.com/juk0de/mtf2json). Initially, I thought it was just an inconsistency, but these eight files are the only biped mech files missing the `CHASSIS` string. Therefore, I believe it is an ordinary bug, so I decided to fix it.