### PR TITLE
Fix clipping issues for small unit RS preview

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -22,6 +22,7 @@ package megameklab.ui.generalUnit;
 import megamek.common.Entity;
 import megameklab.printing.PaperSize;
 import megameklab.printing.PrintRecordSheet;
+import megameklab.printing.PrintSmallUnitSheet;
 import megameklab.printing.RecordSheetOptions;
 import megameklab.util.UnitPrintManager;
 import org.apache.batik.gvt.GraphicsNode;
@@ -117,16 +118,23 @@ public class RecordSheetPreviewPanel extends JPanel {
             PrintRecordSheet sheet = UnitPrintManager.createSheets(List.of(entity), true, options).get(0);
 
             // 5-pixel margin around rs
+            // Except for SmallUnitSheets which have weird clipping issues with nonstandard margin
             PageFormat pf = new PageFormat();
-            pf.setPaper(options.getPaperSize().createPaper(5, 5, 5, 5));
+            if (sheet instanceof PrintSmallUnitSheet) {
+                pf.setPaper(options.getPaperSize().createPaper());
+            }
+            else {
+                pf.setPaper(options.getPaperSize().createPaper(5, 5, 5, 5));
+            }
             sheet.createDocument(0, pf, true);
+
 
             GraphicsNode gn = sheet.build();
 
-            // Scale record sheet to the size of the panel, taking into account the 10 pixels taken up by margin
+            // Scale record sheet to the size of the panel
             var bounds = gn.getBounds();
-            var yscale = (height - 10) / bounds.getHeight();
-            var xscale = (width - 10) / bounds.getWidth();
+            var yscale = (height - 5) / bounds.getHeight();
+            var xscale = (width - 5) / bounds.getWidth();
             var scale = Math.min(yscale, xscale);
             gn.setTransform(AffineTransform.getScaleInstance(scale, scale));
 


### PR DESCRIPTION
The small unit sheet (Infantry, Battle Armor, and Protomechs) doesn't cope well with a nonstandard paper size. It gets cut off on the right side, and sometimes tables overlap with the unit blocks. 

This change uses standard margins for these unit types. This leads to an annoyingly large margin around the sheet, but it's better than straight up rendering wrong. 