### PR TITLE
Record sheet fixes and improvements

### DIFF
--- a/megameklab/resources/megameklab/resources/Dialogs.properties
+++ b/megameklab/resources/megameklab/resources/Dialogs.properties
@@ -34,8 +34,10 @@ ConfigurationDialog.chkProgressBar.text=Show progress bar during printing
 ConfigurationDialog.chkProgressBar.tooltip=Display a popup dialog that shows printing progress.
 ConfigurationDialog.chkShowReferenceTables.text=Print reference tables 
 ConfigurationDialog.chkShowReferenceTables.tooltip=Include quick reference tables on side and bottom of the record sheet.
-ConfigurationDialog.chkShowCondensedTables.text=Print Mech hit location and cluster tables instead of fluff image
-ConfigurationDialog.chkShowCondensedTables.tooltip=Include hit location and cluster hits tables in the space where the fluff image normally goes.
+ConfigurationDialog.chkShowCondensedTables.text=Replace optional elements with additional reference tables
+ConfigurationDialog.chkShowCondensedTables.tooltip=<html>Adds additional tables to certain unit types with unused space in their record sheet.<br/>\
+  Meks have their fluff art replaced with cluster and hit location tables, vehicles have their fluff art/notes box replaced with a cluster table.<br/>\
+  Infantry, BA, and ProtoMek sheets include a cluster table instead of blank space when there are few enough units on the sheet.</html>
 ConfigurationDialog.chkShowQuirks.text=Print design quirks
 ConfigurationDialog.chkShowQuirks.tooltip=Displays featured design quirks
 ConfigurationDialog.chkShowPilotData.text=Include pilot and force data when printing from a MUL

--- a/megameklab/src/megameklab/printing/PrintSmallUnitSheet.java
+++ b/megameklab/src/megameklab/printing/PrintSmallUnitSheet.java
@@ -230,7 +230,7 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
         if (numTypes > 1) {
             throw new IllegalArgumentException("Heterogeneous unit types are not supported");
         }
-        if (entities.get(0) instanceof BattleArmor || entities.get(0) instanceof Protomech) {
+        if ((entities.get(0) instanceof BattleArmor) || (entities.get(0) instanceof Protomech)) {
             return entities.size() > 4;
         }
         if (entities.get(0) instanceof Infantry) {

--- a/megameklab/src/megameklab/printing/PrintSmallUnitSheet.java
+++ b/megameklab/src/megameklab/printing/PrintSmallUnitSheet.java
@@ -16,12 +16,17 @@ package megameklab.printing;
 import megamek.client.ui.swing.util.FluffImageHelper;
 import megamek.common.*;
 import megameklab.printing.reference.*;
+import org.apache.batik.anim.dom.SVGLocatableSupport;
+import org.apache.batik.bridge.BridgeContext;
+import org.apache.batik.bridge.DocumentLoader;
+import org.apache.batik.bridge.GVTBuilder;
+import org.apache.batik.bridge.UserAgentAdapter;
 import org.w3c.dom.Element;
 import org.w3c.dom.svg.SVGRectElement;
 
 import java.awt.*;
+import java.awt.geom.Rectangle2D;
 import java.awt.print.PageFormat;
-import java.io.File;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -83,6 +88,8 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
         drawFluffImage();
         if (includeReferenceCharts()) {
             addReferenceCharts(pageFormat);
+        } else if (options.showCondensedReferenceCharts() && !fillsSheet(entities, options)) {
+            addClusterChart();
         }
     }
 
@@ -148,6 +155,7 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
         return options.showReferenceCharts();
     }
 
+
     @Override
     protected List<ReferenceTable> getRightSideReferenceTables() {
         List<ReferenceTable> list = new ArrayList<>();
@@ -174,7 +182,7 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
             printBottomTable(clusterTable, pageFormat);
         } else {
             printBottomTable(new GroundMovementRecord(this, false,
-                            entities.get(0) instanceof Protomech), pageFormat);
+                entities.get(0) instanceof Protomech), pageFormat);
         }
     }
 
@@ -182,5 +190,52 @@ public class PrintSmallUnitSheet extends PrintRecordSheet {
         getSVGDocument().getDocumentElement().appendChild(table.createTable(pageFormat.getImageableX(),
                 pageFormat.getImageableY() + pageFormat.getImageableHeight() * TABLE_RATIO + 3.0,
                 pageFormat.getImageableWidth() * TABLE_RATIO, pageFormat.getImageableHeight() * 0.2 - 3.0));
+    }
+
+    private void addClusterChart() {
+        Element g = getSVGDocument().getElementById("unit_" + entities.size());
+        if (g == null) {
+            return;
+        }
+
+        var table = new ClusterHitsTable(this, entities, true);
+        if (!table.required()) {
+            return;
+        }
+
+        var uaa = new UserAgentAdapter();
+        var loader = new DocumentLoader(uaa);
+        var ctx = new BridgeContext(uaa, loader);
+        ctx.setDynamicState(BridgeContext.DYNAMIC);
+        new GVTBuilder().build(ctx, getSVGDocument());
+
+        var dims = SVGLocatableSupport.getBBox(getSVGDocument().getElementById("unit_0"));
+
+        var bbox = new Rectangle2D.Double(0, 10, dims.getWidth() + 5, dims.getHeight() - 20);
+
+        g.appendChild(table.createTable(bbox));
+    }
+
+    /**
+     * Determines if the supplied list of units fills the sheet or if there's room for more
+     * @param entities The list of entities to place on the sheet
+     * @param options The record sheet options, as reference tables can reduce available space
+     * @return {@code true} if no more entities can be printed on a single sheet
+     */
+    public static boolean fillsSheet(List<? extends Entity> entities, RecordSheetOptions options) {
+        var numTypes = entities.stream().map(Entity::getClass).distinct().count();
+        if (numTypes == 0) {
+            return false;
+        }
+        if (numTypes > 1) {
+            throw new IllegalArgumentException("Heterogeneous unit types are not supported");
+        }
+        if (entities.get(0) instanceof BattleArmor || entities.get(0) instanceof Protomech) {
+            return entities.size() > 4;
+        }
+        if (entities.get(0) instanceof Infantry) {
+            return entities.size() > (options.showReferenceCharts() ? 2 : 3);
+        }
+        throw new IllegalArgumentException("Small unit sheet only supports CI, BA, and Protomeks");
     }
 }

--- a/megameklab/src/megameklab/printing/reference/ReferenceTable.java
+++ b/megameklab/src/megameklab/printing/reference/ReferenceTable.java
@@ -168,7 +168,7 @@ public abstract class ReferenceTable extends ReferenceTableBase {
                 rowParity = (i + 1) % 2;
             } else {
                 if (i % 2 == rowParity) {
-                    g.appendChild(createShadeElement(0, ypos - fontSize / 3 - rowSpacing / 2, width * 0.97, rowSpacing * lineCount(row)));
+                    g.appendChild(createShadeElement(1, ypos - fontSize / 3 - rowSpacing / 2, width - 5, rowSpacing * lineCount(row)));
                 }
             }
 

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -22,6 +22,7 @@ package megameklab.ui.generalUnit;
 import megamek.common.Entity;
 import megameklab.printing.PaperSize;
 import megameklab.printing.PrintRecordSheet;
+import megameklab.printing.PrintSmallUnitSheet;
 import megameklab.printing.RecordSheetOptions;
 import megameklab.util.UnitPrintManager;
 import org.apache.batik.gvt.GraphicsNode;
@@ -117,16 +118,23 @@ public class RecordSheetPreviewPanel extends JPanel {
             PrintRecordSheet sheet = UnitPrintManager.createSheets(List.of(entity), true, options).get(0);
 
             // 5-pixel margin around rs
+            // Except for SmallUnitSheets which have weird clipping issues with nonstandard margin
             PageFormat pf = new PageFormat();
-            pf.setPaper(options.getPaperSize().createPaper(5, 5, 5, 5));
+            if (sheet instanceof PrintSmallUnitSheet) {
+                pf.setPaper(options.getPaperSize().createPaper());
+            }
+            else {
+                pf.setPaper(options.getPaperSize().createPaper(5, 5, 5, 5));
+            }
             sheet.createDocument(0, pf, true);
+
 
             GraphicsNode gn = sheet.build();
 
-            // Scale record sheet to the size of the panel, taking into account the 10 pixels taken up by margin
+            // Scale record sheet to the size of the panel
             var bounds = gn.getBounds();
-            var yscale = (height - 10) / bounds.getHeight();
-            var xscale = (width - 10) / bounds.getWidth();
+            var yscale = (height - 5) / bounds.getHeight();
+            var xscale = (width - 5) / bounds.getWidth();
             var scale = Math.min(yscale, xscale);
             gn.setTransform(AffineTransform.getScaleInstance(scale, scale));
 

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -122,11 +122,12 @@ public class RecordSheetPreviewPanel extends JPanel {
             PageFormat pf = new PageFormat();
             if (sheet instanceof PrintSmallUnitSheet) {
                 pf.setPaper(options.getPaperSize().createPaper());
+                sheet.createDocument(0, pf, false);
             }
             else {
                 pf.setPaper(options.getPaperSize().createPaper(5, 5, 5, 5));
+                sheet.createDocument(0, pf, true);
             }
-            sheet.createDocument(0, pf, true);
 
 
             GraphicsNode gn = sheet.build();

--- a/megameklab/src/megameklab/util/UnitPrintManager.java
+++ b/megameklab/src/megameklab/util/UnitPrintManager.java
@@ -155,7 +155,7 @@ public class UnitPrintManager {
                     }
                 } else if (unit instanceof BattleArmor) {
                     baList.add((BattleArmor) unit);
-                    if (singlePrint || baList.size() > 4) {
+                    if (singlePrint || PrintSmallUnitSheet.fillsSheet(baList, options)) {
                         PrintRecordSheet prs = new PrintSmallUnitSheet(baList, pageCount, options);
                         pageCount += prs.getPageCount();
                         sheets.add(prs);
@@ -163,7 +163,7 @@ public class UnitPrintManager {
                     }
                 } else if (unit instanceof Infantry) {
                     infList.add((Infantry) unit);
-                    if (singlePrint || infList.size() > (options.showReferenceCharts() ? 2 : 3)) {
+                    if (singlePrint || PrintSmallUnitSheet.fillsSheet(infList, options)) {
                         PrintRecordSheet prs = new PrintSmallUnitSheet(infList, pageCount, options);
                         pageCount += prs.getPageCount();
                         sheets.add(prs);
@@ -171,7 +171,7 @@ public class UnitPrintManager {
                     }
                 } else if (unit instanceof Protomech) {
                     protoList.add((Protomech) unit);
-                    if (singlePrint || protoList.size() > 4) {
+                    if (singlePrint || PrintSmallUnitSheet.fillsSheet(protoList, options)) {
                         PrintRecordSheet prs = new PrintSmallUnitSheet(protoList, pageCount, options);
                         pageCount += prs.getPageCount();
                         sheets.add(prs);

--- a/megameklab/unittests/megameklab/printing/PrintSmallUnitSheetTest.java
+++ b/megameklab/unittests/megameklab/printing/PrintSmallUnitSheetTest.java
@@ -16,12 +16,6 @@ import static org.junit.jupiter.api.Assertions.*;
 class PrintSmallUnitSheetTest {
     private RecordSheetOptions noTables, yesTables;
 
-    @BeforeAll
-    static void before() {
-        // Has to be done so all types are populated for lookups
-        EquipmentType.initializeTypes();
-    }
-
     @BeforeEach
     void setUp() {
         noTables = new RecordSheetOptions();

--- a/megameklab/unittests/megameklab/printing/PrintSmallUnitSheetTest.java
+++ b/megameklab/unittests/megameklab/printing/PrintSmallUnitSheetTest.java
@@ -1,0 +1,81 @@
+package megameklab.printing;
+
+import megamek.common.*;
+import megameklab.testing.util.InitializeTypes;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(value = InitializeTypes.class)
+class PrintSmallUnitSheetTest {
+    private RecordSheetOptions noTables, yesTables;
+
+    @BeforeAll
+    static void before() {
+        // Has to be done so all types are populated for lookups
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() {
+        noTables = new RecordSheetOptions();
+        noTables.setReferenceCharts(false);
+        yesTables = new RecordSheetOptions();
+        yesTables.setReferenceCharts(true);
+    }
+
+    @Test
+    void fillsSheetProtomech() {
+        var entities = new ArrayList<>(List.of(new Protomech(), new Protomech(), new Protomech(), new Protomech()));
+        assertFalse(PrintSmallUnitSheet.fillsSheet(entities, noTables));
+        assertFalse(PrintSmallUnitSheet.fillsSheet(entities, yesTables));
+        entities.add(new Protomech());
+        assertTrue(PrintSmallUnitSheet.fillsSheet(entities, noTables));
+        assertTrue(PrintSmallUnitSheet.fillsSheet(entities, yesTables));
+    }
+
+    @Test
+    void fillsSheetBA() {
+        var entities = new ArrayList<>(List.of(new BattleArmor(), new BattleArmor(), new BattleArmor(), new BattleArmor()));
+        assertFalse(PrintSmallUnitSheet.fillsSheet(entities, noTables));
+        assertFalse(PrintSmallUnitSheet.fillsSheet(entities, yesTables));
+        entities.add(new BattleArmor());
+        assertTrue(PrintSmallUnitSheet.fillsSheet(entities, noTables));
+        assertTrue(PrintSmallUnitSheet.fillsSheet(entities, yesTables));
+    }
+
+    @Test
+    void fillsSheetCI() {
+        var entities = new ArrayList<>(List.of(new Infantry(), new Infantry()));
+        assertFalse(PrintSmallUnitSheet.fillsSheet(entities, noTables));
+        assertFalse(PrintSmallUnitSheet.fillsSheet(entities, yesTables));
+        entities.add(new Infantry());
+        assertFalse(PrintSmallUnitSheet.fillsSheet(entities, noTables));
+        assertTrue(PrintSmallUnitSheet.fillsSheet(entities, yesTables));
+        entities.add(new Infantry());
+        assertTrue(PrintSmallUnitSheet.fillsSheet(entities, noTables));
+        assertTrue(PrintSmallUnitSheet.fillsSheet(entities, yesTables));
+    }
+
+    @Test
+    void fillsSheetEmpty() {
+        var entities = List.<Entity>of();
+        assertFalse(PrintSmallUnitSheet.fillsSheet(entities, noTables));
+        assertFalse(PrintSmallUnitSheet.fillsSheet(entities, yesTables));
+    }
+
+    @Test
+    void fillsSheetIllegal() {
+        var heterogeneousEntities = List.of(new Infantry(), new BattleArmor());
+        assertThrows(IllegalArgumentException.class, () -> PrintSmallUnitSheet.fillsSheet(heterogeneousEntities, noTables));
+
+        var unsupportedEntities = List.of(new SupportTank());
+        assertThrows(IllegalArgumentException.class, () -> PrintSmallUnitSheet.fillsSheet(unsupportedEntities, noTables));
+    }
+}

--- a/megameklab/unittests/megameklab/testing/util/InitializeTypes.java
+++ b/megameklab/unittests/megameklab/testing/util/InitializeTypes.java
@@ -1,0 +1,17 @@
+package megameklab.testing.util;
+
+import megamek.common.EquipmentType;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class InitializeTypes implements BeforeAllCallback {
+    private static boolean initialized = false;
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        if (!initialized) {
+            initialized = true;
+            EquipmentType.initializeTypes();
+        }
+    }
+}

--- a/megameklab/unittests/megameklab/ui/util/EquipmentTableModelTest.java
+++ b/megameklab/unittests/megameklab/ui/util/EquipmentTableModelTest.java
@@ -2,12 +2,14 @@ package megameklab.ui.util;
 
 import megamek.common.*;
 import megamek.common.loaders.EntityLoadingException;
+import megameklab.testing.util.InitializeTypes;
 import megameklab.ui.EntitySource;
 import megameklab.ui.fighterAero.ASMainUI;
 import megameklab.ui.generalUnit.BasicInfoView;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -17,17 +19,12 @@ import java.util.Collections;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(value = InitializeTypes.class)
 class EquipmentTableModelTest {
 
     private BasicInfoView techManager;
     private EntitySource eSource;
     private EquipmentTableModel etm;
-
-    @BeforeAll
-    static void before() {
-        // Has to be done so all types are populated for lookups
-        EquipmentType.initializeTypes();
-    }
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
This PR collects several bug fixes and improvements that are somewhat related which I worked on at the same time.

- Row shading for tables looks better, the shading is now centered within the table.
- Record sheet preview for small units (CI/BA/Protos) was fixed to not cut off the right edge of the sheet.
- The option to replace mek fluff art with tables has been reworded to indicate it works on more than just meks.
- Small units will now include a cluster table instead of empty space when there aren't enough units to fill a whole sheet.
- The code that detects when a small unit sheet is full has been factored out into its own method and given unit tests.