### PR TITLE
Add toggle for RS adjusted BV printing, and set default export filename

### DIFF
--- a/megameklab/src/megameklab/util/UnitPrintManager.java
+++ b/megameklab/src/megameklab/util/UnitPrintManager.java
@@ -76,23 +76,14 @@ public class UnitPrintManager {
             return;
         }
 
-        // Dummy player and game allow bonus BV from C3 and TAG to be calculated
-        Game g = new Game();
-        Player p = new Player(1, "Nobody");
-        for (Entity e : loadedUnits) {
-            e.setOwner(p);
-            g.addEntity(e);
-            C3Util.wireC3(g, e);
-        }
-
-        new PrintQueueDialog(parent, printToPdf, loadedUnits, true).setVisible(true);
+        new PrintQueueDialog(parent, printToPdf, loadedUnits, true, f.getSelectedFile().getName()).setVisible(true);
     }
 
     public static File getExportFile(Frame parent) {
         return getExportFile(parent, "");
     }
 
-    private static File getExportFile(Frame parent, String suggestedFileName) {
+    public static File getExportFile(Frame parent, String suggestedFileName) {
         JFileChooser f = new JFileChooser(System.getProperty("user.dir"));
         f.setLocation(parent.getLocation().x + 150, parent.getLocation().y + 100);
         f.setDialogTitle("Choose export file name");


### PR DESCRIPTION
Closes #1581.

This PR contains two features:
 - When exporting from MUL to PDF, prefill the name of the pdf with the name of the mul file.
 - Add a checkbox to the print queue dialog when printing from MUL to adjust the BV displayed on the record sheet for force modifiers like TAG and C3. BV is _always_ adjusted for pilot skill regardless of this checkbox.