### PR TITLE
Fix 1588: NPE printing or previewing DropShip

### DIFF
--- a/megameklab/src/megameklab/printing/PrintAero.java
+++ b/megameklab/src/megameklab/printing/PrintAero.java
@@ -26,10 +26,9 @@ import org.w3c.dom.svg.SVGRectElement;
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
 import java.awt.print.PageFormat;
-import java.io.File;
 import java.text.DecimalFormat;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -126,8 +125,12 @@ public class PrintAero extends PrintEntity {
         super.writeTextFields();
         setTextField(HS_TYPE, formatHeatSinkType());
         setTextField(HS_COUNT, formatHeatSinkCount());
-        setTextField(ENGINE_TYPE, aero.getEngine().getShortEngineName()
+        if (aero.getEngine() != null) {
+            setTextField(ENGINE_TYPE, aero.getEngine().getShortEngineName()
                 .replaceAll("\\[.*]", "").trim());
+        } else {
+            setTextField(ENGINE_TYPE, "Unknown");
+        }
     }
 
     @Override

--- a/megameklab/unittests/megameklab/printing/PrintSmallUnitSheetTest.java
+++ b/megameklab/unittests/megameklab/printing/PrintSmallUnitSheetTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.awt.print.PageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -71,5 +72,29 @@ class PrintSmallUnitSheetTest {
 
         var unsupportedEntities = List.of(new SupportTank());
         assertThrows(IllegalArgumentException.class, () -> PrintSmallUnitSheet.fillsSheet(unsupportedEntities, noTables));
+    }
+
+    /**
+     * Verify that we can process the image (basically, create the record sheet output) for an Aero with a null Engine object
+     * without throwing an NPE.
+     */
+    @Test
+    void testAeroWithoutEngineDoesNotThrowNPE() {
+        // Required setting objects
+        PageFormat pf = new PageFormat();
+        RecordSheetOptions rso = new RecordSheetOptions();
+
+        // Set up DS entity with required attributes
+        Dropship testDS = new Dropship();
+        testDS.setChassis("Test Dropship");
+        testDS.setModel("TDS-999");
+
+        // Create print object
+        PrintAero pa = new PrintDropship(testDS, 1, rso);
+
+        // Test A) Document is created, B) Engine is null, C) processImage() doesn't throw.
+        assertTrue(pa.createDocument(1, pf, false));
+        assertNull(testDS.getEngine());
+        pa.processImage(1, pf);
     }
 }


### PR DESCRIPTION
Adds a safety check for the MML print code to prevent an NPE when an Aerospace unit's Engine isn't populated.
This _shouldn't_ happen, and is nominally controlled by MM code, but if it _does_, there's no real reason not to populate the sheet:

- DropShips don't even show the Engine info line,
- ASFs do, but it's informational, not functional

Testing:
- Ran checks with provided DS .blk files
- Ran all 3 projects' unit tests
- Added a unit test to confirm proper functionality in the above case.

Close #1588 