### PR TITLE
Better display of radical heat sinking in RS

### DIFF
--- a/megameklab/src/megameklab/printing/PrintEntity.java
+++ b/megameklab/src/megameklab/printing/PrintEntity.java
@@ -101,7 +101,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
      */
     protected String heatProfileText() {
         int heat = getEntity().getEquipment().stream().mapToInt(m -> m.getType().getHeat()).sum();
-        return "Total Heat (Dissipation): " + heat + " (" + getEntity().getHeatCapacity() + ")";
+        return "Total Heat (Dissipation): " + heat + " (" + getEntity().formatHeat() + ")";
     }
 
     /**


### PR DESCRIPTION
Closes #1584.
Requires MegaMek/megamek#6033.

When a unit mounts optional heat sinking equipment (Coolant Pods, Radical Heat Sinks), the heat profile is unhelpful: the given Dissipation value is never actually correct, since it's an approximate average between the dissipation with the system on or off.

This PR makes the sheet display both the heat value with the system off, and with the system on.

Since official sheets do not use the Heat Profile record sheet option, this change does not affect official sheets.

Example sheets:

![image](https://github.com/user-attachments/assets/12285a2c-e52f-49a7-950f-6721f6185a5e)
![image](https://github.com/user-attachments/assets/2f2370c9-871c-4151-bc64-841186b01d90)
![image](https://github.com/user-attachments/assets/d6502bf9-c7ac-4e11-a4f5-4f80567e44b8)
