### PR TITLE
Print SPAs in record sheets printed from MUL

### DIFF
--- a/megameklab/src/megameklab/util/UnitPrintManager.java
+++ b/megameklab/src/megameklab/util/UnitPrintManager.java
@@ -35,10 +35,14 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.common.*;
+import megamek.common.options.GameOptions;
 import megamek.logging.MMLogger;
 import megameklab.printing.*;
 import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
 import megameklab.ui.dialog.PrintQueueDialog;
+
+import static megamek.common.options.OptionsConstants.RPG_MANEI_DOMINI;
+import static megamek.common.options.OptionsConstants.RPG_PILOT_ADVANTAGES;
 
 public class UnitPrintManager {
     private static final MMLogger logger = MMLogger.create(UnitPrintManager.class);
@@ -75,7 +79,11 @@ public class UnitPrintManager {
         }
         Vector<Entity> loadedUnits;
         try {
-            loadedUnits = new MULParser(f.getSelectedFile(), null).getEntities();
+            var options = new GameOptions();
+            options.initialize();
+            options.getOption(RPG_MANEI_DOMINI).setValue(true);
+            options.getOption(RPG_PILOT_ADVANTAGES).setValue(true);
+            loadedUnits = new MULParser(f.getSelectedFile(), options).getEntities();
             loadedUnits.trimToSize();
         } catch (Exception ex) {
             logger.error("", ex);


### PR DESCRIPTION
This seems to be a feature that previously existed in MML, but at some point got broken.

When including pilot data when printing from a MUL, print the unit's SPAs in the Warrior Data box.
![image](https://github.com/user-attachments/assets/9338ba66-379c-45ca-b665-bbac68be9cd7)

This has no impact on official sheets, since official sheets don't include warrior data.