### PR TITLE
Fix exporting MUL files from MML

### DIFF
--- a/megameklab/src/megameklab/ui/dialog/PrintQueueDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/PrintQueueDialog.java
@@ -238,6 +238,9 @@ public class PrintQueueDialog extends AbstractMMLButtonDialog {
         Game g = new Game();
         Player p = new Player(1, "Nobody");
         for (Entity e : getEntities()) {
+            if (e.getId() == -1) {
+                e.setId(g.getNextEntityId());
+            }
             e.setOwner(p);
             g.addEntity(e);
             C3Util.wireC3(g, e);


### PR DESCRIPTION
Previously units created in MML were not given IDs, which created problems when those units were added to a game for MUL file export.