### PR TITLE
Set techlevel of armor in specific location, not entire mek, when setting patchwork armor

### DIFF
--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -1377,13 +1377,10 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
                             + ". Resetting to Standard Armor in this location.",
                     "Error",
                     JOptionPane.INFORMATION_MESSAGE);
-            getEntity().setArmorType(
-                    getMek().isIndustrial() ? EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL : EquipmentType.T_ARMOR_STANDARD,
-                    location);
-            getEntity().setArmorTechLevel(TechConstants.T_INTRO_BOXSET);
+            UnitUtil.resetArmor(getMek(), location);
         } else {
             getMek().setArmorType(armor.getArmorType(), location);
-            getMek().setArmorTechLevel(armor.getTechLevel(getTechManager().getGameYear(), armor.isClan()));
+            getMek().setArmorTechLevel(armor.getTechLevel(getTechManager().getGameYear(), armor.isClan()), location);
             for (; crits > 0; crits--) {
                 try {
                     getMek().addEquipment(Mounted.createMounted(getMek(), armor), location, false);


### PR DESCRIPTION
Requires MegaMek/megamek#6078 to produce correct mixed-tech patchwork armor mtfs.

Currently, setting the armor in one location sets the armor tech level of _every_ location, creating situations where we try to load a unit with Heavy Ferro-Fibrous (Clan) and other nonsense armors.