### PR TITLE
Add RISC Heat Sink Override Kit

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -203,6 +203,9 @@ HeatSinkView.lblCritFree.text=Engine Free:
 HeatSinkView.lblCritFree.tooltip=<html>These heat sinks are an integral part of the engine and do not have to be assigned critical space.<br/>Omni units must assign critical space to any pod-mounted heat sinks even if they would be part of the engine in standard Meks.</html>
 HeatSinkView.lblWeightFree.text=Weight Free:
 HeatSinkView.lblWeightFree.tooltip=<html>These heat sinks are included in the weight of the engine.</html>
+HeatSinkView.lblRiscHeatSinkKit.text=RISC Heat Sink Override Kit:
+HeatSinkView.lblRiscHeatSinkKit.tooltip=<html>Reduces chance of heat-induced shutdown. IO:AE p86.<br/>\
+  Construction only, not implemented for gameplay in MegaMek.</html>
 
 ArmorView.cbArmorType.text=Armor Type:
 ArmorView.cbArmorType.tooltip=The type of armor determines the amount of protection per ton and the amount of space required. Some armors provide additional special abilities.

--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -264,8 +264,7 @@ public class InventoryWriter {
         if (sheet.getEntity() instanceof Mek mek && mek.hasRiscHeatSinkOverrideKit()) {
             var mounted = new MiscMounted(sheet.getEntity(), new MiscType() {{
                 name = "RISC Heat Sink Override Kit";
-                // todo: find out (from CGL?) what a good shortName is
-                shortName = "RISC Heat Sink Override Kit";
+                shortName = "RISC HS Override Kit";
                 internalName = "RISC Heat Sink Override Kit";
             }});
             equipment.add(new StandardInventoryEntry(mounted));

--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -267,6 +267,7 @@ public class InventoryWriter {
                 shortName = "RISC HS Override Kit";
                 internalName = "RISC Heat Sink Override Kit";
             }});
+            mounted.setLocation(Mek.LOC_NONE);
             equipment.add(new StandardInventoryEntry(mounted));
         }
     }

--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -32,6 +32,7 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import megamek.common.equipment.MiscMounted;
 import org.apache.batik.util.SVGConstants;
 import org.w3c.dom.Element;
 import org.w3c.dom.svg.SVGRectElement;
@@ -259,6 +260,15 @@ public class InventoryWriter {
             } else {
                 same.incrementQty();
             }
+        }
+        if (sheet.getEntity() instanceof Mek mek && mek.hasRiscHeatSinkOverrideKit()) {
+            var mounted = new MiscMounted(sheet.getEntity(), new MiscType() {{
+                name = "RISC Heat Sink Override Kit";
+                // todo: find out (from CGL?) what a good shortName is
+                shortName = "RISC Heat Sink Override Kit";
+                internalName = "RISC Heat Sink Override Kit";
+            }});
+            equipment.add(new StandardInventoryEntry(mounted));
         }
     }
 
@@ -933,12 +943,12 @@ public class InventoryWriter {
                     }
                     bayCapacityString.append(NumberFormat.getInstance().format(capacity));
                     if ((i + 1) < bays.size()) {
-                        bayTypeString.append("/");
-                        bayCapacityString.append("/");
+                        bayTypeString.append('/');
+                        bayCapacityString.append('/');
                     }
                     doors = Math.max(doors, b.getDoors());
                 }
-                bayCapacityString.append(")");
+                bayCapacityString.append(')');
                 String bayString = "Bay " + bayNum + ": " + bayTypeString
                         + bayCapacityString + " (" + doors + (doors == 1 ? " Door)" : " Doors)");
                 sheet.addTextElement(canvas, bayColX[0], currY, bayString, fontSize,

--- a/megameklab/src/megameklab/printing/StandardInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/StandardInventoryEntry.java
@@ -323,6 +323,9 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
     }
 
     private String formatLocation() {
+        if (mount.getLocation() == Entity.LOC_NONE) {
+            return DASH;
+        }
         if ((mount.getEntity() instanceof Tank)
                 && mount.getLocation() == Tank.LOC_TURRET
                 && !((Tank) mount.getEntity()).hasNoDualTurret()) {

--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -28,9 +28,7 @@ import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import javax.swing.JLabel;
-import javax.swing.JSpinner;
-import javax.swing.SpinnerNumberModel;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -94,6 +92,9 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     private final JLabel lblCritFreeCount = new JLabel();
     private final JLabel lblWeightFreeText = new JLabel();
     private final JLabel lblWeightFreeCount = new JLabel();
+    private final JLabel lblRiscHeatSinkKit = new JLabel();
+    private final JCheckBox chkRiscHeatSinkKit = new JCheckBox();
+
 
     private final SpinnerNumberModel countModel = new SpinnerNumberModel(0, 0, null, 1);
     private final SpinnerNumberModel baseCountModel = new SpinnerNumberModel(0, 0, null, 1);
@@ -142,6 +143,8 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         add(spnCount, gbc);
         spnCount.addChangeListener(this);
 
+        gbc.gridx = 2;
+        add(new JLabel("<html>&nbsp;</html>"), gbc);
         gbc.gridx = 3;
         lblCritFreeText.setText(resourceMap.getString("HeatSinkView.lblCritFree.text"));
         add(lblCritFreeText, gbc);
@@ -177,10 +180,31 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         lblWeightFreeCount.setToolTipText(resourceMap.getString("HeatSinkView.lblWeightFree.tooltip"));
         add(lblWeightFreeCount, gbc);
 
+
+        lblRiscHeatSinkKit.setText(resourceMap.getString("HeatSinkView.lblRiscHeatSinkKit.text"));
+        lblRiscHeatSinkKit.setToolTipText(resourceMap.getString("HeatSinkView.lblRiscHeatSinkKit.tooltip"));
+        chkRiscHeatSinkKit.setToolTipText(resourceMap.getString("HeatSinkView.lblRiscHeatSinkKit.tooltip"));
+        lblRiscHeatSinkKit.setVisible(false);
+        chkRiscHeatSinkKit.setVisible(false);
+        gbc.gridx = 0;
+        gbc.gridy++;
+        add(lblRiscHeatSinkKit, gbc);
+        gbc.gridx = GridBagConstraints.RELATIVE;
+        add(chkRiscHeatSinkKit, gbc);
+        chkRiscHeatSinkKit.addActionListener(this);
+
     }
 
     private String getDisplayName(int index) {
         return isAero ? aeroDisplayNames[index] : MekDisplayNames[index];
+    }
+
+    private void showRiscKit(boolean show) {
+        chkRiscHeatSinkKit.setVisible(show);
+        lblRiscHeatSinkKit.setVisible(show);
+        if (!show) {
+            chkRiscHeatSinkKit.setSelected(false);
+        }
     }
 
     public void setFromMek(Mek mek) {
@@ -224,6 +248,11 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         spnPrototypeCount.addChangeListener(this);
         lblCritFreeCount.setText(String.valueOf(UnitUtil.getCriticalFreeHeatSinks(mek, isCompact)));
         lblWeightFreeCount.setText(String.valueOf(mek.getEngine().getWeightFreeEngineHeatSinks()));
+
+        showRiscKit(techManager.isLegal(Mek.getRiscHeatSinkOverrideKitAdvancement()));
+        if (mek.hasRiscHeatSinkOverrideKit()) {
+            chkRiscHeatSinkKit.setSelected(true);
+        }
     }
 
     public void setFromAero(Aero aero) {
@@ -258,6 +287,8 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         spnPrototypeCount.setVisible(false);
         lblCritFreeText.setVisible(false);
         lblCritFreeCount.setVisible(false);
+
+        showRiscKit(false);
     }
 
     public void refresh() {
@@ -287,6 +318,8 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         if (cbHSType.getSelectedIndex() < 0) {
             cbHSType.setSelectedIndex(0);
         }
+
+        showRiscKit(techManager.isLegal(Mek.getRiscHeatSinkOverrideKitAdvancement()) && !isAero);
     }
 
     public int getHeatSinkIndex() {
@@ -333,6 +366,8 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     public void actionPerformed(ActionEvent e) {
         if (e.getSource() == cbHSType) {
             reportChange();
+        } else if (e.getSource() == chkRiscHeatSinkKit) {
+            listeners.forEach(l -> l.riscHeatSinkOverrideKitChanged(chkRiscHeatSinkKit.isSelected()));
         }
     }
 

--- a/megameklab/src/megameklab/ui/listeners/BuildListener.java
+++ b/megameklab/src/megameklab/ui/listeners/BuildListener.java
@@ -56,7 +56,7 @@ public interface BuildListener {
      * Notifies of a change of the manually entered BV. When manualBV is 0 or less,
      * the unit
      * should be set to not use a manual BV value and the manual BV set to -1.
-     * 
+     *
      * @param manualBV The entered manual BV; may be invalid (0 or less)
      */
     void manualBVChanged(int manualBV);
@@ -75,7 +75,7 @@ public interface BuildListener {
 
     /**
      * Notifies of a change in heat sink type or count for aerospace units
-     * 
+     *
      * @param index Either
      *              {@link megameklab.ui.generalUnit.HeatSinkView#TYPE_SINGLE} or
      *              {@link megameklab.ui.generalUnit.HeatSinkView#TYPE_DOUBLE_AERO}
@@ -86,7 +86,7 @@ public interface BuildListener {
 
     /**
      * Notifies of a change in heat sink type or count for meks
-     * 
+     *
      * @param hsType The type of heat sink
      * @param count  The total number of heat sinks
      */
@@ -97,7 +97,7 @@ public interface BuildListener {
      * Notifies of a change in the distribution between single and double heat sinks
      * on a unit with
      * prototype double heat sinks.
-     * 
+     *
      * @param prototype The number of prototype double heat sinks
      */
     default void redistributePrototypeHS(int prototype) {
@@ -106,10 +106,17 @@ public interface BuildListener {
     /**
      * Notifies of a change in the number of heat sinks that are part of the base
      * chassis of an omni unit
-     * 
+     *
      * @param count The number of fixed heat sinks
      */
     default void heatSinkBaseCountChanged(int count) {
+    }
+
+    /**
+     * Notifies of a change in the presence of a RISC Heat Sink Override Kit
+     * @param hasKit True if the unit now has the kit
+     */
+    default void riscHeatSinkOverrideKitChanged(boolean hasKit) {
     }
 
     // For aerospace units and support vehicles

--- a/megameklab/src/megameklab/ui/mek/BMChassisView.java
+++ b/megameklab/src/megameklab/ui/mek/BMChassisView.java
@@ -609,6 +609,8 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
         chkFullHeadEject.addActionListener(this);
     }
 
+
+
     public List<Engine> getAvailableEngines() {
         List<Engine> retVal = new ArrayList<>();
         boolean isMixed = techManager.useMixedTech();

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -675,6 +675,9 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         } else {
             refresh.refreshEquipmentTable();
         }
+        if (!getTechManager().isLegal(Mek.getRiscHeatSinkOverrideKitAdvancement())) {
+            getMek().setRiscHeatSinkOverrideKit(false);
+        }
         panChassis.refresh();
         panHeat.refresh();
         panArmor.refresh();
@@ -973,6 +976,14 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
     public void heatSinkBaseCountChanged(int count) {
         getMek().getEngine().setBaseChassisHeatSinks(Math.max(0, count));
         MekUtil.updateAutoSinks(getMek(), panHeat.getHeatSinkType().hasFlag(MiscType.F_COMPACT_HEAT_SINK));
+        refresh.refreshBuild();
+        refresh.refreshStatus();
+        refresh.refreshPreview();
+    }
+
+    @Override
+    public void riscHeatSinkOverrideKitChanged(boolean hasKit) {
+        getMek().setRiscHeatSinkOverrideKit(hasKit);
         refresh.refreshBuild();
         refresh.refreshStatus();
         refresh.refreshPreview();


### PR DESCRIPTION
Depends on MegaMek/megamek#6149

Allows meks to be given a RISC Heat Sink Override Kit. Includes support for record sheets.

Checkbox to add the Kit is hidden when invalid for the current year/tech level.

![image](https://github.com/user-attachments/assets/e1a75705-6c9d-4e5f-b436-275492cd2e8c)

![image](https://github.com/user-attachments/assets/dfea829e-80ed-46d1-aea7-09fc1b7ec6ab)
