### PR TITLE
Various Mek crit table improvements

### DIFF
--- a/megameklab/src/megameklab/ui/mek/BMCriticalView.java
+++ b/megameklab/src/megameklab/ui/mek/BMCriticalView.java
@@ -207,6 +207,15 @@ public class BMCriticalView extends IView {
     }
 
     /**
+     * Darkens all crit blocks other than the one for the given location
+     */
+    public void markUnavailableLocations(int location) {
+        currentCritBlocks.stream()
+            .filter(b -> b.getCritLocation() != location)
+            .forEach(b -> b.setDarkened(true));
+    }
+
+    /**
      * Darkens all crit blocks that are unavailable to the given equipment, e.g. all but Torsos for CASE.
      */
     public void markUnavailableLocations(@Nullable Mounted<?> equipment) {

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -930,6 +930,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         refresh.refreshPreview();
         refresh.refreshStatus();
         refresh.refreshSummary();
+        refresh.refreshEquipment();
     }
 
     @Override

--- a/megameklab/src/megameklab/util/MekUtil.java
+++ b/megameklab/src/megameklab/util/MekUtil.java
@@ -1150,16 +1150,18 @@ public final class MekUtil {
             return 4;
         } else if (mounted.getType() instanceof AmmoType) {
             return 5;
-        } else if (mounted.getType().isHittable()) {
+        } else if (mounted.getType().isHittable() && !mounted.getType().hasFlag(MiscType.F_SCM)) {
             return 6;
-        } else if (isCASE(mounted)) {
+        } else if(mounted.getType().hasFlag(MiscType.F_SCM)) {
             return 7;
-        } else if (EquipmentType.isStructureType(mounted.getType())) {
+        } else if (isCASE(mounted)) {
             return 8;
-        } else if (EquipmentType.isArmorType(mounted.getType())) {
+        } else if (EquipmentType.isStructureType(mounted.getType())) {
             return 9;
-        } else {
+        } else if (EquipmentType.isArmorType(mounted.getType())) {
             return 10;
+        } else {
+            return 11;
         }
     }
 

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -390,6 +390,39 @@ public class UnitUtil {
         }
     }
 
+    /**
+     * Sets the corresponding critical slots to null for the Mounted object in the given location.
+     *
+     * @param unit The entity
+     * @param eq   The equipment to test
+     * @param loc The location to remove crits from.
+     */
+    public static void removeCriticals(Entity unit, Mounted<?> eq, int loc) {
+        if (eq.getLocation() == Entity.LOC_NONE) {
+            return;
+        }
+        for (int slot = 0; slot < unit.getNumberOfCriticals(loc); slot++) {
+            CriticalSlot cs = unit.getCritical(loc, slot);
+            if ((cs != null)
+                && (cs.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
+                if (cs.getMount().equals(eq)) {
+                    // If there are two pieces of equipment in this slot,
+                    // remove first one, and replace it with the second
+                    if (cs.getMount2() != null) {
+                        cs.setMount(cs.getMount2());
+                        cs.setMount2(null);
+                    } else { // If it's the only Mounted, clear the slot
+                        cs = null;
+                        unit.setCritical(loc, slot, cs);
+                    }
+                } else if ((cs.getMount2() != null)
+                    && cs.getMount2().equals(eq)) {
+                    cs.setMount2(null);
+                }
+            }
+        }
+    }
+
     public static void addMounted(Entity unit, Mounted<?> mounted, int loc, boolean rearMounted)
             throws LocationFullException {
         unit.addEquipment(mounted, loc, rearMounted);


### PR DESCRIPTION
Includes three related features. I implemented the latter two while failing to implement the first one.

1. See #1644. RISC Super-Cooled Myomer slots are autosorted after other equipment.
2. Changing the myomer type in the Structure tab now fully removes the previous myomer type right away, instead of leaving parts of it in the unit until something else triggered a full refresh.
3. Critical slots of fixed-location equipment (RISC SCM, Null-Sig, Partial Wing, etc) can now be moved around within a location if you want to reorder them manually:
![image](https://github.com/user-attachments/assets/636d6d04-8210-4389-a0ad-1e84a2df50fd)
