### PR TITLE
Allow opening unit and MUL files with MML by file association or drag-drop

### DIFF
--- a/megameklab/resources/megameklab/resources/Dialogs.properties
+++ b/megameklab/resources/megameklab/resources/Dialogs.properties
@@ -66,6 +66,8 @@ ConfigurationDialog.startup.text=MML Startup:
 ConfigurationDialog.startup.tooltip=Depending on the startup type selected, MML will start in the main menu or, alternatively, directly load the most recent unit or start with a new unit instead of the main menu.
 ConfigurationDialog.mekChassis.text=Mek Chassis Arrangement:
 ConfigurationDialog.mekChassis.tooltip=Meks with a Clan and an IS chassis name will print their chassis in the selected arrangement. Meks with no clan chassis name will always just print their chassis.
+ConfigurationDialog.cbMulDndBehaviour.text=MUL file drag and drop behaviour:
+ConfigurationDialog.cbMulDndBehaviour.tooltip=What should be done when a MUL file is dragged onto the MML window?
 
 RecordSheetTask.printing=Printing
 RecordSheetTask.exporting=Exporting

--- a/megameklab/resources/megameklab/resources/Dialogs.properties
+++ b/megameklab/resources/megameklab/resources/Dialogs.properties
@@ -66,8 +66,8 @@ ConfigurationDialog.startup.text=MML Startup:
 ConfigurationDialog.startup.tooltip=Depending on the startup type selected, MML will start in the main menu or, alternatively, directly load the most recent unit or start with a new unit instead of the main menu.
 ConfigurationDialog.mekChassis.text=Mek Chassis Arrangement:
 ConfigurationDialog.mekChassis.tooltip=Meks with a Clan and an IS chassis name will print their chassis in the selected arrangement. Meks with no clan chassis name will always just print their chassis.
-ConfigurationDialog.cbMulDndBehaviour.text=MUL file drag and drop behaviour:
-ConfigurationDialog.cbMulDndBehaviour.tooltip=What should be done when a MUL file is dragged onto the MML window?
+ConfigurationDialog.cbMulOpenBehaviour.text=MUL file open behaviour:
+ConfigurationDialog.cbMulOpenBehaviour.tooltip=What should be done when a MUL file is dragged onto the MML window or opened with MML by the operating system?
 
 RecordSheetTask.printing=Printing
 RecordSheetTask.exporting=Exporting

--- a/megameklab/resources/megameklab/resources/Menu.properties
+++ b/megameklab/resources/megameklab/resources/Menu.properties
@@ -117,6 +117,9 @@ MMLStartUp.NEW_JUMPSHIP=New Advanced Aerospace
 MMLStartUp.NEW_SUPPORTVEE=New Support Vehicle
 MMLStartUp.NEW_PROTOMEK=New ProtoMek
 
+MulDndBehaviour.PRINT=Print
+MulDndBehaviour.EXPORT=Export to PDF
+
 # The following values are used programatically by ClanISMekNameOrdering
 ClanISMekNameOrdering.CLAN_IS=Clan Name (IS Name)
 ClanISMekNameOrdering.IS_CLAN=IS Name (Clan Name)

--- a/megameklab/src/megameklab/MegaMekLab.java
+++ b/megameklab/src/megameklab/MegaMekLab.java
@@ -40,6 +40,7 @@ import megameklab.ui.PopupMessages;
 import megameklab.ui.StartupGUI;
 import megameklab.ui.dialog.UiLoader;
 import megameklab.util.CConfig;
+import megameklab.util.UnitPrintManager;
 import megameklab.util.UnitUtil;
 
 public class MegaMekLab {
@@ -74,7 +75,7 @@ public class MegaMekLab {
         MegaMek.initializeSuiteGraphicalSetups(MMLConstants.PROJECT_NAME);
         ToolTipManager.sharedInstance().setDismissDelay(1000000);
         ToolTipManager.sharedInstance().setReshowDelay(50);
-        startup();
+        startup(args);
     }
 
     public static void initializeLogging(final String originProject) {
@@ -89,7 +90,7 @@ public class MegaMekLab {
         return MegaMek.getUnderlyingInformation(originProject, MMLConstants.PROJECT_NAME);
     }
 
-    private static void startup() {
+    private static void startup(String[] args) {
         EquipmentType.initializeTypes();
         MekSummaryCache.getInstance();
         CConfig.load();
@@ -102,6 +103,28 @@ public class MegaMekLab {
         Locale.setDefault(getMMLOptions().getLocale());
 
         updateGuiScaling(); // also sets the look-and-feel
+
+        if (args.length == 1) {
+            try {
+                var name = args[0];
+                logger.info("Trying to open file {}", name);
+                if (name.toLowerCase().endsWith(".blk") || name.endsWith(".mtf")) {
+                    var file = new File(name);
+                    Entity e = new MekFileParser(file).getEntity();
+                    if (!UnitUtil.validateUnit(e).isBlank()) {
+                        PopupMessages.showUnitInvalidWarning(null, UnitUtil.validateUnit(e));
+                    }
+                    UiLoader.loadUi(e, file.toString());
+                    return;
+                } else if (name.toLowerCase().endsWith(".mul")) {
+                    UnitPrintManager.printMUL(new JFrame(),  CConfig.getBooleanParam(CConfig.MISC_MUL_OPEN_BEHAVIOUR), new File(name));
+                    System.exit(0);
+                    return;
+                }
+            } catch (Exception e) {
+                logger.warn(e);
+            }
+        }
 
         // Create a startup frame and display it
         switch (CConfig.getStartUpType()) {

--- a/megameklab/src/megameklab/MegaMekLab.java
+++ b/megameklab/src/megameklab/MegaMekLab.java
@@ -117,9 +117,11 @@ public class MegaMekLab {
                     UiLoader.loadUi(e, file.toString());
                     return;
                 } else if (name.toLowerCase().endsWith(".mul")) {
-                    UnitPrintManager.printMUL(new JFrame(),  CConfig.getBooleanParam(CConfig.MISC_MUL_OPEN_BEHAVIOUR), new File(name));
-                    System.exit(0);
-                    return;
+                    SwingUtilities.invokeLater(() -> {
+                        var frame = new JFrame();
+                        UnitPrintManager.printMUL(frame,  CConfig.getBooleanParam(CConfig.MISC_MUL_OPEN_BEHAVIOUR), new File(name));
+                        frame.dispose();
+                    });
                 }
             } catch (Exception e) {
                 logger.warn(e);

--- a/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
@@ -24,6 +24,7 @@ import megameklab.MegaMekLab;
 import megameklab.ui.util.ExitOnWindowClosingListener;
 import megameklab.ui.util.RefreshListener;
 import megameklab.util.CConfig;
+import megameklab.util.MMLFileDropTarget;
 
 import javax.swing.*;
 import java.awt.*;
@@ -34,7 +35,7 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
     protected MenuBar mmlMenuBar;
     protected boolean refreshRequired = false;
     private String originalName = "";
-    
+
     public MegaMekLabMainUI() {
         setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
         addWindowListener(new ExitOnWindowClosingListener(this));
@@ -46,8 +47,9 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
         setJMenuBar(mmlMenuBar);
         reloadTabs();
         refreshAll();
+        this.setDropTarget(new MMLFileDropTarget(this));
     }
-    
+
     protected void setSizeAndLocation() {
         pack();
         restrictToScrenSize();
@@ -195,5 +197,10 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
     @Override
     public boolean hasEntityNameChanged() {
         return !MenuBar.createUnitFilename(entity).equals(originalName);
+    }
+
+    @Override
+    public MenuBar getMMLMenuBar() {
+        return mmlMenuBar;
     }
 }

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -1202,6 +1202,10 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
             }
         }
 
+        loadFile(unitFile);
+    }
+
+    public void loadFile(File unitFile) {
         try {
             Entity loadedUnit = new MekFileParser(unitFile).getEntity();
 

--- a/megameklab/src/megameklab/ui/MenuBarOwner.java
+++ b/megameklab/src/megameklab/ui/MenuBarOwner.java
@@ -133,4 +133,6 @@ public interface MenuBarOwner extends AppCloser {
             }
         });
     }
+
+    MenuBar getMMLMenuBar();
 }

--- a/megameklab/src/megameklab/ui/MulDndBehaviour.java
+++ b/megameklab/src/megameklab/ui/MulDndBehaviour.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megameklab.ui;
+
+import java.util.ResourceBundle;
+
+public enum MulDndBehaviour {
+    PRINT,
+    EXPORT;
+
+    private final ResourceBundle resources = ResourceBundle.getBundle("megameklab.resources.Menu");
+
+    /** @return A display name for this MMLStartUp taken from the resources (possibly localised). */
+    public String getDisplayName() {
+        return resources.getString("MulDndBehaviour." + name());
+    }
+}

--- a/megameklab/src/megameklab/ui/StartupGUI.java
+++ b/megameklab/src/megameklab/ui/StartupGUI.java
@@ -29,6 +29,7 @@ import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
 import megameklab.ui.dialog.UiLoader;
 import megameklab.ui.util.ExitOnWindowClosingListener;
 import megameklab.util.CConfig;
+import megameklab.util.MMLFileDropTarget;
 import megameklab.util.UnitUtil;
 
 import javax.swing.*;
@@ -236,6 +237,7 @@ public class StartupGUI extends SkinnedJPanel implements MenuBarOwner {
         frame.pack();
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
+        this.setDropTarget(new MMLFileDropTarget(this));
     }
 
     /**
@@ -313,5 +315,10 @@ public class StartupGUI extends SkinnedJPanel implements MenuBarOwner {
     @Override
     public void refreshMenuBar() {
         mmlMenuBar.refreshMenuBar();
+    }
+
+    @Override
+    public MenuBar getMMLMenuBar() {
+        return mmlMenuBar;
     }
 }

--- a/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
@@ -39,16 +39,10 @@ import megamek.client.ui.swing.HelpDialog;
 import megamek.common.preference.PreferenceManager;
 import megamek.logging.MMLogger;
 import megameklab.ui.MMLStartUp;
+import megameklab.ui.MulDndBehaviour;
 import megameklab.ui.util.SpringUtilities;
 import megameklab.util.CConfig;
-import org.apache.logging.log4j.LogManager;
 
-import javax.swing.*;
-import javax.swing.border.EmptyBorder;
-import java.awt.*;
-import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.*;
 
 /**
@@ -64,9 +58,10 @@ public class MiscSettingsPanel extends JPanel {
     private final JCheckBox chkSkipSavePrompts = new JCheckBox();
     private final JTextField txtUserDir = new JTextField(20);
     private final JSlider guiScale = new JSlider();
+    private final MMComboBox<MulDndBehaviour> cbMulDndBehaviour = new MMComboBox<>("MUL Drag and Drop behaviour", MulDndBehaviour.values());
 
     MiscSettingsPanel(JFrame parent) {
-        startUpMMComboBox.setRenderer(startUpRenderer);
+        startUpMMComboBox.setRenderer(miscComboBoxRenderer);
         startUpMMComboBox.setSelectedItem(CConfig.getStartUpType());
         startUpMMComboBox.setToolTipText(resources.getString("ConfigurationDialog.startup.tooltip"));
         JLabel startUpLabel = new JLabel(resources.getString("ConfigurationDialog.startup.text"));
@@ -77,6 +72,17 @@ public class MiscSettingsPanel extends JPanel {
         startUpLine.add(startUpLabel);
         startUpLine.add(Box.createHorizontalStrut(5));
         startUpLine.add(startUpMMComboBox);
+
+        cbMulDndBehaviour.setRenderer(miscComboBoxRenderer);
+        cbMulDndBehaviour.setToolTipText(resources.getString("ConfigurationDialog.cbMulDndBehaviour.tooltip"));
+        cbMulDndBehaviour.setSelectedItem(CConfig.getBooleanParam(CConfig.MISC_MUL_DND_BEHAVIOUR) ? MulDndBehaviour.EXPORT : MulDndBehaviour.PRINT);
+        JLabel mulDndLabel = new JLabel(resources.getString("ConfigurationDialog.cbMulDndBehaviour.text"));
+        mulDndLabel.setToolTipText(resources.getString("ConfigurationDialog.cbMulDndBehaviour.tooltip"));
+
+        JPanel mulDndLine = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        mulDndLine.add(mulDndLabel);
+        mulDndLine.add(Box.createHorizontalStrut(5));
+        mulDndLine.add(cbMulDndBehaviour);
 
         chkSummaryFormatTRO.setText(resources.getString("ConfigurationDialog.chkSummaryFormatTRO.text"));
         chkSummaryFormatTRO.setToolTipText(resources.getString("ConfigurationDialog.chkSummaryFormatTRO.tooltip"));
@@ -136,11 +142,12 @@ public class MiscSettingsPanel extends JPanel {
         JPanel gridPanel = new JPanel(new SpringLayout());
         gridPanel.add(startUpLine);
         gridPanel.add(userDirLine);
+        gridPanel.add(mulDndLine);
         gridPanel.add(chkSummaryFormatTRO);
         gridPanel.add(chkSkipSavePrompts);
         gridPanel.add(scaleLine);
 
-        SpringUtilities.makeCompactGrid(gridPanel, 5, 1, 0, 0, 15, 10);
+        SpringUtilities.makeCompactGrid(gridPanel, 6, 1, 0, 0, 15, 10);
         gridPanel.setBorder(new EmptyBorder(20, 30, 20, 30));
         setLayout(new FlowLayout(FlowLayout.LEFT));
         add(gridPanel);
@@ -154,6 +161,7 @@ public class MiscSettingsPanel extends JPanel {
                 ? MMLStartUp.SPLASH_SCREEN
                 : startUpMMComboBox.getSelectedItem();
         miscSettings.put(CConfig.MISC_STARTUP, startUp.name());
+        miscSettings.put(CConfig.MISC_MUL_DND_BEHAVIOUR, String.valueOf(cbMulDndBehaviour.getSelectedItem() == MulDndBehaviour.EXPORT));
         // User directory and gui scale are stored in MM's client settings, not in CConfig, therefore not added here
         return miscSettings;
     }
@@ -166,7 +174,7 @@ public class MiscSettingsPanel extends JPanel {
         return 0.1f * guiScale.getValue();
     }
 
-    DefaultListCellRenderer startUpRenderer = new DefaultListCellRenderer() {
+    DefaultListCellRenderer miscComboBoxRenderer = new DefaultListCellRenderer() {
         @Override
         public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected,
                 boolean cellHasFocus) {
@@ -175,6 +183,11 @@ public class MiscSettingsPanel extends JPanel {
     };
 
     private String displayName(Object value) {
-        return (value instanceof MMLStartUp) ? ((MMLStartUp) value).getDisplayName() : "";
+        if (value instanceof MMLStartUp su) {
+            return su.getDisplayName();
+        } else if (value instanceof MulDndBehaviour mdb) {
+            return mdb.getDisplayName();
+        }
+        return "";
     }
 }

--- a/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
@@ -58,7 +58,7 @@ public class MiscSettingsPanel extends JPanel {
     private final JCheckBox chkSkipSavePrompts = new JCheckBox();
     private final JTextField txtUserDir = new JTextField(20);
     private final JSlider guiScale = new JSlider();
-    private final MMComboBox<MulDndBehaviour> cbMulDndBehaviour = new MMComboBox<>("MUL Drag and Drop behaviour", MulDndBehaviour.values());
+    private final MMComboBox<MulDndBehaviour> cbMulOpenBehaviour = new MMComboBox<>("MUL Drag and Drop behaviour", MulDndBehaviour.values());
 
     MiscSettingsPanel(JFrame parent) {
         startUpMMComboBox.setRenderer(miscComboBoxRenderer);
@@ -73,16 +73,16 @@ public class MiscSettingsPanel extends JPanel {
         startUpLine.add(Box.createHorizontalStrut(5));
         startUpLine.add(startUpMMComboBox);
 
-        cbMulDndBehaviour.setRenderer(miscComboBoxRenderer);
-        cbMulDndBehaviour.setToolTipText(resources.getString("ConfigurationDialog.cbMulDndBehaviour.tooltip"));
-        cbMulDndBehaviour.setSelectedItem(CConfig.getBooleanParam(CConfig.MISC_MUL_DND_BEHAVIOUR) ? MulDndBehaviour.EXPORT : MulDndBehaviour.PRINT);
-        JLabel mulDndLabel = new JLabel(resources.getString("ConfigurationDialog.cbMulDndBehaviour.text"));
-        mulDndLabel.setToolTipText(resources.getString("ConfigurationDialog.cbMulDndBehaviour.tooltip"));
+        cbMulOpenBehaviour.setRenderer(miscComboBoxRenderer);
+        cbMulOpenBehaviour.setToolTipText(resources.getString("ConfigurationDialog.cbMulOpenBehaviour.tooltip"));
+        cbMulOpenBehaviour.setSelectedItem(CConfig.getBooleanParam(CConfig.MISC_MUL_OPEN_BEHAVIOUR) ? MulDndBehaviour.EXPORT : MulDndBehaviour.PRINT);
+        JLabel mulOpenLabel = new JLabel(resources.getString("ConfigurationDialog.cbMulOpenBehaviour.text"));
+        mulOpenLabel.setToolTipText(resources.getString("ConfigurationDialog.cbMulOpenBehaviour.tooltip"));
 
-        JPanel mulDndLine = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
-        mulDndLine.add(mulDndLabel);
-        mulDndLine.add(Box.createHorizontalStrut(5));
-        mulDndLine.add(cbMulDndBehaviour);
+        JPanel mulOpenLine = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        mulOpenLine.add(mulOpenLabel);
+        mulOpenLine.add(Box.createHorizontalStrut(5));
+        mulOpenLine.add(cbMulOpenBehaviour);
 
         chkSummaryFormatTRO.setText(resources.getString("ConfigurationDialog.chkSummaryFormatTRO.text"));
         chkSummaryFormatTRO.setToolTipText(resources.getString("ConfigurationDialog.chkSummaryFormatTRO.tooltip"));
@@ -142,7 +142,7 @@ public class MiscSettingsPanel extends JPanel {
         JPanel gridPanel = new JPanel(new SpringLayout());
         gridPanel.add(startUpLine);
         gridPanel.add(userDirLine);
-        gridPanel.add(mulDndLine);
+        gridPanel.add(mulOpenLine);
         gridPanel.add(chkSummaryFormatTRO);
         gridPanel.add(chkSkipSavePrompts);
         gridPanel.add(scaleLine);
@@ -161,7 +161,7 @@ public class MiscSettingsPanel extends JPanel {
                 ? MMLStartUp.SPLASH_SCREEN
                 : startUpMMComboBox.getSelectedItem();
         miscSettings.put(CConfig.MISC_STARTUP, startUp.name());
-        miscSettings.put(CConfig.MISC_MUL_DND_BEHAVIOUR, String.valueOf(cbMulDndBehaviour.getSelectedItem() == MulDndBehaviour.EXPORT));
+        miscSettings.put(CConfig.MISC_MUL_OPEN_BEHAVIOUR, String.valueOf(cbMulOpenBehaviour.getSelectedItem() == MulDndBehaviour.EXPORT));
         // User directory and gui scale are stored in MM's client settings, not in CConfig, therefore not added here
         return miscSettings;
     }

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -62,6 +62,7 @@ public final class CConfig {
     public static final String MISC_STARTUP = "StartupGui";
     public static final String MISC_SUMMARY_FORMAT_TRO = "useTROFormat";
     public static final String MISC_SKIP_SAFETY_PROMPTS = "skipSafetyPrompts";
+    public static final String MISC_MUL_DND_BEHAVIOUR = "mulDndBehaviour";
 
     public static final String GUI_PLAF = "lookAndFeel";
     public static final String GUI_COLOR_WEAPONS = "Weapons";

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -62,7 +62,7 @@ public final class CConfig {
     public static final String MISC_STARTUP = "StartupGui";
     public static final String MISC_SUMMARY_FORMAT_TRO = "useTROFormat";
     public static final String MISC_SKIP_SAFETY_PROMPTS = "skipSafetyPrompts";
-    public static final String MISC_MUL_DND_BEHAVIOUR = "mulDndBehaviour";
+    public static final String MISC_MUL_OPEN_BEHAVIOUR = "mulDndBehaviour";
 
     public static final String GUI_PLAF = "lookAndFeel";
     public static final String GUI_COLOR_WEAPONS = "Weapons";

--- a/megameklab/src/megameklab/util/MMLFileDropTarget.java
+++ b/megameklab/src/megameklab/util/MMLFileDropTarget.java
@@ -51,11 +51,11 @@ public class MMLFileDropTarget extends DropTarget {
             var file = files.get(0);
             var name = file.getName();
 
-            if (name.endsWith(".mtf") || name.endsWith(".blk")) {
+            if (name.toLowerCase().endsWith(".mtf") || name.toLowerCase().endsWith(".blk")) {
                 owner.getMMLMenuBar().loadFile(file);
                 event.dropComplete(true);
-            } else if (name.endsWith(".mul")) {
-                UnitPrintManager.printMUL(owner.getFrame(), CConfig.getBooleanParam(CConfig.MISC_MUL_DND_BEHAVIOUR), file);
+            } else if (name.toLowerCase().endsWith(".mul")) {
+                UnitPrintManager.printMUL(owner.getFrame(), CConfig.getBooleanParam(CConfig.MISC_MUL_OPEN_BEHAVIOUR), file);
                 event.dropComplete(true);
             } else {
                 event.dropComplete(false);

--- a/megameklab/src/megameklab/util/MMLFileDropTarget.java
+++ b/megameklab/src/megameklab/util/MMLFileDropTarget.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package megameklab.util;
+
+import megamek.logging.MMLogger;
+import megameklab.ui.MenuBarOwner;
+
+import java.awt.datatransfer.DataFlavor;
+import java.awt.dnd.DnDConstants;
+import java.awt.dnd.DropTarget;
+import java.awt.dnd.DropTargetDropEvent;
+import java.io.File;
+import java.util.List;
+
+public class MMLFileDropTarget extends DropTarget {
+    private static final MMLogger logger = MMLogger.create(MMLFileDropTarget.class);
+
+    private final MenuBarOwner owner;
+
+    public MMLFileDropTarget(MenuBarOwner owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public synchronized void drop(DropTargetDropEvent event) {
+        try {
+            event.acceptDrop(DnDConstants.ACTION_COPY);
+            var files = (List<File>) event.getTransferable().getTransferData(DataFlavor.javaFileListFlavor);
+            if (files.size() != 1) {
+                event.dropComplete(false);
+                return;
+            }
+
+            var file = files.get(0);
+            var name = file.getName();
+
+            if (name.endsWith(".mtf") || name.endsWith(".blk")) {
+                owner.getMMLMenuBar().loadFile(file);
+                event.dropComplete(true);
+            } else if (name.endsWith(".mul")) {
+                UnitPrintManager.printMUL(owner.getFrame(), CConfig.getBooleanParam(CConfig.MISC_MUL_DND_BEHAVIOUR), file);
+                event.dropComplete(true);
+            } else {
+                event.dropComplete(false);
+            }
+
+
+        } catch (Exception e) {
+            event.dropComplete(false);
+            logger.warn(e);
+        }
+    }
+}

--- a/megameklab/src/megameklab/util/UnitPrintManager.java
+++ b/megameklab/src/megameklab/util/UnitPrintManager.java
@@ -77,20 +77,24 @@ public class UnitPrintManager {
             // I want a file, y'know!
             return;
         }
+        printMUL(parent, printToPdf, f.getSelectedFile());
+    }
+
+    public static void printMUL(JFrame parent, boolean printToPdf, File file) {
         Vector<Entity> loadedUnits;
         try {
             var options = new GameOptions();
             options.initialize();
             options.getOption(RPG_MANEI_DOMINI).setValue(true);
             options.getOption(RPG_PILOT_ADVANTAGES).setValue(true);
-            loadedUnits = new MULParser(f.getSelectedFile(), options).getEntities();
+            loadedUnits = new MULParser(file, options).getEntities();
             loadedUnits.trimToSize();
         } catch (Exception ex) {
             logger.error("", ex);
             return;
         }
 
-        new PrintQueueDialog(parent, printToPdf, loadedUnits, true, f.getSelectedFile().getName()).setVisible(true);
+        new PrintQueueDialog(parent, printToPdf, loadedUnits, true, file.getName()).setVisible(true);
     }
 
     public static File getExportFile(Frame parent) {


### PR DESCRIPTION
Allows you to drag unit files (MTF/BLK) or MUL files from your OS's file explorer onto MegaMekLab:

![image](https://github.com/user-attachments/assets/f96a5885-6f68-4d66-b5d2-ae961e5a3389)

You can drag them onto the startup GUI or almost anywhere onto the unit editing GUI.

I've tested, and crit-slot drag-and-drop still works without issues, the only thing to note there is that you cannot drag files onto a unit's crit table, which I'm sure no one will mind.

You can also ask your operating system to open these files with MML if you tell it the path to MegaMekLab.exe (or equivalent executable for your system):
![image](https://github.com/user-attachments/assets/6370cf9a-6099-4bda-9d80-93e01f313c8e)


Unit files will be opened to edit, while MUL files will be opened to print. 

A new setting is added to determine if dropped MUL files should be printed or exported to PDF:

![image](https://github.com/user-attachments/assets/78119e1f-3d23-4e18-8c54-a22baa5bc5e0)


