### PR TITLE
Fix 1631: Armor rating incorrectly persisted

### DIFF
--- a/megameklab/src/megameklab/ui/supportVehicle/SVArmorTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVArmorTab.java
@@ -127,17 +127,8 @@ public class SVArmorTab extends ITab implements ArmorAllocationListener {
     @Override
     public void armorTechRatingChanged(int techRating) {
         getEntity().setArmorTechRating(techRating);
+        getEntity().setArmorTechLevel(techRating);
         getEntity().recalculateTechAdvancement();
-        panArmor.setFromEntity(getEntity());
-        panArmorAllocation.setFromEntity(getEntity());
-        refresh.refreshSummary();
-        refresh.refreshStatus();
-        refresh.refreshPreview();
-    }
-
-    @Override
-    public void armorBARRatingChanged(int bar) {
-        getEntity().setBARRating(bar);
         panArmor.setFromEntity(getEntity());
         panArmorAllocation.setFromEntity(getEntity());
         refresh.refreshSummary();


### PR DESCRIPTION
The unit encoding process looks for a random (hardcoded the number 1) "armor tech level" inside the array of the armor_tech_level and picks that value as the armor tech level, however this value isnt being set when the armor is changed, the armor_tech_rating is set instead.
I need to validate why or how the BAR is set, but it is being correctly set, so this isnt as much a big of a deal.

Also, it had a piece of code right after the part where it should be setting it, but it wasan't correct and also was never called by any code anywhere, so I removed it.

Maybe I should take a further look in the persisting process because it is kind of a messs right now.

Fixes: #1631 