### PR TITLE
Fix MML #1667: incorrect cargo bay minimum doors (MML side)

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
@@ -886,7 +886,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
             if (column == InstalledBaysModel.COL_DOORS) {
                 int doors = (Integer) modelInstalled.getValueAt(row, column);
                 SpinnerNumberModel model = new SpinnerNumberModel(doors,
-                        (isInfantry) ? 0 : 1,
+                        modelInstalled.bayList.get(row).getMinDoors(),
                         getEntity().isAero() ? doorsAvailable() + doors : Integer.MAX_VALUE, 1);
                 spinner.removeChangeListener(this);
                 spinner.setModel(model);

--- a/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
@@ -376,7 +376,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
             return false;
         }
         BayData bayType = modelAvailable.getBayType(tblAvailable.convertRowIndexToModel(selected));
-        return (doorsAvailable() > 0) || bayType.isInfantryBay();
+        return (doorsAvailable() >= bayType.getMinDoors());
     }
 
     /**
@@ -867,7 +867,10 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                 refreshDockingHardpoints();
 
             } else if (column == InstalledBaysModel.COL_DOORS) {
-                modelInstalled.bayList.get(row).setDoors((Integer) getCellEditorValue());
+                int value = (Integer) getCellEditorValue();
+                modelInstalled.bayList.get(row).setDoors(
+                    Math.max(value, bay.getMinDoors())
+                );
             }
             modelInstalled.fireTableRowsUpdated(row, row);
             checkButtons();


### PR DESCRIPTION
Fix for #1667, "Incorrect minimum doors required for cargo bays".

Corrects the UI elements which determine whether bays can be added, doors increased or decreased, and whether a unit with bays is valid or not, based on the matching PR for MegaMek.

NOTE: this PR will break MML until the [MM PR](https://github.com/MegaMek/megamek/pull/6322) is merged!

Testing:
- Loaded units from original issue successfully.
- Added various bays with 0 doors as default.
- Reduced existing cargo bay doors to 0 without issue.
- Saved and loaded updated units.
- Ran all 3 projects' unit tests (with MM and MML patches applied)

Close #1667