### PR TITLE
Tabbed UI Improvements

### DIFF
--- a/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
@@ -18,6 +18,7 @@ package megameklab.ui;
 import megamek.MegaMek;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
+import megamek.common.Mounted;
 import megamek.common.preference.PreferenceManager;
 import megameklab.MMLConstants;
 import megameklab.MegaMekLab;
@@ -212,4 +213,12 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
     public void setOwner(MegaMekLabTabbedUI owner) {
         this.owner = owner;
     }
+
+    /**
+     * Retrieves a list of mounted components that are currently not assigned to a location.
+     * Such equipment would be deleted on save and reload.
+     *
+     * @return a List containing unallocated Mounted objects.
+     */
+    public abstract java.util.List<Mounted<?>> getUnallocatedMounted();
 }

--- a/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
@@ -348,17 +348,104 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner {
     private class NewTabButton extends JPanel {
         public NewTabButton() {
             setOpaque(false);
-            var button = new JButton("➕");
-            button.setForeground(Color.GREEN);
-            button.setFont(Font.getFont("Symbola"));
-            button.setFocusable(false);
-            button.setBorder(BorderFactory.createEmptyBorder());
+            var newUnitButton = new JButton("➕");
+            newUnitButton.setForeground(Color.GREEN);
+            newUnitButton.setFont(Font.getFont("Symbola"));
+            newUnitButton.setFocusable(false);
+            newUnitButton.setBorder(BorderFactory.createEmptyBorder());
+            newUnitButton.setToolTipText("<html>New Blank Mek<br>Right Click: Select Unit Type");
 
-            button.addActionListener(e -> {
-                newTab();
+            newUnitButton.addActionListener(e -> newTab());
+            newUnitButton.addMouseListener(new MouseAdapter() {
+                @Override
+                public void mousePressed(MouseEvent e) {
+                    if (e.isPopupTrigger()) {
+                        newUnitPopupMenu().show(e.getComponent(), e.getX(), e.getY());
+                    }
+                }
+
+                @Override
+                public void mouseReleased(MouseEvent e) {
+                    if (e.isPopupTrigger()) {
+                        newUnitPopupMenu().show(e.getComponent(), e.getX(), e.getY());
+                    }
+                }
             });
 
-            add(button);
+            add(newUnitButton);
+
+            var loadUnitButton = new JButton("⌸");
+            loadUnitButton.setFont(Font.getFont("Symbola"));
+            loadUnitButton.setForeground(Color.CYAN);
+            loadUnitButton.setFocusable(false);
+            loadUnitButton.setBorder(BorderFactory.createEmptyBorder());
+            loadUnitButton.setToolTipText("<html>Load unit from cache<br>Right Click: Load Unit Menu");
+
+            loadUnitButton.addActionListener(e -> StartupGUI.selectAndLoadUnitFromCache(MegaMekLabTabbedUI.this));
+            loadUnitButton.addMouseListener(new MouseAdapter() {
+
+                @Override
+                public void mousePressed(MouseEvent e) {
+                    if (e.isPopupTrigger()) {
+                        loadUnitMenu().show(e.getComponent(), e.getX(), e.getY());
+                    }
+                }
+
+                @Override
+                public void mouseReleased(MouseEvent e) {
+                    if (e.isPopupTrigger()) {
+                        loadUnitMenu().show(e.getComponent(), e.getX(), e.getY());
+                    }
+                }
+            });
+
+            add(loadUnitButton);
+        }
+
+        private JPopupMenu newUnitPopupMenu() {
+            var menu = new JPopupMenu();
+            menu.add(newUnitItem("New Mek", Entity.ETYPE_MEK, false));
+            menu.add(newUnitItem("New Fighter", Entity.ETYPE_AERO, false));
+            menu.add(newUnitItem("New DropShip/Small Craft", Entity.ETYPE_DROPSHIP, false));
+            menu.add(newUnitItem("New Advanced Aerospace", Entity.ETYPE_JUMPSHIP, false));
+            menu.add(newUnitItem("New Tank", Entity.ETYPE_TANK, false));
+            menu.add(newUnitItem("New Support Vehicle", Entity.ETYPE_SUPPORT_TANK, false));
+            menu.add(newUnitItem("New Battle Armor", Entity.ETYPE_BATTLEARMOR, false));
+            menu.add(newUnitItem("New Conventional Infantry", Entity.ETYPE_INFANTRY, false));
+            menu.add(newUnitItem("New ProtoMek", Entity.ETYPE_PROTOMEK, false));
+
+            var primitive = new JMenu("New Primitive...");
+            primitive.add(newUnitItem("New Mek", Entity.ETYPE_MEK, true));
+            primitive.add(newUnitItem("New Fighter", Entity.ETYPE_AERO, true));
+            primitive.add(newUnitItem("New DropShip/Small Craft", Entity.ETYPE_DROPSHIP, true));
+            primitive.add(newUnitItem("New JumpShip", Entity.ETYPE_JUMPSHIP, true));
+
+            menu.add(primitive);
+
+            return menu;
+        }
+
+        private JMenuItem newUnitItem(String name, long entityType, boolean primitive) {
+            var item = new JMenuItem(name);
+            item.addActionListener(e -> {
+                newTab();
+                newUnit(entityType, primitive);
+            });
+            return item;
+        }
+
+        private JPopupMenu loadUnitMenu() {
+            var menu = new JPopupMenu();
+
+            var fromCache = new JMenuItem("Load from cache");
+            fromCache.addActionListener(e ->  StartupGUI.selectAndLoadUnitFromCache(MegaMekLabTabbedUI.this));
+            menu.add(fromCache);
+
+            var fromFile = new JMenuItem("Load from file");
+            fromFile.addActionListener(e -> getMMLMenuBar().loadUnitFromFile(-1));
+            menu.add(fromFile);
+
+            return menu;
         }
     }
 

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -1216,7 +1216,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         }
     }
 
-    private void loadUnitFromFile(int fileNumber) {
+    public void loadUnitFromFile(int fileNumber) {
         File unitFile;
         if (fileNumber > 0) {
             String recentFileName = CConfig.getRecentFile(fileNumber);

--- a/megameklab/src/megameklab/ui/battleArmor/BABuildTab.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BABuildTab.java
@@ -43,6 +43,11 @@ public class BABuildTab extends ITab {
 
     private RefreshListener refresh = null;
     private final ArrayList<BACriticalView> critViews = new ArrayList<>();
+
+    public BABuildView getBuildView() {
+        return buildView;
+    }
+
     private final BABuildView buildView;
 
     /** Panel for displaying the critical trees for each trooper in the squad. */

--- a/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
@@ -20,6 +20,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 import javax.swing.BorderFactory;
@@ -66,6 +67,11 @@ public class BABuildView extends IView implements ActionListener, MouseListener 
     private JPanel mainPanel = new JPanel();
 
     private CriticalTableModel equipmentList;
+
+    public List<Mounted<?>> getEquipment() {
+        return equipmentList.getCrits();
+    }
+
     private Vector<Mounted<?>> masterEquipmentList = new Vector<>(10, 1);
     private JTable equipmentTable = new JTable();
     private JScrollPane equipmentScroll = new JScrollPane();

--- a/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
@@ -25,6 +25,7 @@ import megameklab.ui.util.TabScrollPane;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.List;
 
 public class BAMainUI extends MegaMekLabMainUI {
 
@@ -123,7 +124,7 @@ public class BAMainUI extends MegaMekLabMainUI {
     public void refreshEquipment() {
         equipTab.refresh();
     }
-    
+
     @Override
     public void refreshTransport() {
         // not used for ba
@@ -146,10 +147,10 @@ public class BAMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         structureTab.refreshPreview();
     }
-    
+
     @Override
     public void refreshSummary() { }
-    
+
     @Override
     public void refreshEquipmentTable() {
         equipTab.refreshTable();
@@ -163,5 +164,10 @@ public class BAMainUI extends MegaMekLabMainUI {
 
     public JDialog getFloatingEquipmentDatabase() {
         return floatingEquipmentDatabase;
+    }
+
+    @Override
+    public List<Mounted<?>> getUnallocatedMounted() {
+        return buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/combatVehicle/CVBuildTab.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVBuildTab.java
@@ -41,6 +41,11 @@ public class CVBuildTab extends ITab implements ActionListener {
 
     private RefreshListener refresh = null;
     private CVCriticalView critView;
+
+    public UnallocatedView getUnallocatedView() {
+        return unallocatedView;
+    }
+
     private UnallocatedView unallocatedView;
 
     private JButton autoFillButton = new JButton("Auto Fill");

--- a/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
@@ -28,6 +28,7 @@ import megameklab.ui.util.TabScrollPane;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.List;
 
 public class CVMainUI extends MegaMekLabMainUI {
 
@@ -63,7 +64,7 @@ public class CVMainUI extends MegaMekLabMainUI {
         buildTab.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
         statusbar.addRefreshedListener(this);
-        
+
         previewTab = new PreviewTab(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
@@ -216,5 +217,10 @@ public class CVMainUI extends MegaMekLabMainUI {
 
     public JDialog getFloatingEquipmentDatabase() {
         return floatingEquipmentDatabase;
+    }
+
+    @Override
+    public List<Mounted<?>> getUnallocatedMounted() {
+        return buildTab.getUnallocatedView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/fighterAero/ASBuildTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASBuildTab.java
@@ -36,6 +36,11 @@ import megameklab.util.UnitUtil;
 public class ASBuildTab extends ITab implements ActionListener {
     private RefreshListener refresh = null;
     private ASCriticalView critView = null;
+
+    public ASBuildView getBuildView() {
+        return buildView;
+    }
+
     private ASBuildView buildView = null;
     private JPanel buttonPanel = new JPanel();
     private JPanel mainPanel = new JPanel();

--- a/megameklab/src/megameklab/ui/fighterAero/ASBuildView.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASBuildView.java
@@ -22,6 +22,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 
 import javax.swing.BorderFactory;
@@ -60,6 +61,11 @@ public class ASBuildView extends IView implements ActionListener, MouseListener 
     private static final MMLogger logger = MMLogger.create(ASBuildView.class);
 
     private CriticalTableModel equipmentList;
+
+    public List<Mounted<?>> getEquipment() {
+        return equipmentList.getCrits();
+    }
+
     private Vector<Mounted<?>> masterEquipmentList = new Vector<>(10, 1);
     private JTable equipmentTable = new JTable();
     private JScrollPane equipmentScroll = new JScrollPane();

--- a/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
@@ -16,20 +16,13 @@
 package megameklab.ui.fighterAero;
 
 import java.awt.BorderLayout;
+import java.util.List;
 
 import javax.swing.JDialog;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingConstants;
 
-import megamek.common.Aero;
-import megamek.common.AeroSpaceFighter;
-import megamek.common.ConvFighter;
-import megamek.common.Engine;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.ITechManager;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TechConstants;
+import megamek.common.*;
 import megamek.logging.MMLogger;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
@@ -218,5 +211,10 @@ public class ASMainUI extends MegaMekLabMainUI {
 
     public JDialog getFloatingEquipmentDatabase() {
         return floatingEquipmentDatabase;
+    }
+
+    @Override
+    public List<Mounted<?>> getUnallocatedMounted() {
+        return buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/generalUnit/UnallocatedView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/UnallocatedView.java
@@ -20,6 +20,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.util.List;
 import java.util.Vector;
 import java.util.function.Supplier;
 
@@ -52,6 +53,11 @@ public class UnallocatedView extends IView implements ActionListener, MouseListe
     private static final MMLogger logger = MMLogger.create(UnallocatedView.class);
 
     private CriticalTableModel equipmentList;
+
+    public List<Mounted<?>> getEquipment() {
+        return equipmentList.getCrits();
+    }
+
     private Vector<Mounted<?>> masterEquipmentList = new Vector<>(10, 1);
     private JTable equipmentTable = new JTable();
 

--- a/megameklab/src/megameklab/ui/infantry/CIMainUI.java
+++ b/megameklab/src/megameklab/ui/infantry/CIMainUI.java
@@ -17,6 +17,7 @@
 package megameklab.ui.infantry;
 
 import java.awt.BorderLayout;
+import java.util.List;
 
 import javax.swing.*;
 
@@ -127,6 +128,11 @@ public class CIMainUI extends MegaMekLabMainUI {
     @Override
     public JDialog getFloatingEquipmentDatabase() {
         return null;
+    }
+
+    @Override
+    public List<Mounted<?>> getUnallocatedMounted() {
+        return List.of();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -14,6 +14,7 @@
 package megameklab.ui.largeAero;
 
 import java.awt.BorderLayout;
+import java.util.List;
 
 import javax.swing.JDialog;
 import javax.swing.JTabbedPane;
@@ -232,5 +233,10 @@ public class DSMainUI extends MegaMekLabMainUI {
 
     public JDialog getFloatingEquipmentDatabase() {
         return floatingEquipmentDatabase;
+    }
+
+    @Override
+    public List<Mounted<?>> getUnallocatedMounted() {
+        return buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/largeAero/LABuildTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/LABuildTab.java
@@ -37,6 +37,11 @@ import megameklab.util.UnitUtil;
 public class LABuildTab extends ITab implements ActionListener {
     private RefreshListener refresh = null;
     private LACriticalView critView = null;
+
+    public LABuildView getBuildView() {
+        return buildView;
+    }
+
     private LABuildView buildView = null;
     private JPanel buttonPanel = new JPanel();
     private JPanel mainPanel = new JPanel();

--- a/megameklab/src/megameklab/ui/largeAero/LABuildView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LABuildView.java
@@ -63,6 +63,11 @@ public class LABuildView extends IView implements MouseListener {
     }
 
     private CriticalTableModel equipmentList;
+
+    public List<Mounted<?>> getEquipment() {
+        return equipmentList.getCrits();
+    }
+
     private Vector<Mounted<?>> masterEquipmentList = new Vector<>(10, 1);
     private JTable equipmentTable = new JTable();
     private JScrollPane equipmentScroll = new JScrollPane();

--- a/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
@@ -14,6 +14,7 @@
 package megameklab.ui.largeAero;
 
 import java.awt.BorderLayout;
+import java.util.List;
 
 import javax.swing.JDialog;
 import javax.swing.JTabbedPane;
@@ -249,5 +250,10 @@ public class WSMainUI extends MegaMekLabMainUI {
 
     public JDialog getFloatingEquipmentDatabase() {
         return floatingEquipmentDatabase;
+    }
+
+    @Override
+    public List<Mounted<?>> getUnallocatedMounted() {
+        return buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/mek/BMBuildTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildTab.java
@@ -42,6 +42,11 @@ public class BMBuildTab extends ITab {
 
     private RefreshListener refresh = null;
     private final BMCriticalView critView;
+
+    public BMBuildView getBuildView() {
+        return buildView;
+    }
+
     private final BMBuildView buildView;
     private final ResourceBundle resources = ResourceBundle.getBundle("megameklab.resources.Tabs");
 

--- a/megameklab/src/megameklab/ui/mek/BMBuildView.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildView.java
@@ -67,6 +67,7 @@ public class BMBuildView extends IView implements ActionListener, MouseListener 
     private int engineHeatSinkCount = 0;
     private final CriticalTransferHandler transferHandler;
     private RefreshListener refresh;
+    private List<Mounted<?>> masterEquipmentList;
 
     public BMBuildView(EntitySource eSource, RefreshListener refresh, BMCriticalView critView) {
         super(eSource);
@@ -101,7 +102,7 @@ public class BMBuildView extends IView implements ActionListener, MouseListener 
     }
 
     private void loadEquipmentTable() {
-        final List<Mounted<?>> masterEquipmentList = new ArrayList<>();
+        masterEquipmentList = new ArrayList<>();
         equipmentList.removeAllCrits();
         engineHeatSinkCount = UnitUtil.getCriticalFreeHeatSinks(getMek(), getMek().hasCompactHeatSinks());
         for (Mounted<?> mount : getMek().getMisc()) {
@@ -120,6 +121,10 @@ public class BMBuildView extends IView implements ActionListener, MouseListener 
 
         masterEquipmentList.sort(new MekUtil.MekMountedSorter(getMek()));
         masterEquipmentList.forEach(equipmentList::addCrit);
+    }
+
+    public List<Mounted<?>> getEquipment() {
+        return masterEquipmentList;
     }
 
     private boolean isEngineHeatSink(Mounted<?> mount) {

--- a/megameklab/src/megameklab/ui/mek/BMMainUI.java
+++ b/megameklab/src/megameklab/ui/mek/BMMainUI.java
@@ -27,6 +27,7 @@ import megameklab.util.MekUtil;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.List;
 
 public class BMMainUI extends MegaMekLabMainUI {
 
@@ -231,5 +232,10 @@ public class BMMainUI extends MegaMekLabMainUI {
     @Override
     public JDialog getFloatingEquipmentDatabase() {
         return floatingEquipmentDatabase;
+    }
+
+    @Override
+    public List<Mounted<?>> getUnallocatedMounted() {
+        return this.buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/protoMek/PMBuildTab.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMBuildTab.java
@@ -42,6 +42,11 @@ import megameklab.util.UnitUtil;
 public class PMBuildTab extends ITab implements ActionListener {
     private RefreshListener refresh;
     private PMCriticalView critView;
+
+    public PMBuildView getBuildView() {
+        return buildView;
+    }
+
     private PMBuildView buildView;
     private JPanel buttonPanel = new JPanel();
     private JPanel mainPanel = new JPanel();

--- a/megameklab/src/megameklab/ui/protoMek/PMBuildView.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMBuildView.java
@@ -33,6 +33,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.util.List;
 import java.util.Vector;
 
 /**
@@ -44,6 +45,11 @@ public class PMBuildView extends IView implements ActionListener, MouseListener 
     private JPanel mainPanel = new JPanel();
 
     private CriticalTableModel equipmentList;
+
+    public List<Mounted<?>> getEquipment() {
+        return equipmentList.getCrits();
+    }
+
     private Vector<Mounted<?>> masterEquipmentList = new Vector<>(10, 1);
     private JTable equipmentTable = new JTable();
     private JScrollPane equipmentScroll = new JScrollPane();

--- a/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
@@ -25,6 +25,7 @@ import megameklab.ui.util.TabScrollPane;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.List;
 
 /**
  * Main UI for building protomeks
@@ -187,5 +188,10 @@ public class PMMainUI extends MegaMekLabMainUI {
 
     public JDialog getFloatingEquipmentDatabase() {
         return floatingEquipmentDatabase;
+    }
+
+    @Override
+    public List<Mounted<?>> getUnallocatedMounted() {
+        return buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/supportVehicle/SVBuildTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVBuildTab.java
@@ -47,6 +47,11 @@ public class SVBuildTab extends ITab implements ActionListener {
 
     private RefreshListener refresh = null;
     private SVCriticalView critView;
+
+    public UnallocatedView getUnallocatedView() {
+        return unallocatedView;
+    }
+
     private UnallocatedView unallocatedView;
 
     private JButton autoFillButton = new JButton("Auto Fill");

--- a/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
@@ -26,6 +26,7 @@ import megameklab.ui.util.TabScrollPane;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.List;
 
 /**
  * Main window for support vehicle construction
@@ -230,5 +231,10 @@ public class SVMainUI extends MegaMekLabMainUI {
 
     public JDialog getFloatingEquipmentDatabase() {
         return floatingEquipmentDatabase;
+    }
+
+    @Override
+    public List<Mounted<?>> getUnallocatedMounted() {
+        return buildTab.getUnallocatedView().getEquipment();
     }
 }


### PR DESCRIPTION
Minor improvement to the new Tabs UI.

First, when tabs are restored, equipment not allocated to a location is no longer lost, making that feature more reliable.

Second, new ways to open a new tab:

![image](https://github.com/user-attachments/assets/ff803708-c8b7-4363-b1d3-4c5cac6af7ce)

The old + button can now be right-clicked to select a unit type:

![image](https://github.com/user-attachments/assets/3b2a9972-2bb9-4037-a4a6-86b69d9ece1a)

The new ⌸ button will load a unit from cache, and can be right clicked to load a unit from a file: 
![image](https://github.com/user-attachments/assets/fb83490f-09a4-4179-bd30-8e72e99752af)