### PR TITLE
Detect unsaved work

### DIFF
--- a/megameklab/src/megameklab/EntityChangedUtil.java
+++ b/megameklab/src/megameklab/EntityChangedUtil.java
@@ -1,0 +1,74 @@
+package megameklab;
+
+import megamek.common.Entity;
+import megamek.common.Mek;
+import megamek.common.MekFileParser;
+import megamek.common.loaders.BLKFile;
+import megamek.common.loaders.EntitySavingException;
+import megamek.logging.MMLogger;
+import megameklab.ui.MegaMekLabMainUI;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class EntityChangedUtil {
+    private static MMLogger logger = MMLogger.create(EntityChangedUtil.class);
+
+    private static Map<String, String> cache = new ConcurrentHashMap<>();
+
+    public static boolean hasEntityChanged(MegaMekLabMainUI editor) {
+        var filename = editor.getFileName();
+        if (filename == null || filename.isBlank()) {
+            return true;
+        }
+
+
+        if (!cache.containsKey(filename)) {
+            var f = new File(filename);
+            if (!f.exists()) {
+                return true;
+            }
+
+            try {
+                var e = new MekFileParser(f).getEntity();
+                cache.put(filename, encode(e));
+            } catch (Exception ex) {
+                logger.error("Entity loading failure:", ex);
+            }
+        }
+
+        try {
+            var o = cache.get(filename);
+            var n = encode(editor.getEntity());
+            return !o.equals(n);
+        } catch (EntitySavingException e) {
+            logger.error("Entity encoding failure:", e);
+            return true;
+        }
+    }
+
+    public static void editorSaved(MegaMekLabMainUI editor) {
+        var filename = editor.getFileName();
+        if (filename == null || filename.isBlank()) {
+            return;
+        }
+
+        try {
+            cache.put(editor.getFileName(), encode(editor.getEntity()));
+        } catch (EntitySavingException e) {
+            logger.error("Entity encoding failure:", e);
+        }
+    }
+
+    private static String encode(Entity e) throws EntitySavingException {
+        if (e instanceof Mek m) {
+            return m.getMtf();
+        } else {
+            var blk = BLKFile.getBlock(e);
+            return String.join("\n", blk.getAllDataAsString());
+        }
+    }
+
+    private EntityChangedUtil() {}
+}

--- a/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
@@ -20,6 +20,7 @@ import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
 import megamek.common.Mounted;
 import megamek.common.preference.PreferenceManager;
+import megameklab.util.EntityChangedUtil;
 import megameklab.MMLConstants;
 import megameklab.MegaMekLab;
 import megameklab.ui.util.ExitOnWindowClosingListener;
@@ -83,7 +84,7 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
 
     @Override
     public boolean safetyPrompt() {
-        if (CConfig.getBooleanParam(CConfig.MISC_SKIP_SAFETY_PROMPTS)) {
+        if (CConfig.getBooleanParam(CConfig.MISC_SKIP_SAFETY_PROMPTS) || !EntityChangedUtil.hasEntityChanged(this)) {
             return true;
         } else {
             int savePrompt = JOptionPane.showConfirmDialog(this,

--- a/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
@@ -553,6 +553,18 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
                     }
                 }
             });
+
+            addMouseListener(
+                new MouseAdapter() {
+                    @Override
+                    public void mouseClicked(MouseEvent e) {
+                        // middle click to close tab
+                        if (e.getButton() == MouseEvent.BUTTON2 && editor.safetyPrompt()) {
+                            closeTabAt(editors.indexOf(editor));
+                        }
+                    }
+                }
+            );
         }
     }
 

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -44,6 +44,7 @@ import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.templates.TROView;
 import megamek.logging.MMLogger;
+import megameklab.EntityChangedUtil;
 import megameklab.MMLConstants;
 import megameklab.ui.dialog.MMLFileChooser;
 import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -44,7 +44,6 @@ import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.templates.TROView;
 import megamek.logging.MMLogger;
-import megameklab.EntityChangedUtil;
 import megameklab.MMLConstants;
 import megameklab.ui.dialog.MMLFileChooser;
 import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
@@ -1171,7 +1170,8 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
                 throw new Exception();
             }
 
-            if (!owner.safetyPrompt()) {
+            // TabbedUi loads a unit into a new tab, no safety prompt needed.
+            if (!(owner instanceof MegaMekLabTabbedUI) || !owner.safetyPrompt()) {
                 return;
             }
 

--- a/megameklab/src/megameklab/ui/util/MegaMekLabFileSaver.java
+++ b/megameklab/src/megameklab/ui/util/MegaMekLabFileSaver.java
@@ -19,9 +19,11 @@ import megamek.common.annotations.Nullable;
 import megamek.common.loaders.BLKFile;
 import megamek.logging.MMLogger;
 import megameklab.ui.FileNameManager;
+import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.PopupMessages;
 import megameklab.ui.dialog.MMLFileChooser;
 import megameklab.util.CConfig;
+import megameklab.util.EntityChangedUtil;
 
 import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -119,6 +121,12 @@ public class MegaMekLabFileSaver {
             } else {
                 BLKFile.encode(file.getPath(), entity);
             }
+
+            if (ownerFrame instanceof MegaMekLabMainUI mui) {
+                // Since we've saved the entity, update the entity being compared against to determine if the user has unsaved work.
+                EntityChangedUtil.editorSaved(mui);
+            }
+
             PopupMessages.showUnitSavedMessage(ownerFrame, entity, file);
             return file.toString();
         } catch (Exception ex) {

--- a/megameklab/src/megameklab/util/EntityChangedUtil.java
+++ b/megameklab/src/megameklab/util/EntityChangedUtil.java
@@ -33,17 +33,28 @@ import java.io.File;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Helps to determine if a tab should have an "Unsaved Work" indicator and if the "would you like to save" prompt should appear.
+ */
 public class EntityChangedUtil {
     private static final MMLogger logger = MMLogger.create(EntityChangedUtil.class);
 
     private static final Map<String, Entity> cache = new ConcurrentHashMap<>();
 
+    /**
+     * Determines if the editor has unsaved changes.
+     * @param editor The MainUI to check for changes
+     * @return true if saving the unit would produce a different unit than the one saved already, or if there is no existing file for the unit.
+     */
     public static boolean hasEntityChanged(MegaMekLabMainUI editor) {
         var filename = editor.getFileName();
         if (filename == null || filename.isBlank()) {
             return true;
         }
 
+        // The idea behind how this works is to store a copy of the unit based on that unit's current file.
+        // By encoding both the original and current version of the entity to mtf/blk at the same time,
+        // We ensure that identical units will encode to identical mtf/blk strings, which indicates no unsaved work.
 
         if (!cache.containsKey(filename)) {
             var f = new File(filename);
@@ -70,6 +81,10 @@ public class EntityChangedUtil {
         }
     }
 
+    /**
+     *
+     * @param editor The editor containing the unit that was just saved.
+     */
     public static void editorSaved(MegaMekLabMainUI editor) {
         var filename = editor.getFileName();
         if (filename == null || filename.isBlank()) {

--- a/megameklab/src/megameklab/util/EntityChangedUtil.java
+++ b/megameklab/src/megameklab/util/EntityChangedUtil.java
@@ -1,21 +1,42 @@
-package megameklab;
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package megameklab.util;
 
 import megamek.common.Entity;
 import megamek.common.Mek;
 import megamek.common.MekFileParser;
 import megamek.common.loaders.BLKFile;
+import megamek.common.loaders.EntityLoadingException;
 import megamek.common.loaders.EntitySavingException;
 import megamek.logging.MMLogger;
 import megameklab.ui.MegaMekLabMainUI;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class EntityChangedUtil {
-    private static MMLogger logger = MMLogger.create(EntityChangedUtil.class);
+    private static final MMLogger logger = MMLogger.create(EntityChangedUtil.class);
 
-    private static Map<String, String> cache = new ConcurrentHashMap<>();
+    private static final Map<String, Entity> cache = new ConcurrentHashMap<>();
 
     public static boolean hasEntityChanged(MegaMekLabMainUI editor) {
         var filename = editor.getFileName();
@@ -32,14 +53,15 @@ public class EntityChangedUtil {
 
             try {
                 var e = new MekFileParser(f).getEntity();
-                cache.put(filename, encode(e));
+                cache.put(filename, e);
             } catch (Exception ex) {
                 logger.error("Entity loading failure:", ex);
+                cache.put(filename, null);
             }
         }
 
         try {
-            var o = cache.get(filename);
+            var o = encode(cache.get(filename));
             var n = encode(editor.getEntity());
             return !o.equals(n);
         } catch (EntitySavingException e) {
@@ -55,13 +77,19 @@ public class EntityChangedUtil {
         }
 
         try {
-            cache.put(editor.getFileName(), encode(editor.getEntity()));
-        } catch (EntitySavingException e) {
+            var bis = new ByteArrayInputStream(encode(editor.getEntity()).getBytes());
+            cache.put(editor.getFileName(), new MekFileParser(bis, editor.getFileName()).getEntity());
+        } catch (EntitySavingException | EntityLoadingException e) {
+            cache.remove(filename);
             logger.error("Entity encoding failure:", e);
         }
     }
 
     private static String encode(Entity e) throws EntitySavingException {
+        if (e == null) {
+            return "";
+        }
+
         if (e instanceof Mek m) {
             return m.getMtf();
         } else {


### PR DESCRIPTION
This enables MML to determine if a unit has unsaved changes, offering us two features: First, tabs now show a little * next to the unit name if the tab has unsaved work, and second, we don't show the "would you like to save your work" safety prompt for units which don't have any work to save.

This PR also contains a very small extra feature, which allows you to middle click tabs to close them, which might cause merge conflicts if it was in a separate PR.