### PR TITLE
Fix loading of FMU slots

### DIFF
--- a/megameklab/src/megameklab/ui/StartupGUI.java
+++ b/megameklab/src/megameklab/ui/StartupGUI.java
@@ -279,6 +279,7 @@ public class StartupGUI extends SkinnedJPanel implements MenuBarOwner {
 
         CConfig.setMostRecentFile(fileName);
         if (previousFrame instanceof MegaMekLabTabbedUI tabbedUi) {
+            UnitUtil.updateLoadedUnit(newUnit);
             tabbedUi.addUnit(newUnit, fileName);
         } else if (!(previousFrame instanceof MegaMekLabMainUI)
                 || (newUnit.getEntityType() != previousFrame.getEntity().getEntityType())) {


### PR DESCRIPTION
Yeah, that function you're supposed to call on a unit before loading it in the editor? Turns out it exists for a reason.

Fixes #1687.