### PR TITLE
Fix 1686: Add unit test to verify IS Unofficial tech base and level can be saved and loaded

### DIFF
--- a/megameklab/testresources/ui/generalUnit/BasicInfoViewTest/Puma Assault Tank PAT-001.blk
+++ b/megameklab/testresources/ui/generalUnit/BasicInfoViewTest/Puma Assault Tank PAT-001.blk
@@ -1,0 +1,103 @@
+#Saved from version 0.50.03-SNAPSHOT on 2025-01-09
+<UnitType>
+Tank
+</UnitType>
+
+<Name>
+Puma Assault Tank
+</Name>
+
+<Model>
+PAT-001
+</Model>
+
+<mul id:>
+4879
+</mul id:>
+
+<year>
+2650
+</year>
+
+<originalBuildYear>
+2650
+</originalBuildYear>
+
+<type>
+IS Level 1
+</type>
+
+<role>
+None
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<cruiseMP>
+3
+</cruiseMP>
+
+<engine_type>
+0
+</engine_type>
+
+<armor_type>
+0
+</armor_type>
+
+<armor_tech_rating>
+0
+</armor_tech_rating>
+
+<armor_tech_level>
+0
+</armor_tech_level>
+
+<armor>
+48
+32
+32
+24
+48
+</armor>
+
+<Body Equipment>
+IS Vehicle Flamer Ammo
+IS Ammo SRM-4
+IS Ammo LRM-20
+IS Ammo LRM-20
+</Body Equipment>
+
+<Front Equipment>
+Medium Laser
+Medium Laser
+SRM 4
+</Front Equipment>
+
+<Right Equipment>
+LRM 20
+</Right Equipment>
+
+<Left Equipment>
+LRM 20
+</Left Equipment>
+
+<Rear Equipment>
+Small Laser
+Flamer (Vehicle)
+</Rear Equipment>
+
+<Turret Equipment>
+PPC
+</Turret Equipment>
+
+<source>
+TRO: 3050
+</source>
+
+<tonnage>
+95.0
+</tonnage>
+

--- a/megameklab/unittests/megameklab/ui/generalUnit/BasicInfoViewTest.java
+++ b/megameklab/unittests/megameklab/ui/generalUnit/BasicInfoViewTest.java
@@ -1,0 +1,66 @@
+package megameklab.ui.generalUnit;
+
+import megamek.common.*;
+import megamek.common.loaders.BLKFile;
+import megamek.common.loaders.BLKTankFile;
+import megamek.common.loaders.EntityLoadingException;
+import megamek.common.loaders.EntitySavingException;
+import megamek.common.util.BuildingBlock;
+import megameklab.testing.util.InitializeTypes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(value = InitializeTypes.class)
+class BasicInfoViewTest {
+
+    // Filenames must be preceded with a slash to load from the testresources path
+    private final String resourcesPath = "/ui/generalUnit/BasicInfoViewTest/";
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    private Entity loadEntity(String filename) throws EntityLoadingException {
+        String path = resourcesPath + filename;
+        InputStream is = getClass().getResourceAsStream(path);
+        assertNotNull(is);
+        return new MekFileParser(is, filename).getEntity();
+    }
+
+    @Test
+    void testSetTechAdvancementFromEarlyISUnofficial() throws EntityLoadingException, EntitySavingException {
+        String fname = "Puma Assault Tank PAT-001.blk";
+        Entity te = loadEntity(fname);
+
+        // Confirm expected Tech Base (IS) and Tech Level (Simple Intro)
+        int techBase = te.getTechBase();
+        int techLevel = te.getTechLevel();
+        assertEquals(TechAdvancement.TECH_BASE_IS, techBase);
+        assertEquals(TechConstants.T_SIMPLE_INTRO, techLevel);
+
+        // Update Tech Level
+        te.setTechLevel(TechConstants.T_IS_UNOFFICIAL);
+
+        // Convert test entity to BLK block and back to a new entity using BLKFile conversion
+        BLKTankFile blkTankFile = new BLKTankFile(BLKFile.getBlock(te));
+        Entity newTE = blkTankFile.getEntity();
+
+        // Confirm values were saved correctly
+        techBase = newTE.getTechBase();
+        techLevel = newTE.getTechLevel();
+        // Confirm expected Tech Base (IS) and Tech Level (IS Unofficial)
+        assertEquals(TechAdvancement.TECH_BASE_IS, techBase);
+        assertEquals(TechConstants.T_IS_UNOFFICIAL, techLevel);
+        assertFalse(newTE.isClan());
+    }
+}


### PR DESCRIPTION
Unit test to verify updating and saving BLK files from MML code will maintain IS Unofficial tech base and level.

Confirms fix for #1686

Note: must be merged following [this PR](https://github.com/MegaMek/megamek/pull/6386) or the test will fail.