### PR TITLE
 Fix for Introductory tech level also showing Standard equipment in non-VTL mode.

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
@@ -409,7 +409,8 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     @Override
     public SimpleTechLevel getTechLevel() {
         try {
-            return SimpleTechLevel.valueOf(((String) cbTechLevel.getSelectedItem()).toUpperCase());
+            return SimpleTechLevel.parse((String) cbTechLevel.getSelectedItem());
+            //return SimpleTechLevel.valueOf(((String) cbTechLevel.getSelectedItem()).toUpperCase());
         } catch (Exception e) {
             return SimpleTechLevel.STANDARD;
         }

--- a/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
@@ -410,7 +410,6 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
     public SimpleTechLevel getTechLevel() {
         try {
             return SimpleTechLevel.parse((String) cbTechLevel.getSelectedItem());
-            //return SimpleTechLevel.valueOf(((String) cbTechLevel.getSelectedItem()).toUpperCase());
         } catch (Exception e) {
             return SimpleTechLevel.STANDARD;
         }

--- a/megameklab/src/megameklab/ui/util/AbstractEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/util/AbstractEquipmentDatabaseView.java
@@ -555,6 +555,9 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
             public boolean include(Entry<? extends EquipmentTableModel, ? extends Integer> entry) {
                 EquipmentTableModel equipModel = entry.getModel();
                 EquipmentType etype = equipModel.getType(entry.getIdentifier());
+                // Note: append `&& eSource.getTechManager().getGameYear() >= etype.getProductionDate()`
+                // or `etype.getCommonDate()` in case we wish to change the availability start year from
+                // the prototype/introduction date to something later.
                 return shouldShow(etype);
             }
         };


### PR DESCRIPTION
While exploring our Equipment filtering code as part of #1696 , I found that we are incorrectly applying the "Introductory" tech level filter in such a way that it always shows up to Standard-level equipment instead.

The fix is to use an existing function in SimpleTechLevel to get the correct enum value from the Tech Level combobox, which prevents the exception that defaults to Standard tech level.

Testing:
- Ran all 3 projects' unit tests
- Confirmed Tech Level selection now works correctly in the UI
- Confirmed non-VTL tech advancement follows the process outlined in #1696 comments

Close #1696 