### PR TITLE
Fix "Reset crits" on DropShip/SmallCraft not working

### DIFF
--- a/megameklab/src/megameklab/ui/util/ITab.java
+++ b/megameklab/src/megameklab/ui/util/ITab.java
@@ -49,7 +49,7 @@ public class ITab extends JPanel {
     }
 
     public Aero getAero() {
-        return (AeroSpaceFighter) eSource.getEntity();
+        return (Aero) eSource.getEntity();
     }
 
     public SmallCraft getSmallCraft() {


### PR DESCRIPTION
Fixes #1699, `getAero` is used by some methods that work with any kind of aerospace unit, not necessary an ASF.