### PR TITLE
fix transport tab weight inflation on infantry bays

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/TransportTab.java
@@ -430,7 +430,7 @@ public class TransportTab extends IView implements ActionListener, ChangeListene
                 }
             } else {
                 BayData bayType = BayData.getBayType(bay);
-                Bay newBay = bayType.newBay(bay.getCapacity(), bayNum);
+                Bay newBay = bayType.newBay(bay.getUnusedSlots(), bayNum);
                 newBay.setDoors(bay.getDoors());
                 newBay.setFacing(bay.getFacing());
                 if (getEntity().isPodMountedTransport(bay)) {


### PR DESCRIPTION
I think this fixes #1661 
Infantry Bays multiplied their own weight by their intrinsic weight (e.g. 5 for foot inf) every time they were re-created. I suppose this led to the weird crew calculation. The MASH bug is fixed by unit data changes in MM.