### PR TITLE
Prevent tab names from being messed up by entity type change

### DIFF
--- a/megameklab/docs/history.txt
+++ b/megameklab/docs/history.txt
@@ -2,6 +2,7 @@ MEGAMEKLAB VERSION HISTORY:
 ----------------
 0.50.04-SNAPSHOT
 + Fix #1707: Fix transport tab weight inflation on infantry bays
++ Fix #1710: Prevent tab names from being messed up by entity type change
 
 0.50.03 (2025-02-02 2030 UTC)
 + PR #1678: MHQ RFE #5604: save refit files from MHQ MekLab tab (MML side)

--- a/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabMainUI.java
@@ -133,7 +133,7 @@ public abstract class MegaMekLabMainUI extends JFrame implements RefreshListener
         setTitle(getEntity().getFullChassis() + " " + getEntity().getModel() + fileInfo);
         if (owner != null) {
             getEntity().generateDisplayName();
-            owner.setTabName(getEntity().getDisplayName());
+            owner.setTabName(getEntity().getDisplayName(), this);
         }
     }
 

--- a/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
@@ -119,11 +119,12 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
      * Should typically be called when the name of the unit being edited changes.
      *
      * @param tabName The new name to be set for the currently selected tab.
+     * @param editor The editor for which the tab name needs to be set
      */
-    public void setTabName(String tabName) {
+    public void setTabName(String tabName, MegaMekLabMainUI editor) {
         // ClosableTab is a label with the unit name, and a close button.
         // If we didn't need that close button, this could be tabs.setTitleAt
-        tabs.setTabComponentAt(tabs.getSelectedIndex(), new EditorTab(tabName, currentEditor()) );
+        tabs.setTabComponentAt(editors.indexOf(editor), new EditorTab(tabName, currentEditor()) );
     }
 
     /**

--- a/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
@@ -604,10 +604,7 @@ public class CVStructureTab extends ITab implements CVBuildListener, ArmorAlloca
         panArmorAllocation.setFromEntity(getTank());
         panPatchwork.setFromEntity(getTank());
         panSummary.refresh();
-        refresh.refreshEquipment();
-        refresh.refreshBuild();
-        refresh.refreshStatus();
-        refresh.refreshPreview();
+        refresh.refreshAll();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
@@ -152,6 +152,7 @@ public class ASMainUI extends MegaMekLabMainUI {
         buildTab.refresh();
         previewTab.refresh();
         floatingEquipmentDatabase.refresh();
+        refreshHeader();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
@@ -530,10 +530,7 @@ public class ASStructureTab extends ITab implements AeroBuildListener, ArmorAllo
             eSource.createNewUnit(Entity.ETYPE_CONV_FIGHTER, getAero());
         }
         refresh();
-        refresh.refreshEquipment();
-        refresh.refreshBuild();
-        refresh.refreshPreview();
-        refresh.refreshStatus();
+        refresh.refreshAll();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/infantry/CIMainUI.java
+++ b/megameklab/src/megameklab/ui/infantry/CIMainUI.java
@@ -91,6 +91,7 @@ public class CIMainUI extends MegaMekLabMainUI {
         statusbar.refresh();
         structureTab.refresh();
         previewTab.refresh();
+        refreshHeader();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -196,6 +196,7 @@ public class DSMainUI extends MegaMekLabMainUI {
         buildTab.refresh();
         previewTab.refresh();
         floatingEquipmentDatabase.refresh();
+        refreshHeader();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
@@ -434,11 +434,7 @@ public class DSStructureTab extends ITab implements DropshipBuildListener, Armor
             eSource.createNewUnit(Entity.ETYPE_DROPSHIP, getSmallCraft());
         }
         refresh();
-        refresh.refreshEquipment();
-        refresh.refreshBuild();
-        refresh.refreshTransport();
-        refresh.refreshPreview();
-        refresh.refreshStatus();
+        refresh.refreshAll();
     }
 
 
@@ -453,9 +449,7 @@ public class DSStructureTab extends ITab implements DropshipBuildListener, Armor
         }
         panArmor.setFromEntity(getSmallCraft());
         panHeat.setFromAero(getSmallCraft());
-        refresh.refreshBuild();
-        refresh.refreshStatus();
-        refresh.refreshPreview();
+        refresh.refreshAll();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
@@ -213,6 +213,7 @@ public class WSMainUI extends MegaMekLabMainUI {
         buildTab.refresh();
         previewTab.refresh();
         floatingEquipmentDatabase.refresh();
+        refreshHeader();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
@@ -486,11 +486,7 @@ public class WSStructureTab extends ITab implements AdvancedAeroBuildListener, A
                 break;
         }
         refresh();
-        refresh.refreshEquipment();
-        refresh.refreshBuild();
-        refresh.refreshTransport();
-        refresh.refreshPreview();
-        refresh.refreshStatus();
+        refresh.refreshAll();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/mek/BMMainUI.java
+++ b/megameklab/src/megameklab/ui/mek/BMMainUI.java
@@ -177,6 +177,7 @@ public class BMMainUI extends MegaMekLabMainUI {
         buildTab.refresh();
         previewTab.refresh();
         floatingEquipmentDatabase.refresh();
+        refreshHeader();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -822,10 +822,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         }
 
         refresh();
-        refresh.refreshEquipment();
-        refresh.refreshBuild();
-        refresh.refreshPreview();
-        refresh.refreshStatus();
+        refresh.refreshAll();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
@@ -132,6 +132,7 @@ public class PMMainUI extends MegaMekLabMainUI {
         buildTab.refresh();
         previewTab.refresh();
         floatingEquipmentDatabase.refresh();
+        refreshHeader();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
@@ -384,11 +384,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
             panChassisMod.setFromEntity(getSV());
             panCrew.setFromEntity(getSV());
             panSummary.refresh();
-            refresh.refreshEquipmentTable();
-            refresh.refreshBuild();
-            refresh.refreshStatus();
-            refresh.refreshPreview();
-            // TODO: Refresh other views
+            refresh.refreshAll();
         }
     }
 


### PR DESCRIPTION
Changing the type of an entity (e.g., from biped mek to quad mek) now properly updates the tab title instead of setting it to "null".
This bug actually existed before tabs, where it would improperly set the window title. 