### PR TITLE
Issue #1575: correctly identify compact heat sinks

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -221,6 +221,10 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
                     .filter(UnitUtil::isHeatSink).findAny();
         }
         if (hs.isPresent()) {
+            if (hs.get().is(EquipmentTypeLookup.COMPACT_HS_2)) {
+                // 2 CHS packed in 1 slot is its own MiscType but doesnt find the right combobox entry; must translate it manually
+                hs = Optional.of((MiscType) EquipmentType.get(EquipmentTypeLookup.COMPACT_HS_1));
+            }
             cbHSType.removeActionListener(this);
             setHeatSinkType(hs.get());
             cbHSType.addActionListener(this);


### PR DESCRIPTION
Fixes #1575
Also fixes #1649 which I think was caused by a mismatch of the unit having CHS and the MML UI having selected Single HS

2 CHS packed in 1 slot is its own MiscType. The UI didnt find the Compact HS combobox entry for it though. This happened only when the CHS needed to be assigned to slots (more than the engine free).

history entry: The MML heat sink GUI section will now correctly identify compact heat sinks on a freshly-loaded mek even if it has some of them assigned to crit slots

