### PR TITLE
#1536: Unify armorable equipment tests in MM

### DIFF
--- a/megameklab/src/megameklab/ui/util/BAASBMDropTargetCriticalList.java
+++ b/megameklab/src/megameklab/ui/util/BAASBMDropTargetCriticalList.java
@@ -393,8 +393,8 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                     }
                 }
 
-                if (UnitUtil.isArmorable(cs) && !(getUnit() instanceof BattleArmor)
-                        && eSource.getTechManager().isLegal(Entity.getArmoredComponentTechAdvancement())) {
+                if ((cs != null) && cs.isArmorable() && (getUnit() instanceof Mek)
+                    && eSource.getTechManager().isLegal(Entity.getArmoredComponentTechAdvancement())) {
                     popup.addSeparator();
                     if (cs.isArmored()) {
                         JMenuItem info = new JMenuItem("Remove Armoring");

--- a/megameklab/src/megameklab/ui/util/DropTargetCriticalList.java
+++ b/megameklab/src/megameklab/ui/util/DropTargetCriticalList.java
@@ -19,7 +19,6 @@ import java.awt.dnd.DropTargetDragEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.Objects;
 import java.util.Vector;
 
 import javax.swing.JList;
@@ -28,7 +27,6 @@ import javax.swing.JPopupMenu;
 
 import megamek.common.CriticalSlot;
 import megamek.common.Entity;
-import megamek.common.Mek;
 import megamek.common.MekFileParser;
 import megamek.common.MiscType;
 import megamek.common.Mounted;
@@ -172,22 +170,6 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
                     }
                 }
 
-                if ((getUnit() instanceof Mek) && UnitUtil.isArmorable(cs)
-                        && eSource.getTechManager().isLegal(Entity.getArmoredComponentTechAdvancement())) {
-                    popup.addSeparator();
-                    if (cs.isArmored()) {
-                        JMenuItem info = new JMenuItem("Remove Armoring");
-                        info.setActionCommand(Integer.toString(location));
-                        info.addActionListener(evt2 -> changeArmoring());
-                        popup.add(info);
-                    } else {
-                        JMenuItem info = new JMenuItem("Add Armoring");
-                        info.setActionCommand(Integer.toString(location));
-                        info.addActionListener(evt2 -> changeArmoring());
-                        popup.add(info);
-                    }
-                }
-
                 if (popup.getComponentCount() > 0) {
                     popup.show(this, evt.getX(), evt.getY());
                 }
@@ -285,25 +267,6 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
 
     private int getCritLocation() {
         return Integer.parseInt(getName());
-    }
-
-    private void changeArmoring() {
-        CriticalSlot cs = getCrit();
-
-        if (cs != null) {
-            if (cs.getType() == CriticalSlot.TYPE_EQUIPMENT) {
-                Mounted<?> mount = Objects.requireNonNull(getMounted());
-                mount.setArmored(!cs.isArmored());
-                UnitUtil.updateCritsArmoredStatus(getUnit(), mount);
-            } else {
-                cs.setArmored(!cs.isArmored());
-                UnitUtil.updateCritsArmoredStatus(getUnit(), cs, getCritLocation());
-            }
-        }
-
-        if (refresh != null) {
-            refresh.refreshAll();
-        }
     }
 
     private void removeMount() {

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -1347,27 +1347,6 @@ public class UnitUtil {
         return UnitUtil.isArmor(eq) || UnitUtil.isStructure(eq);
     }
 
-    public static boolean isArmorable(@Nullable CriticalSlot cs) {
-        if (cs == null) {
-            return false;
-        } else if (cs.getType() == CriticalSlot.TYPE_SYSTEM) {
-            return true;
-        } else {
-            Mounted<?> mount = cs.getMount();
-            return (mount != null) && isArmorable(mount.getType());
-        }
-    }
-
-    public static boolean isArmorable(EquipmentType eq) {
-        if (eq instanceof AmmoType) {
-            // The prohibition against armoring ammo bins presumably only applies to actual
-            // ammo bins and not equipment that we've implemented as ammo because it's
-            // explody and gets used up.
-            return ((AmmoType) eq).getAmmoType() == AmmoType.T_COOLANT_POD;
-        }
-        return eq.isHittable();
-    }
-
     public static void updateLoadedUnit(Entity unit) {
         // Check for illegal armor tech levels and set to the tech level of the unit.
         for (int loc = 0; loc < unit.locations(); loc++) {


### PR DESCRIPTION
Fixes #1536
Requires MegaMek/megamek#6541

This moves tests for armorable components (TO:AUE p95) from MML to MM to unify them. 

Also removes some armoring code from DropTargetCritList as that class is not used for Meks and armoring is not allowed elsewhere.

history entry: + Fix #1536: Mek shields can now be armored

