### PR TITLE
Improve RS display of information for Insulators/Pulse Modules/Capacitors

### DIFF
--- a/megameklab/src/megameklab/printing/PrintUtil.java
+++ b/megameklab/src/megameklab/printing/PrintUtil.java
@@ -92,9 +92,12 @@ public final class PrintUtil {
                         || eq.hasFlag(MiscType.F_MASS)
                         || eq.hasFlag(MiscType.F_CHASSIS_MODIFICATION)
                         || eq.hasFlag(MiscType.F_SPONSON_TURRET))
-                || eq.hasFlag(MiscType.F_EXTERNAL_STORES_HARDPOINT)
-                || eq.hasFlag(MiscType.F_BASIC_FIRECONTROL)
-                || eq.hasFlag(MiscType.F_ADVANCED_FIRECONTROL)) {
+                        || eq.hasFlag(MiscType.F_EXTERNAL_STORES_HARDPOINT)
+                        || eq.hasFlag(MiscType.F_BASIC_FIRECONTROL)
+                        || eq.hasFlag(MiscType.F_ADVANCED_FIRECONTROL)
+                        || eq.hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)
+                        || eq.hasFlag(MiscType.F_LASER_INSULATOR)
+        ) {
             return false;
         }
 

--- a/megameklab/src/megameklab/printing/StandardInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/StandardInventoryEntry.java
@@ -26,6 +26,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import megamek.common.*;
 import megamek.common.equipment.WeaponMounted;
@@ -51,6 +53,8 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
     private final String[][] ranges;
     private final boolean isMML;
     private final boolean isATM;
+    private final boolean hasInsulator;
+    private final boolean hasPulseModule;
     private final boolean hasArtemis;
     private final boolean hasArtemisProto;
     private final boolean hasArtemisV;
@@ -111,6 +115,8 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
         isSquadSupport = m.isSquadSupportWeapon();
         isMML = m.getType() instanceof MMLWeapon;
         isATM = m.getType() instanceof ATMWeapon || m.getType() instanceof CLIATMWeapon;
+        hasInsulator = hasLinkedEquipment(m, MiscType.F_LASER_INSULATOR);
+        hasPulseModule = hasLinkedEquipment(m, MiscType.F_RISC_LASER_PULSE_MODULE);
         hasArtemis = hasLinkedEquipment(m, MiscType.F_ARTEMIS);
         hasArtemisProto = hasLinkedEquipment(m, MiscType.F_ARTEMIS_PROTO);
         hasArtemisV = hasLinkedEquipment(m, MiscType.F_ARTEMIS_V);
@@ -400,6 +406,10 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
             return "w/Apollo";
         } else if (hasCapacitor) {
             return "w/Capacitor";
+        } else if (hasPulseModule) {
+            return "w/RISC Laser Module";
+        } else if (hasInsulator) {
+            return "w/Laser Insulator";
         }
         return "";
     }
@@ -421,10 +431,22 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
             } else {
                 return DASH;
             }
+        } else if(row == 1) {
+            if (hasInsulator) {
+                return Integer.toString(mount.getType().getHeat() - 1);
+            } else if (hasPulseModule) {
+                return Integer.toString(mount.getType().getHeat() + 2);
+            } else if (hasCapacitor) {
+                return Integer.toString(mount.getType().getHeat() + 5);
+            } else {
+                return "";
+            }
         } else {
             return "";
         }
     }
+
+    private static final Pattern digits = Pattern.compile("\\d+");
 
     @Override
     public String getDamageField(int row) {
@@ -456,6 +478,8 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
             return "";
         } else if (row == 0) {
             return StringUtils.getEquipmentInfo(mount.getEntity(), mount);
+        } else if (row == 1 && hasCapacitor) {
+            return StringUtils.getEquipmentInfo(mount.getEntity(), mount, true);
         }
         return "";
     }
@@ -545,7 +569,7 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
             return 3 + mmlArtemisRowDelta();
         } else if (isATM) {
             return 4;
-        } else if (hasArtemis || hasArtemisV || hasApollo || hasArtemisProto || hasCapacitor) {
+        } else if (hasArtemis || hasArtemisV || hasApollo || hasArtemisProto || hasCapacitor || hasPulseModule || hasInsulator) {
             return 2;
         }
         return 1;
@@ -573,7 +597,9 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
                 isTurret == that.isTurret &&
                 isSquadSupport == that.isSquadSupport &&
                 name.equals(that.name) &&
-                location.equals(that.location);
+                location.equals(that.location) &&
+                hasInsulator == that.hasInsulator &&
+                hasPulseModule == that.hasPulseModule;
     }
 
     @Override

--- a/megameklab/src/megameklab/printing/StandardInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/StandardInventoryEntry.java
@@ -426,15 +426,15 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
     @Override
     public String getHeatField(int row) {
         if (row == 0) {
-            if (mount.getType().getHeat() > 0) {
+            if (hasInsulator) {
+                return Integer.toString(mount.getType().getHeat() - 1) + '*';
+            } else if (mount.getType().getHeat() > 0) {
                 return Integer.toString(mount.getType().getHeat());
             } else {
                 return DASH;
             }
         } else if(row == 1) {
-            if (hasInsulator) {
-                return Integer.toString(mount.getType().getHeat() - 1);
-            } else if (hasPulseModule) {
+            if (hasPulseModule) {
                 return Integer.toString(mount.getType().getHeat() + 2);
             } else if (hasCapacitor) {
                 return Integer.toString(mount.getType().getHeat() + 5);

--- a/megameklab/src/megameklab/printing/StandardInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/StandardInventoryEntry.java
@@ -599,7 +599,8 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
                 name.equals(that.name) &&
                 location.equals(that.location) &&
                 hasInsulator == that.hasInsulator &&
-                hasPulseModule == that.hasPulseModule;
+                hasPulseModule == that.hasPulseModule &&
+                hasCapacitor == that.hasCapacitor;
     }
 
     @Override

--- a/megameklab/src/megameklab/util/StringUtils.java
+++ b/megameklab/src/megameklab/util/StringUtils.java
@@ -74,6 +74,10 @@ public class StringUtils {
     }
 
     public static String getEquipmentInfo(Entity unit, Mounted<?> mount) {
+        return getEquipmentInfo(unit, mount, false);
+    }
+
+    public static String getEquipmentInfo(Entity unit, Mounted<?> mount, boolean capacitor) {
         String info = "";
 
         if (mount.getType() instanceof WeaponType) {
@@ -121,7 +125,7 @@ public class StringUtils {
                         || (weapon instanceof PrototypeRLWeapon)) {
                     info = "1/Msl [M,C]";
                 } else if (weapon instanceof ISSnubNosePPC) {
-                    info = "10/8/5 [DE,V]";
+                    info = capacitor ? "15/13/10 [DE,V,X]" : "10/8/5 [DE,V]";
                 } else if (weapon instanceof VariableSpeedPulseLaserWeapon) {
                     info = String.format("%d/%d/%d [P,V]",
                             weapon.getDamage(weapon.getShortRange()),
@@ -168,7 +172,14 @@ public class StringUtils {
                 info = "[AE,OS]";
             } else {
                 if (!UnitUtil.isAMS(weapon)) {
-                    info = Integer.toString(weapon.getDamage());
+                    if (capacitor) {
+                        if (!(weapon instanceof PPCWeapon) || !mount.getLinkedBy().getType().hasFlag(MiscType.F_PPC_CAPACITOR)) {
+                            throw new IllegalArgumentException("Don't ask for the statline of a weapon with its capacitor charged if it's not a PPC with a capacitor");
+                        }
+                        info = Integer.toString(weapon.getDamage() + 5);
+                    } else {
+                        info = Integer.toString(weapon.getDamage());
+                    }
                 }
                 info += " [";
 
@@ -214,9 +225,8 @@ public class StringUtils {
                     info += "AI,";
                 }
 
-                if (weapon.isExplosive(mount) && !(weapon instanceof ACWeapon)
-                        && (!(weapon instanceof PPCWeapon) || ((mount.getLinkedBy() != null)
-                                && mount.getLinkedBy().getType().hasFlag(MiscType.F_PPC_CAPACITOR)))) {
+                if (weapon.isExplosive(mount, capacitor) && !(weapon instanceof ACWeapon)
+                ) {
                     info += "X,";
                 }
 


### PR DESCRIPTION
Previously Laser Insulators and RISC Laser Pulse Modules would be listed as ordinary equipment in the RS inventory readout.
This adjusts them to be displayed together with the weapon they're associated with, similar to how Artemis and PPC Capacitors work.

Additionally, since these enhancements (plus the capacitor) affect the weapon's basic stats and they take up a second line on the sheet, we can use that second line to display the new stats for for the weapon with that enhancement. 

Example sheet:
![image](https://github.com/user-attachments/assets/ef6804bd-fc6b-4d6c-af2c-52b3e6040c11)


In the future it would be nice to also update the value shown in the heat profile, but that's a separate (and more complex) issue that I won't be addressing for now.