### PR TITLE
Fixes for tabbed UI

### DIFF
--- a/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
@@ -302,8 +302,10 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
     }
 
     private void closeTabAt(int position) {
+        // If you try to close the last tab, create a new blank mek tab
+        // Since the UI can't exist in a meaningful state without a tab open
         if (tabs.getTabCount() <= 2) {
-            MegaMekLabTabbedUI.this.dispatchEvent(new WindowEvent(MegaMekLabTabbedUI.this, WindowEvent.WINDOW_CLOSING));
+            newTab();
         }
 
         var editor = editors.get(position);
@@ -314,6 +316,7 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
         }
         editors.remove(editor);
         closedEditors.push(editor);
+
         // Tell the menu bar to enable the "reopen tab" shortcut
         refreshMenuBar();
     }

--- a/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
@@ -197,6 +197,7 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
         tabs.setTabComponentAt(tabs.getSelectedIndex(), new EditorTab(newUi.getEntity().getDisplayName(), newUi));
         tabs.setEnabledAt(tabs.getSelectedIndex(), true);
         oldUi.dispose();
+        refreshMenuBar();
     }
 
     /**


### PR DESCRIPTION
Fixes #1716: When switching unit type, the menubar is now refreshed to reflect to the new unit type.
Fixes #1718: When closing the last tab, create a new blank mek tab instead of entering a broken tabless state.