### PR TITLE
Chain Drape

### DIFF
--- a/megameklab/src/megameklab/util/MekUtil.java
+++ b/megameklab/src/megameklab/util/MekUtil.java
@@ -640,7 +640,7 @@ public final class MekUtil {
                     locations.add(Mek.LOC_CLEG);
                     blocks = 3;
                 }
-            } else if (equip.hasFlag(MiscType.F_PARTIAL_WING)) {
+            } else if (equip.hasFlag(MiscType.F_PARTIAL_WING) || equip.hasFlag(MiscType.F_CHAIN_DRAPE)) {
                 // one block in each side torso
                 locations.add(Mek.LOC_LT);
                 locations.add(Mek.LOC_RT);
@@ -1337,6 +1337,10 @@ public final class MekUtil {
             }
             if ((eq.hasFlag(MiscType.F_QUAD_TURRET) || eq.hasFlag(MiscType.F_RAM_PLATE))
                     && !(unit instanceof QuadMek)) {
+                return false;
+            }
+            if ((eq.hasFlag(MiscType.F_CHAIN_DRAPE_PONCHO) || eq.hasFlag(MiscType.F_CHAIN_DRAPE_APRON))
+                && unit instanceof QuadMek) {
                 return false;
             }
 

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -95,6 +95,7 @@ public class UnitUtil {
                         || eq.hasFlag(MiscType.F_BLUE_SHIELD)
                         || eq.hasFlag(MiscType.F_MAST_MOUNT)
                         || eq.hasFlag(MiscType.F_SCM)
+                        || eq.hasFlag(MiscType.F_CHAIN_DRAPE)
                         || (eq.hasFlag(MiscType.F_RAM_PLATE)
                                 || (eq.hasFlag(MiscType.F_JUMP_JET) && eq.hasFlag(MiscType.F_PROTOMEK_EQUIPMENT))
                                 || (eq.hasFlag(MiscType.F_UMU) && eq.hasFlag(MiscType.F_PROTOMEK_EQUIPMENT))
@@ -187,6 +188,8 @@ public class UnitUtil {
         final EquipmentType eq = mount.getType();
         if ((eq instanceof MiscType) && eq.hasFlag(MiscType.F_PARTIAL_WING)) {
             toReturn = eq.isClan() ? 3 : 4;
+        } else if (eq.hasFlag(MiscType.F_CHAIN_DRAPE)) {
+            toReturn = 3;
         } else if ((eq instanceof MiscType)
                 && (eq.hasFlag(MiscType.F_JUMP_BOOSTER)
                         || eq.hasFlag(MiscType.F_TALON)


### PR DESCRIPTION
Chain Drape from Arcade Operations: UrbanFest.

Closes #1222.

Requires MegaMek/megamek#6594, see there for more information.

There are a couple differences between the published UrbanKnight sheet and this recreated one.
First, the printed MP is reduced to be consistent with Modular Armor reducing the MP listed on the record sheet.
Second, the BV doesn't match. There is no published information on calculating BV for the chain drape, so I don't know how to make it line up.
![image](https://github.com/user-attachments/assets/43ac74a9-f66e-4fee-b426-5d65ea20ee57)
