### PR TITLE
Allow loading multiple unit files by drag-and-drop

### DIFF
--- a/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
@@ -28,7 +28,7 @@ import megameklab.MegaMekLab;
 import megameklab.ui.dialog.UiLoader;
 import megameklab.ui.mek.BMMainUI;
 import megameklab.ui.util.ExitOnWindowClosingListener;
-import megameklab.ui.util.TabStateUtil;
+import megameklab.ui.util.TabUtil;
 import megameklab.util.CConfig;
 import megameklab.util.MMLFileDropTransferHandler;
 import megameklab.util.UnitUtil;
@@ -265,7 +265,7 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
 
         if (CConfig.getStartUpType() == MMLStartUp.RESTORE_TABS) {
             try {
-                TabStateUtil.saveTabState(editors.stream().limit(editors.size() - 1).toList());
+                TabUtil.saveTabState(editors.stream().limit(editors.size() - 1).toList());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -26,6 +26,7 @@ import java.awt.event.KeyEvent;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import javax.swing.*;

--- a/megameklab/src/megameklab/util/MMLFileDropTransferHandler.java
+++ b/megameklab/src/megameklab/util/MMLFileDropTransferHandler.java
@@ -2,6 +2,7 @@ package megameklab.util;
 
 import megamek.logging.MMLogger;
 import megameklab.ui.MenuBarOwner;
+import megameklab.ui.util.TabUtil;
 
 import javax.swing.*;
 import java.awt.datatransfer.DataFlavor;
@@ -35,8 +36,8 @@ public class MMLFileDropTransferHandler extends TransferHandler {
         try {
             var files = (List<File>) support.getTransferable().getTransferData(DataFlavor.javaFileListFlavor);
             if (files.size() != 1) {
-                logger.error("Cannot open multiple files at a time!", "Import error");
-                return false;
+                TabUtil.loadMany(files, owner);
+                return true;
             }
 
             var file = files.get(0);


### PR DESCRIPTION
Closes #1745.

Allows dragging multiple files onto MML (either the splash screen or the tabbed UI) to open all the files, with a progress bar: https://i.imgur.com/MbmR9ch.gif