### PR TITLE
Load multiple units from cache at a time

### DIFF
--- a/megameklab/build.gradle
+++ b/megameklab/build.gradle
@@ -84,6 +84,8 @@ dependencies {
         exclude group: 'xml-apis'
     }
 
+    implementation ('org.apache.commons:commons-collections4:4.5.0-M3')
+
     testImplementation 'org.mockito:mockito-core:5.15.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
 

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -14,27 +14,6 @@
  */
 package megameklab.ui;
 
-import java.awt.Component;
-import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.ClipboardOwner;
-import java.awt.datatransfer.StringSelection;
-import java.awt.datatransfer.Transferable;
-import java.awt.event.ActionEvent;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
-import java.util.List;
-import java.util.ResourceBundle;
-
-import javax.swing.*;
-import javax.swing.UIManager.LookAndFeelInfo;
-import javax.swing.filechooser.FileNameExtensionFilter;
-import javax.swing.text.DefaultCaret;
-import javax.swing.text.html.HTMLEditorKit;
-
 import megamek.client.ui.dialogs.BVDisplayDialog;
 import megamek.client.ui.dialogs.CostDisplayDialog;
 import megamek.client.ui.dialogs.WeightDisplayDialog;
@@ -55,6 +34,24 @@ import megameklab.ui.util.MegaMekLabFileSaver;
 import megameklab.util.CConfig;
 import megameklab.util.UnitPrintManager;
 import megameklab.util.UnitUtil;
+
+import javax.swing.*;
+import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import javax.swing.text.DefaultCaret;
+import javax.swing.text.html.HTMLEditorKit;
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.util.ResourceBundle;
 
 /**
  * @author jtighe (torren@users.sourceforge.net)
@@ -919,7 +916,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
     private void jMenuGetUnitValidationFromCache_actionPerformed() {
         UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(owner.getFrame());
         unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog);
+        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog, false);
         Entity chosenEntity = viewer.getChosenEntity();
         if (chosenEntity != null) {
             UnitUtil.showValidation(chosenEntity, owner.getFrame());
@@ -930,7 +927,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
     private void jMenuGetUnitBreakdownFromCache_actionPerformed() {
         UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(owner.getFrame());
         unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog);
+        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog, false);
         Entity chosenEntity = viewer.getChosenEntity();
         if (chosenEntity != null) {
             new CostDisplayDialog(owner.getFrame(), chosenEntity).setVisible(true);
@@ -941,7 +938,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
     private void jMenuGetUnitWeightBreakdownFromCache_actionPerformed() {
         UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(owner.getFrame());
         unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog);
+        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog, false);
 
         Entity chosenEntity = viewer.getChosenEntity();
         if (chosenEntity != null) {

--- a/megameklab/src/megameklab/ui/dialog/MegaMekLabUnitSelectorDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/MegaMekLabUnitSelectorDialog.java
@@ -18,23 +18,6 @@
  */
 package megameklab.ui.dialog;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Image;
-import java.awt.event.ActionEvent;
-import java.awt.event.KeyEvent;
-import java.util.function.Consumer;
-
-import javax.swing.AbstractAction;
-import javax.swing.Action;
-import javax.swing.ImageIcon;
-import javax.swing.JButton;
-import javax.swing.JComponent;
-import javax.swing.JFrame;
-import javax.swing.JPanel;
-import javax.swing.JRootPane;
-import javax.swing.KeyStroke;
-
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.dialog.AbstractUnitSelectorDialog;
@@ -46,20 +29,32 @@ import megamek.common.TechConstants;
 import megamek.common.icons.Camouflage;
 import megameklab.util.CConfig;
 
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.util.ArrayList;
+import java.util.function.Consumer;
+
 public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
     // region Variable Declarations
     private Entity chosenEntity;
+    private ArrayList<Entity> chosenEntities;
     private final boolean allowPickWithoutClose;
-    private Consumer<Entity> entityPickCallback;
+    private Consumer<MegaMekLabUnitSelectorDialog> entityPickCallback;
 
     // endregion Variable Declarations
 
     /**
      * Constructs a Unit Selector Dialog that only allows choosing with closing the
      * dialog.
+     *
+     * @param parent The parent window of this dialog
+     * @param unitLoadingDialog A {@link UnitLoadingDialog} likely {@code new UnitLoadingDialog(parent)}.
+     * @param multiselect Set this to {@code true} to allow multiple units to be selected at once.
      */
-    public MegaMekLabUnitSelectorDialog(JFrame parent, UnitLoadingDialog unitLoadingDialog) {
-        super(parent, unitLoadingDialog);
+    public MegaMekLabUnitSelectorDialog(JFrame parent, UnitLoadingDialog unitLoadingDialog, boolean multiselect) {
+        super(parent, unitLoadingDialog, multiselect);
         gameTechLevel = TechConstants.T_SIMPLE_UNOFFICIAL;
         allowPickWithoutClose = false;
         eraBasedTechLevel = CConfig.getBooleanParam(CConfig.TECH_PROGRESSION);
@@ -74,11 +69,16 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
     /**
      * Constructs a Unit Selector Dialog that allows choosing a Unit while keeping
      * the dialog open by pressing Enter or the "Select" button. The
-     * entityPickCallback method will be called when a Unit is selected in this way.
+     * entityPickCallback method will be called when units are selected in this way.
+     * Multiselect is always enabled.
+     *
+     * @param parent The parent window of this dialog
+     * @param unitLoadingDialog A {@link UnitLoadingDialog} likely {@code new UnitLoadingDialog(parent)}.
+     * @param entityPickCallback This will be called when the user presses Select.
      */
     public MegaMekLabUnitSelectorDialog(JFrame parent, UnitLoadingDialog unitLoadingDialog,
-            Consumer<Entity> entityPickCallback) {
-        super(parent, unitLoadingDialog);
+            Consumer<MegaMekLabUnitSelectorDialog> entityPickCallback) {
+        super(parent, unitLoadingDialog, true);
         gameTechLevel = TechConstants.T_SIMPLE_UNOFFICIAL;
         allowPickWithoutClose = true;
         eraBasedTechLevel = CConfig.getBooleanParam(CConfig.TECH_PROGRESSION);
@@ -147,12 +147,16 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
 
     @Override
     protected void select(boolean close) {
-        chosenEntity = getSelectedEntity();
+        if (multiSelect) {
+            chosenEntities = getSelectedEntities();
+        } else {
+            chosenEntity = getSelectedEntity();
+        }
 
         if (close) {
             setVisible(false);
         } else if (entityPickCallback != null) {
-            entityPickCallback.accept(chosenEntity);
+            entityPickCallback.accept(this);
         }
     }
     // endregion Button Methods
@@ -161,7 +165,17 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
      * @return the chosenEntity
      */
     public Entity getChosenEntity() {
+        if (multiSelect) {
+            throw new IllegalStateException("multiselect must false to use getChosenEntity");
+        }
         return chosenEntity;
+    }
+
+    public ArrayList<Entity> getChosenEntities() {
+        if (!multiSelect) {
+            throw new IllegalStateException("multiselect must true to use getChosenEntities");
+        }
+        return chosenEntities;
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/dialog/PrintQueueDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/PrintQueueDialog.java
@@ -18,14 +18,32 @@
  */
 package megameklab.ui.dialog;
 
-import static java.util.stream.Collectors.toList;
-import static megamek.client.ui.swing.ClientGUI.CG_FILEPATHMUL;
+import megamek.client.generator.RandomNameGenerator;
+import megamek.client.ui.Messages;
+import megamek.client.ui.baseComponents.MMButton;
+import megamek.client.ui.swing.UnitLoadingDialog;
+import megamek.common.BTObject;
+import megamek.common.Configuration;
+import megamek.common.Entity;
+import megamek.common.EntityListFile;
+import megamek.common.Game;
+import megamek.common.MekFileParser;
+import megamek.common.Player;
+import megamek.common.util.C3Util;
+import megamek.logging.MMLogger;
+import megameklab.printing.PageBreak;
+import megameklab.util.CConfig;
+import megameklab.util.UnitPrintManager;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.logging.log4j.util.Strings;
 
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.GridLayout;
-import java.awt.LayoutManager;
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.TitledBorder;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.io.File;
@@ -36,28 +54,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import javax.swing.*;
-import javax.swing.border.EmptyBorder;
-import javax.swing.border.TitledBorder;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
-import javax.swing.filechooser.FileNameExtensionFilter;
-
-import megamek.client.ui.Messages;
-import megamek.common.*;
-import megameklab.util.CConfig;
-import org.apache.commons.io.FilenameUtils;
-
-import megamek.client.Client;
-import megamek.client.generator.RandomNameGenerator;
-import megamek.client.ui.baseComponents.MMButton;
-import megamek.client.ui.swing.ClientGUI;
-import megamek.client.ui.swing.UnitLoadingDialog;
-import megamek.common.util.C3Util;
-import megamek.logging.MMLogger;
-import megameklab.printing.PageBreak;
-import megameklab.util.UnitPrintManager;
-import org.apache.logging.log4j.util.Strings;
+import static java.util.stream.Collectors.toList;
+import static megamek.client.ui.swing.ClientGUI.CG_FILEPATHMUL;
 
 /**
  * Allows selecting multiple units and printing their record sheets.
@@ -332,28 +330,26 @@ public class PrintQueueDialog extends AbstractMMLButtonDialog {
         UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parent);
         unitLoadingDialog.setVisible(true);
         MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parent, unitLoadingDialog,
-                this::entitySelected);
-        Entity entity = viewer.getChosenEntity();
+                dialog -> entitiesSelected(dialog.getChosenEntities()));
+        var entities = viewer.getChosenEntities();
         viewer.dispose();
 
-        if (entity != null) {
-            units.add(entity);
-            refresh();
-        }
+        entitiesSelected(entities);
     }
 
     /**
      * This is a callback function given to the Unit Selector Dialog to pass on
-     * selected units
-     * without closing the Unit Selector.
+     * selected units without closing the Unit Selector.
      *
-     * @param entity the chosen Unit
+     * @param entities the chosen Units
      */
-    public void entitySelected(Entity entity) {
-        if (entity != null) {
-            units.add(entity);
-            refresh();
+    private void entitiesSelected(List<Entity> entities) {
+        for (var entity : entities) {
+            if (entity != null) {
+                units.add(entity);
+            }
         }
+        refresh();
     }
 
     private void selectFromFile() {

--- a/megameklab/src/megameklab/ui/generalUnit/FluffTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/FluffTab.java
@@ -13,29 +13,6 @@
  */
 package megameklab.ui.generalUnit;
 
-import java.awt.Color;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Image;
-import java.awt.Insets;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.util.Arrays;
-import java.util.ResourceBundle;
-
-import javax.imageio.ImageIO;
-import javax.swing.BorderFactory;
-import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JFileChooser;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JTextArea;
-import javax.swing.JTextField;
-import javax.swing.border.Border;
-
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.util.FluffImageHelper;
 import megamek.common.Entity;
@@ -48,6 +25,17 @@ import megameklab.ui.dialog.MMLFileChooser;
 import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import javax.swing.border.Border;
+import java.awt.*;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.Arrays;
+import java.util.ResourceBundle;
 
 /**
  * Panel for editing unit fluff
@@ -342,7 +330,7 @@ public class FluffTab extends ITab implements FocusListener {
     private void importFluffImage() {
         UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(null);
         unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(null, unitLoadingDialog);
+        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(null, unitLoadingDialog, false);
 
         Entity chosenEntity = viewer.getChosenEntity();
         if (chosenEntity != null) {

--- a/megameklab/src/megameklab/ui/generalUnit/IconView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/IconView.java
@@ -18,18 +18,6 @@
  */
 package megameklab.ui.generalUnit;
 
-import java.awt.GridLayout;
-import java.awt.Image;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.util.Arrays;
-
-import javax.imageio.ImageIO;
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JFileChooser;
-import javax.swing.JPanel;
-
 import megamek.client.ui.panels.EntityImagePanel;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.tileset.MMStaticDirectoryManager;
@@ -42,6 +30,13 @@ import megamek.logging.MMLogger;
 import megameklab.ui.PopupMessages;
 import megameklab.ui.dialog.MMLFileChooser;
 import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.Arrays;
 
 /**
  * This view displays the icon that the unit will use in MM and MHQ and allows
@@ -155,7 +150,7 @@ public class IconView extends BuildView {
     private void chooseIconFromUnitCache() {
         UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(null);
         unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(null, unitLoadingDialog);
+        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(null, unitLoadingDialog, false);
 
         Entity chosenEntity = viewer.getChosenEntity();
         if (chosenEntity != null) {

--- a/megameklab/src/megameklab/util/UnitPrintManager.java
+++ b/megameklab/src/megameklab/util/UnitPrintManager.java
@@ -15,7 +15,20 @@
  */
 package megameklab.util;
 
-import java.awt.Frame;
+import megamek.client.ui.swing.UnitLoadingDialog;
+import megamek.common.*;
+import megamek.common.options.GameOptions;
+import megamek.logging.MMLogger;
+import megameklab.printing.*;
+import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
+import megameklab.ui.dialog.PrintQueueDialog;
+import org.apache.commons.io.FilenameUtils;
+
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.standard.DialogTypeSelection;
+import javax.swing.*;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import java.awt.*;
 import java.awt.print.PageFormat;
 import java.awt.print.PrinterJob;
 import java.io.File;
@@ -25,22 +38,6 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.Vector;
 import java.util.stream.Collectors;
-
-import javax.print.attribute.HashPrintRequestAttributeSet;
-import javax.print.attribute.standard.DialogTypeSelection;
-import javax.swing.JFileChooser;
-import javax.swing.JFrame;
-import javax.swing.JOptionPane;
-import javax.swing.filechooser.FileNameExtensionFilter;
-
-import megamek.client.ui.swing.UnitLoadingDialog;
-import megamek.common.*;
-import megamek.common.options.GameOptions;
-import megamek.logging.MMLogger;
-import megameklab.printing.*;
-import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
-import megameklab.ui.dialog.PrintQueueDialog;
-import org.apache.commons.io.FilenameUtils;
 
 import static megamek.common.options.OptionsConstants.RPG_MANEI_DOMINI;
 import static megamek.common.options.OptionsConstants.RPG_PILOT_ADVANTAGES;
@@ -320,7 +317,7 @@ public class UnitPrintManager {
     public static void printSelectedUnit(JFrame parent, boolean pdf) {
         UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(parent);
         unitLoadingDialog.setVisible(true);
-        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parent, unitLoadingDialog);
+        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(parent, unitLoadingDialog, false);
 
         viewer.setVisible(false);
         Entity entity = viewer.getChosenEntity();


### PR DESCRIPTION
Closes #1744.

Leverages the new multiselect capability of the unit select dialog to allow loading multiple units at a time in MegaMekLab. 

You can now select unit(s) without closing from the tabbed UI, or drag select multiple units in one go.

This required rewiring quite a bit of code, I've mentioned this before but MML was _not_ setup to make it easy to have multiple units open at once.