### PR TITLE
Multipage preview and adv aero fix

### DIFF
--- a/megameklab/data/images/recordsheets/templates_iso/advaero_reverse.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/advaero_reverse.svg
@@ -631,7 +631,7 @@
                                                                         /><g transform="translate (2.5,3.0)"
                                                                         ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 h 83.211 l 4.999,7.500 l -4.999,7.500 h -83.211 Z"
                                                                           /><text x="46.604" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="75.646" lengthAdjust="spacingAndGlyphs"
-                                                                          >%s DATA (Cont.)</text
+                                                                          ><tspan id="unitType">%s</tspan> DATA (Cont.)</text
                                                                         ></g
                                                                       ></g
                                                                       ><text x="6.000" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="21.401" lengthAdjust="spacingAndGlyphs"

--- a/megameklab/data/images/recordsheets/templates_us/advaero_reverse.svg
+++ b/megameklab/data/images/recordsheets/templates_us/advaero_reverse.svg
@@ -631,7 +631,7 @@
                                                                         /><g transform="translate (2.5,3.0)"
                                                                         ><path fill="#000000" d="M 0,7.500 l 4.999,-7.500 h 83.211 l 4.999,7.500 l -4.999,7.500 h -83.211 Z"
                                                                           /><text x="46.604" y="11.250" fill="#ffffff" text-anchor="middle" style="font-family:Eurostile;font-size:10.600px;font-weight:bold;font-style:normal" textLength="75.646" lengthAdjust="spacingAndGlyphs"
-                                                                          >%s DATA (Cont.)</text
+                                                                          ><tspan id="unitType">%s</tspan> DATA (Cont.)</text
                                                                         ></g
                                                                       ></g
                                                                       ><text x="6.000" y="28.000" fill="#231f20" text-anchor="start" style="font-family:Eurostile;font-size:9.670px;font-weight:bold;font-style:normal" textLength="21.401" lengthAdjust="spacingAndGlyphs"

--- a/megameklab/src/megameklab/printing/IdConstants.java
+++ b/megameklab/src/megameklab/printing/IdConstants.java
@@ -33,6 +33,7 @@ public interface IdConstants {
 
     String TYPE = "type";
     String TYPE2 = "type2";
+    String UNIT_TYPE = "unitType";
     String FLUFF_NAME = "fluffName";
     String MP_WALK = "mpWalk";
     String MP_RUN = "mpRun";

--- a/megameklab/src/megameklab/printing/PrintDropship.java
+++ b/megameklab/src/megameklab/printing/PrintDropship.java
@@ -23,6 +23,7 @@ import java.util.StringJoiner;
 import org.w3c.dom.Element;
 import org.w3c.dom.svg.SVGRectElement;
 
+import megamek.common.UnitType;
 import megamek.common.Aero;
 import megamek.common.AmmoType;
 import megamek.common.Dropship;
@@ -136,6 +137,7 @@ public class PrintDropship extends PrintAero {
                 element.setTextContent(String.format(element.getTextContent(), LocalDate.now().getYear()));
             }
             setTextField(TITLE, getRecordSheetTitle().toUpperCase() + " (REVERSE)");
+            setTextField(UNIT_TYPE, UnitType.getTypeDisplayableName(getEntity().getUnitType()).toUpperCase());
             setTextField(TYPE, getEntity().getShortNameRaw());
             setTextField(FLUFF_NAME, ""); // TODO: fluff name needs MM support
             element = getSVGDocument().getElementById(INVENTORY);

--- a/megameklab/src/megameklab/printing/PrintEntity.java
+++ b/megameklab/src/megameklab/printing/PrintEntity.java
@@ -199,6 +199,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
     protected void writeTextFields() {
         setTextField(TITLE, getRecordSheetTitle().toUpperCase());
         setTextField(TYPE, entityName());
+        setTextField(UNIT_TYPE, UnitType.getTypeDisplayableName(getEntity().getUnitType()).toUpperCase());
         setTextField(MP_WALK, formatWalk());
         setTextField(MP_RUN, formatRun());
         setTextField(MP_JUMP, formatJump());

--- a/megameklab/src/megameklab/ui/dialog/MegaMekLabUnitSelectorDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/MegaMekLabUnitSelectorDialog.java
@@ -19,6 +19,7 @@
 package megameklab.ui.dialog;
 
 import megamek.client.ui.Messages;
+import megamek.client.ui.WrapLayout;
 import megamek.client.ui.swing.UnitLoadingDialog;
 import megamek.client.ui.swing.dialog.AbstractUnitSelectorDialog;
 import megamek.client.ui.swing.tileset.EntityImage;
@@ -27,7 +28,9 @@ import megamek.client.ui.swing.util.PlayerColour;
 import megamek.common.Entity;
 import megamek.common.TechConstants;
 import megamek.common.icons.Camouflage;
+import megameklab.ui.generalUnit.RecordSheetPreviewPanel;
 import megameklab.util.CConfig;
+import megameklab.util.UnitPrintManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -42,6 +45,10 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
     private ArrayList<Entity> chosenEntities;
     private final boolean allowPickWithoutClose;
     private Consumer<MegaMekLabUnitSelectorDialog> entityPickCallback;
+    private RecordSheetPreviewPanel recordSheetPanel;
+    private JPanel recordSheetContainer;
+    private JButton printRecordSheetButton;
+    private JButton exportToPDFRecordSheetButton;
 
     // endregion Variable Declarations
 
@@ -49,9 +56,11 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
      * Constructs a Unit Selector Dialog that only allows choosing with closing the
      * dialog.
      *
-     * @param parent The parent window of this dialog
-     * @param unitLoadingDialog A {@link UnitLoadingDialog} likely {@code new UnitLoadingDialog(parent)}.
-     * @param multiselect Set this to {@code true} to allow multiple units to be selected at once.
+     * @param parent            The parent window of this dialog
+     * @param unitLoadingDialog A {@link UnitLoadingDialog} likely
+     *                          {@code new UnitLoadingDialog(parent)}.
+     * @param multiselect       Set this to {@code true} to allow multiple units to
+     *                          be selected at once.
      */
     public MegaMekLabUnitSelectorDialog(JFrame parent, UnitLoadingDialog unitLoadingDialog, boolean multiselect) {
         super(parent, unitLoadingDialog, multiselect);
@@ -62,6 +71,7 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
             allowedYear = CConfig.getIntParam(CConfig.TECH_YEAR);
         }
         initialize();
+        setupRecordSheetTab();
         run();
         setVisible(true);
     }
@@ -72,8 +82,9 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
      * entityPickCallback method will be called when units are selected in this way.
      * Multiselect is always enabled.
      *
-     * @param parent The parent window of this dialog
-     * @param unitLoadingDialog A {@link UnitLoadingDialog} likely {@code new UnitLoadingDialog(parent)}.
+     * @param parent             The parent window of this dialog
+     * @param unitLoadingDialog  A {@link UnitLoadingDialog} likely
+     *                           {@code new UnitLoadingDialog(parent)}.
      * @param entityPickCallback This will be called when the user presses Select.
      */
     public MegaMekLabUnitSelectorDialog(JFrame parent, UnitLoadingDialog unitLoadingDialog,
@@ -96,8 +107,65 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
         rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, CLOSE_ACTION);
         rootPane.getInputMap(JComponent.WHEN_FOCUSED).put(escape, CLOSE_ACTION);
         rootPane.getActionMap().put(CLOSE_ACTION, closeAction);
+        setupRecordSheetTab();
         run();
         setVisible(true);
+
+    }
+
+    private void setupRecordSheetTab() {
+        if (recordSheetPanel == null) {
+            // Create the record sheet panel
+            recordSheetPanel = new RecordSheetPreviewPanel();
+
+            // Create a toolbar panel with print button
+            JPanel toolbarPanel = new JPanel(new WrapLayout(FlowLayout.LEFT, 15, 10));
+            toolbarPanel.setMaximumSize(new Dimension(Integer.MAX_VALUE, toolbarPanel.getPreferredSize().height));
+
+            // Create a print button
+            printRecordSheetButton = new JButton("Print");
+            printRecordSheetButton.setEnabled(false);
+            printRecordSheetButton.addActionListener(e -> {
+                if (multiSelect) {
+                    ArrayList<Entity> entities = getSelectedEntities();
+                    if ((entities != null) && !entities.isEmpty()) {
+                        new PrintQueueDialog(frame, false, entities, false, "").setVisible(true);
+                    }
+                } else {
+                    Entity entity = getSelectedEntity();
+                    if (entity != null) {
+                        UnitPrintManager.printEntity(entity);
+                    }
+                }
+            });
+            toolbarPanel.add(printRecordSheetButton);
+
+            // Create an export to PDF button
+            exportToPDFRecordSheetButton = new JButton("Export to PDF");
+            exportToPDFRecordSheetButton.setEnabled(false);
+            exportToPDFRecordSheetButton.addActionListener(e -> {
+                if (multiSelect) {
+                    ArrayList<Entity> entities = getSelectedEntities();
+                    if ((entities != null) && !entities.isEmpty()) {
+                        new PrintQueueDialog(frame, true, entities, true, "").setVisible(true);
+                    }
+                } else {
+                    Entity entity = getSelectedEntity();
+                    if (entity != null) {
+                        UnitPrintManager.exportEntity(entity, frame);
+                    }
+                }
+            });
+            toolbarPanel.add(exportToPDFRecordSheetButton);
+
+            // Create a container panel for the record sheet and toolbar
+            recordSheetContainer = new JPanel(new BorderLayout());
+            recordSheetContainer.add(toolbarPanel, BorderLayout.NORTH);
+            recordSheetContainer.add(recordSheetPanel);
+
+            // Add the container to the preview tabs
+            panePreview.addTab("Record Sheet", recordSheetContainer);
+        }
     }
 
     // Only necessary to override the default close behavior, see constructor
@@ -181,12 +249,26 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
     @Override
     protected Entity refreshUnitView() {
         Entity selectedEntity = super.refreshUnitView();
+        // Update the record sheet with the selected entity
         if (selectedEntity != null) {
+            // Update unit image first (existing code)
             Image base = MMStaticDirectoryManager.getMekTileset().imageFor(selectedEntity);
             EntityImage entityImage = EntityImage.createIcon(base, Camouflage.of(PlayerColour.GOLD), selectedEntity);
             entityImage.loadFacings();
             labelImage.setIcon(new ImageIcon(entityImage.getFacing(0)));
         }
+
+        ArrayList<Entity> selectedEntities = getSelectedEntities();
+        if (selectedEntities.size() > 0) {
+            recordSheetPanel.setEntities(selectedEntities);
+            printRecordSheetButton.setEnabled(true);
+            exportToPDFRecordSheetButton.setEnabled(true);
+        } else {
+            recordSheetPanel.setEntity(null);
+            printRecordSheetButton.setEnabled(false);
+            exportToPDFRecordSheetButton.setEnabled(false);
+        }
+
         return selectedEntity;
     }
 }

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -462,7 +462,7 @@ import org.apache.batik.gvt.GraphicsNode;
          g.setBackground(Color.WHITE);
          g.clearRect(0, 0, totalWidth, fullHeight);
  
-         if (sheetNodes != null && !sheetNodes.isEmpty()) {
+         if (!sheetNodes.isEmpty()) {
              int k = 0;
              for (int i = 0; i < sheetNodes.size(); i++) {
                  GraphicsNode gnSheet = sheetNodes.get(i);

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -17,473 +17,559 @@
  * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package megameklab.ui.generalUnit;
+ package megameklab.ui.generalUnit;
 
-import java.awt.Color;
-import java.awt.Cursor;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.Point;
-import java.awt.RenderingHints;
-import java.awt.Toolkit;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.Transferable;
-import java.awt.datatransfer.UnsupportedFlavorException;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseMotionAdapter;
-import java.awt.event.MouseWheelEvent;
-import java.awt.event.MouseWheelListener;
-import java.awt.geom.AffineTransform;
-import java.awt.geom.Point2D;
-import java.awt.image.BufferedImage;
-import java.awt.print.PageFormat;
-import java.io.IOException;
-import java.lang.ref.WeakReference;
-import java.util.List;
-
-import javax.swing.JMenuItem;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-
-import org.apache.batik.gvt.GraphicsNode;
-import org.apache.batik.ext.awt.RenderingHintsKeyExt;
-import org.apache.batik.ext.awt.image.GraphicsUtil;
-
-import megamek.common.Entity;
-import megameklab.printing.PaperSize;
-import megameklab.printing.PrintRecordSheet;
-import megameklab.printing.PrintSmallUnitSheet;
-import megameklab.printing.RecordSheetOptions;
-import megameklab.util.UnitPrintManager;
-
-/**
- * @author pavelbraginskiy
- *         Simply fills itself with the record sheet for the given unit.
- */
-public class RecordSheetPreviewPanel extends JPanel {
-    private class RightClickListener extends MouseAdapter {
-        private final JPopupMenu popup = new JPopupMenu();
-        {
-            var copyItem = new JMenuItem("Copy to clipboard");
-            copyItem.addActionListener(l -> {
-                copyRecordSheetToClipboard();
-            });
-            popup.add(copyItem);
-
-            var resetItem = new JMenuItem("Reset view");
-            resetItem.addActionListener(l -> resetView());
-            popup.add(resetItem);
-        }
-
-        @Override
-        public void mouseClicked(MouseEvent e) {
-            super.mouseClicked(e);
-            if (e.getButton() != MouseEvent.BUTTON3) {
-                return;
-            }
-            popup.show(e.getComponent(), e.getX(), e.getY());
-        }
-    }
-
-    // Zoom and pan state
-    private final double MIN_ZOOM = 1.0;
-    private final double MAX_ZOOM = 4.0;
-    private final double ZOOM_STEP = 0.2;
-    private final double CLIPBOARD_ZOOM_SCALE = 4.0;
-    private double minZoom = getMinimumZoom();
-    private double zoomFactor = minZoom;
-    private double initialZoomFactor = zoomFactor;
-
-    private Point2D panOffset = new Point2D.Double(0, 0);
-    private Point lastMousePoint;
-    private boolean isPanning = false;
-    private boolean isHighQuality = true; // Track rendering quality mode
-
-    // High-resolution cached image for optimized rendering
-    private BufferedImage cachedImage;
-
-    public RecordSheetPreviewPanel() {
-        addMouseListener(new RightClickListener());
-        setupMouseHandlers();
-        // Enable better rendering
-        setDoubleBuffered(true);
-    }
-
-    /**
-     * Calculate the minimum zoom level needed to fit the record sheet vertically
-     * within the window.
-     * 
-     * @return The minimum zoom factor
-     */
-    private double getMinimumZoom() {
-        RecordSheetOptions options = new RecordSheetOptions();
-        PaperSize pz = options.getPaperSize();
-        double minZoom = getHeight() / (double) pz.pxHeight;
-        return Math.max(MIN_ZOOM, minZoom);
-    }
-
-    /**
-     * Creates a complete image of the record sheet and copies it to the clipboard
-     */
-    private void copyRecordSheetToClipboard() {
-        if (entity == null) {
-            return;
-        }
-
-        // Use standard paper size for the clipboard image
-        RecordSheetOptions options = new RecordSheetOptions();
-        PaperSize pz = options.getPaperSize();
-        int imgWidth = (int) Math.ceil(pz.pxWidth * CLIPBOARD_ZOOM_SCALE);
-        int imgHeight = (int) Math.ceil(pz.pxHeight * CLIPBOARD_ZOOM_SCALE);
-
-        BufferedImage img = new BufferedImage(imgWidth, imgHeight, BufferedImage.TYPE_INT_RGB);
-        Graphics2D g = GraphicsUtil.createGraphics(img);
-
-        // Set high quality rendering
-        RenderingHints rh = new RenderingHints(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-        rh.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        rh.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-        rh.put(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-        rh.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-        rh.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
-        rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
-        rh.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
-        rh.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
-        rh.put(org.apache.batik.ext.awt.RenderingHintsKeyExt.KEY_TRANSCODING,
-                org.apache.batik.ext.awt.RenderingHintsKeyExt.VALUE_TRANSCODING_PRINTING);
-        g.setRenderingHints(rh);
-
-        // White background
-        g.setBackground(Color.WHITE);
-        g.clearRect(0, 0, imgWidth, imgHeight);
-
-        // Render the record sheet directly without zoom/pan
-        PrintRecordSheet sheet = UnitPrintManager.createSheets(List.of(entity), true, options)
-                .stream().findFirst().orElse(null);
-
-        if (sheet != null) {
-            PageFormat pf = new PageFormat();
-            if (sheet instanceof PrintSmallUnitSheet) {
-                pf.setPaper(options.getPaperSize().createPaper());
-                sheet.createDocument(0, pf, false);
-            } else {
-                pf.setPaper(options.getPaperSize().createPaper(5, 5, 5, 5));
-                sheet.createDocument(0, pf, true);
-            }
-
-            GraphicsNode gn = sheet.build();
-
-            // Scale to fit the clipboard image
-            var bounds = gn.getBounds();
-            var yscale = (imgHeight - 20) / bounds.getHeight();
-            var xscale = (imgWidth - 20) / bounds.getWidth();
-            var scale = Math.min(yscale, xscale);
-
-            // Center the sheet in the image
-            double centerX = (imgWidth - (bounds.getWidth() * scale)) / 2;
-            double centerY = (imgHeight - (bounds.getHeight() * scale)) / 2;
-
-            AffineTransform transform = new AffineTransform();
-            transform.translate(centerX, centerY);
-            transform.scale(scale, scale);
-            gn.setTransform(transform);
-
-            // Draw to the clipboard image
-            gn.paint(g);
-        }
-
-        g.dispose();
-
-        // Copy to clipboard
-        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new Transferable() {
-            @Override
-            public DataFlavor[] getTransferDataFlavors() {
-                return new DataFlavor[] { DataFlavor.imageFlavor };
-            }
-
-            @Override
-            public boolean isDataFlavorSupported(DataFlavor flavor) {
-                return DataFlavor.imageFlavor.equals(flavor);
-            }
-
-            @Override
-            public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
-                if (!isDataFlavorSupported(flavor)) {
-                    throw new UnsupportedFlavorException(flavor);
-                }
-                return img;
-            }
-        }, null);
-    }
-
-    private void setupMouseHandlers() {
-        // Set up mouse wheel for zooming
-        addMouseWheelListener(new MouseWheelListener() {
-            @Override
-            public void mouseWheelMoved(MouseWheelEvent e) {
-                // Calculate zoom centered on mouse position
-                Point mousePoint = e.getPoint();
-                double oldZoom = zoomFactor;
-
-                // Adjust zoom by scroll amount
-                zoomFactor -= e.getPreciseWheelRotation() * ZOOM_STEP;
-                zoomFactor = Math.max(minZoom, Math.min(MAX_ZOOM, zoomFactor));
-
-                if (oldZoom != zoomFactor) {
-                    // Adjust pan to keep mouse position fixed
-                    double zoomRatio = zoomFactor / oldZoom;
-
-                    panOffset.setLocation(
-                            mousePoint.getX() - (mousePoint.getX() - panOffset.getX()) * zoomRatio,
-                            mousePoint.getY() - (mousePoint.getY() - panOffset.getY()) * zoomRatio);
-                    cachedImage = null; // Invalidate cached image on zoom change
-                    repaint();
-                }
-            }
-        });
-
-        // Mouse listener for double-click and drag init
-        addMouseListener(new MouseAdapter() {
-            @Override
-            public void mousePressed(MouseEvent e) {
-                if (e.getButton() == MouseEvent.BUTTON1) {
-                    lastMousePoint = e.getPoint();
-                    setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
-                    isPanning = true;
-                    // Switch to low quality during panning for better performance
-                    isHighQuality = false;
-                    // repaint();
-                }
-            }
-
-            @Override
-            public void mouseReleased(MouseEvent e) {
-                if (e.getButton() == MouseEvent.BUTTON1) {
-                    setCursor(Cursor.getDefaultCursor());
-                    isPanning = false;
-                    isHighQuality = true;
-                    repaint();
-                }
-            }
-
-            @Override
-            public void mouseClicked(MouseEvent e) {
-                if (e.getClickCount() == 2 && e.getButton() == MouseEvent.BUTTON1) {
-                    resetView();
-                }
-            }
-        });
-
-        // Mouse motion listener for panning
-        addMouseMotionListener(new MouseMotionAdapter() {
-            @Override
-            public void mouseDragged(MouseEvent e) {
-                if (isPanning && lastMousePoint != null) {
-                    int dx = e.getX() - lastMousePoint.x;
-                    int dy = e.getY() - lastMousePoint.y;
-
-                    panOffset.setLocation(panOffset.getX() + dx, panOffset.getY() + dy);
-
-                    lastMousePoint = e.getPoint();
-                    repaint();
-                }
-            }
-        });
-    }
-
-    private void resetView() {
-        isHighQuality = true;
-        zoomFactor = getMinimumZoom();
-        initialZoomFactor = zoomFactor;
-        renderHighResolutionImage();
-        if (cachedImage != null) {
-
-            // Calculate offsets to center the image
-            double xOffset = (getWidth() - cachedImage.getWidth()) / 2;
-            double yOffset = (getHeight() - cachedImage.getHeight()) / 2;
-
-            // Set pan offset to center the image
-            // Use max(0, value) to avoid negative offsets if image is bigger than panel
-            panOffset.setLocation(
-                    Math.max(0, xOffset),
-                    Math.max(0, yOffset));
-        } else {
-            // Default to 0,0 if no image
-            panOffset.setLocation(0, 0);
-        }
-
-        repaint();
-    }
-
-    private Entity entity;
-    private GraphicsNode gnSheet;
-
-    public void setEntity(Entity entity) {
-        this.entity = entity;
-        // Reset view and invalidate cached image when entity changes
-        cachedImage = null;
-        gnSheet = null;
-        resetView();
-    }
-
-    private void renderHighResolutionImage() {
-        if (entity == null) {
-            cachedImage = null;
-            return;
-        }
-
-        RecordSheetOptions options = new RecordSheetOptions();
-        PaperSize pz = options.getPaperSize();
-        int fullWidth = (int) Math.ceil(pz.pxWidth * zoomFactor);
-        int fullHeight = (int) Math.ceil(pz.pxHeight * zoomFactor);
-
-        // Try to use hardware-accelerated image if possible
-        try {
-            // Get hardware acceleration configuration
-            java.awt.GraphicsEnvironment ge = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment();
-            java.awt.GraphicsDevice gs = ge.getDefaultScreenDevice();
-            java.awt.GraphicsConfiguration gc = gs.getDefaultConfiguration();
-
-            // Create a compatible image (should work better with hardware)
-            cachedImage = gc.createCompatibleImage(fullWidth, fullHeight, java.awt.Transparency.OPAQUE);
-        } catch (Exception e) {
-            // Fallback to standard image if hardware acceleration fails
-            cachedImage = new BufferedImage(fullWidth, fullHeight, BufferedImage.TYPE_INT_RGB);
-        }
-        Graphics2D g = GraphicsUtil.createGraphics(cachedImage);
-        g.setComposite(java.awt.AlphaComposite.SrcOver);
-
-        // Set render quality for the high-res image
-        RenderingHints rh = new RenderingHints(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-        rh.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        rh.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-        rh.put(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-        rh.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-        rh.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
-        rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
-        rh.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
-        rh.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
-        rh.put(org.apache.batik.ext.awt.RenderingHintsKeyExt.KEY_TRANSCODING,
-                org.apache.batik.ext.awt.RenderingHintsKeyExt.VALUE_TRANSCODING_VECTOR);
-        rh.put(RenderingHintsKeyExt.KEY_BUFFERED_IMAGE, new WeakReference<BufferedImage>(cachedImage));
-        g.setRenderingHints(rh);
-
-        // White background
-        g.setBackground(Color.WHITE);
-        g.clearRect(0, 0, fullWidth, fullHeight);
-
-        // Render the record sheet to the high-res image
-        if (gnSheet == null) {
-            PrintRecordSheet sheet = UnitPrintManager.createSheets(List.of(entity), true, options)
-            .stream().findFirst().orElse(null);
-            PageFormat pf = new PageFormat();
-            if (sheet instanceof PrintSmallUnitSheet) {
-                pf.setPaper(options.getPaperSize().createPaper());
-                sheet.createDocument(0, pf, false);
-            } else {
-                pf.setPaper(options.getPaperSize().createPaper(5, 5, 5, 5));
-                sheet.createDocument(0, pf, true);
-            }
-            gnSheet = sheet.build();
-        }
-        if (gnSheet != null) {
-            AffineTransform originalTransform = gnSheet.getTransform();
-            try {
-                var bounds = gnSheet.getBounds();
-                var yscale = (fullHeight - 20) / bounds.getHeight();
-                var xscale = (fullWidth - 20) / bounds.getWidth();
-                var scale = Math.min(yscale, xscale);
-    
-                double centerX = (fullWidth - (bounds.getWidth() * scale)) / 2;
-                double centerY = (fullHeight - (bounds.getHeight() * scale)) / 2;
-    
-                AffineTransform transform = new AffineTransform();
-                transform.translate(centerX, centerY);
-                transform.scale(scale, scale);
-                gnSheet.setTransform(transform);
-    
-                gnSheet.paint(g);
-            } finally {
-                if (originalTransform != null) {
-                    gnSheet.setTransform(originalTransform);
-                }
-            }
-        }
-
-        g.dispose();
-    }
-
-    private void paintComponent(Graphics2D g, int width, int height) {
-        // Set render hints based on quality mode
-        RenderingHints rh = new RenderingHints(
-                RenderingHints.KEY_RENDERING,
-                isHighQuality ? RenderingHints.VALUE_RENDER_QUALITY : RenderingHints.VALUE_RENDER_SPEED);
-        rh.put(RenderingHints.KEY_INTERPOLATION,
-                isHighQuality ? RenderingHints.VALUE_INTERPOLATION_BICUBIC
-                        : RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-        rh.put(RenderingHints.KEY_ANTIALIASING,
-                isHighQuality ? RenderingHints.VALUE_ANTIALIAS_ON : RenderingHints.VALUE_ANTIALIAS_OFF);
-        rh.put(RenderingHints.KEY_TEXT_ANTIALIASING,
-                isHighQuality ? RenderingHints.VALUE_TEXT_ANTIALIAS_ON : RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
-        rh.put(RenderingHints.KEY_FRACTIONALMETRICS,
-                isHighQuality ? RenderingHints.VALUE_FRACTIONALMETRICS_ON : RenderingHints.VALUE_FRACTIONALMETRICS_OFF);
-        rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
-
-        g.setRenderingHints(rh);
-
-        // White background
-        g.setBackground(Color.WHITE);
-        g.clearRect(0, 0, width, height);
-
-        if (entity != null) {
-            // Generate high-resolution image if needed
-            if (cachedImage == null) {
-                renderHighResolutionImage();
-            }
-
-            if (cachedImage != null) {
-                // Store original transform for restoration later
-                AffineTransform originalTransform = g.getTransform();
-
-                // Calculate source region (in image coordinates)
-                double srcX = Math.max(0, -panOffset.getX());
-                double srcY = Math.max(0, -panOffset.getY());
-
-                // Create a transform that handles positioning and scaling in one step
-                AffineTransform at = new AffineTransform(originalTransform);
-                at.translate(Math.max(0, panOffset.getX()), Math.max(0, panOffset.getY()));
-                g.setTransform(at);
-
-                // Draw the image
-                g.drawImage(cachedImage, -(int) srcX, -(int) srcY, null);
-
-                // Restore original transform
-                g.setTransform(originalTransform);
-            }
-        }
-    }
-
-    @Override
-    public void paintComponent(Graphics g) {
-        super.paintComponent(g);
-        paintComponent((Graphics2D) g, getWidth(), getHeight());
-    }
-
-    // Add a component resize listener to adjust the view on resize
-    @Override
-    public void addNotify() {
-        super.addNotify();
-        addComponentListener(new java.awt.event.ComponentAdapter() {
-            @Override
-            public void componentResized(java.awt.event.ComponentEvent e) {
-                minZoom = getMinimumZoom();
-                // Only auto-fit if we haven't manually zoomed or panned yet
-                // (This prevents resetting user's view when window is resized)
-                if (cachedImage != null && zoomFactor == initialZoomFactor) {
-                    resetView();
-                }
-            }
-        });
-    }
-}
+ import java.awt.Color;
+ import java.awt.Cursor;
+ import java.awt.Graphics;
+ import java.awt.Graphics2D;
+ import java.awt.Point;
+ import java.awt.RenderingHints;
+ import java.awt.Toolkit;
+ import java.awt.datatransfer.DataFlavor;
+ import java.awt.datatransfer.Transferable;
+ import java.awt.datatransfer.UnsupportedFlavorException;
+ import java.awt.event.MouseAdapter;
+ import java.awt.event.MouseEvent;
+ import java.awt.event.MouseMotionAdapter;
+ import java.awt.event.MouseWheelEvent;
+ import java.awt.event.MouseWheelListener;
+ import java.awt.geom.AffineTransform;
+ import java.awt.geom.Point2D;
+ import java.awt.image.BufferedImage;
+ import java.awt.print.PageFormat;
+ import java.io.IOException;
+ import java.lang.ref.SoftReference;
+ import java.lang.ref.WeakReference;
+ import java.util.ArrayList;
+ import java.util.List;
+ 
+ import javax.swing.JMenuItem;
+ import javax.swing.JPanel;
+ import javax.swing.JPopupMenu;
+ 
+ import org.apache.batik.gvt.GraphicsNode;
+ import org.apache.batik.ext.awt.RenderingHintsKeyExt;
+ import org.apache.batik.ext.awt.image.GraphicsUtil;
+ 
+ import megamek.common.Entity;
+ import megameklab.printing.PaperSize;
+ import megameklab.printing.PrintRecordSheet;
+ import megameklab.printing.PrintSmallUnitSheet;
+ import megameklab.printing.RecordSheetOptions;
+ import megameklab.util.UnitPrintManager;
+ 
+ /**
+  * @author pavelbraginskiy
+  *         Simply fills itself with the record sheet for the given unit.
+  */
+ public class RecordSheetPreviewPanel extends JPanel {
+     private class RightClickListener extends MouseAdapter {
+         private final JPopupMenu popup = new JPopupMenu();
+         {
+             var copyItem = new JMenuItem("Copy to clipboard");
+             copyItem.addActionListener(l -> {
+                 copyRecordSheetToClipboard();
+             });
+             popup.add(copyItem);
+ 
+             var resetItem = new JMenuItem("Reset view");
+             resetItem.addActionListener(l -> resetView());
+             popup.add(resetItem);
+         }
+ 
+         @Override
+         public void mouseClicked(MouseEvent e) {
+             super.mouseClicked(e);
+             if (e.getButton() != MouseEvent.BUTTON3) {
+                 return;
+             }
+             popup.show(e.getComponent(), e.getX(), e.getY());
+         }
+     }
+ 
+     // Zoom and pan state
+     public static final int MAX_PRINTABLE_ENTITIES = 10;
+     private final double MIN_ZOOM = 1.0;
+     private final double MAX_ZOOM = 4.0;
+     private final double ZOOM_STEP = 0.2;
+     private final double CLIPBOARD_ZOOM_SCALE = 4.0;
+     private double minZoom = getMinimumZoom();
+     private double zoomFactor = minZoom;
+     private double initialZoomFactor = zoomFactor;
+ 
+     private Point2D panOffset = new Point2D.Double(0, 0);
+     private Point lastMousePoint;
+     private boolean isPanning = false;
+     private boolean isHighQuality = true; // Track rendering quality mode
+ 
+     // cached image for optimized rendering
+     private SoftReference<BufferedImage> cachedImage;
+ 
+     public RecordSheetPreviewPanel() {
+         addMouseListener(new RightClickListener());
+         setupMouseHandlers();
+         // Enable better rendering
+         setDoubleBuffered(true);
+     }
+ 
+     /**
+      * Calculate the minimum zoom level needed to fit the record sheet vertically
+      * within the window.
+      * 
+      * @return The minimum zoom factor
+      */
+     private double getMinimumZoom() {
+         RecordSheetOptions options = new RecordSheetOptions();
+         PaperSize pz = options.getPaperSize();
+         double minZoom = getHeight() / (double) pz.pxHeight;
+         return Math.max(MIN_ZOOM, minZoom);
+     }
+ 
+     /**
+      * Creates a complete image of the record sheet and copies it to the clipboard
+      */
+     private void copyRecordSheetToClipboard() {
+         if (entities == null || entities.isEmpty()) {
+             return;
+         }
+ 
+         // Use standard paper size for the clipboard image
+         RecordSheetOptions options = new RecordSheetOptions();
+         PaperSize pz = options.getPaperSize();
+ 
+         // Render the record sheet directly without zoom/pan
+         ArrayList<GraphicsNode> nodes = getRecordSheetGraphicsNodes(entities, options);
+ 
+         if (nodes.size() == 0) {
+             return;
+         }
+ 
+         int imgWidth = (int) Math.ceil(pz.pxWidth * CLIPBOARD_ZOOM_SCALE);
+         int fullWidth = imgWidth * nodes.size();
+         int imgHeight = (int) Math.ceil(pz.pxHeight * CLIPBOARD_ZOOM_SCALE);
+ 
+         BufferedImage img = new BufferedImage(fullWidth, imgHeight, BufferedImage.TYPE_INT_RGB);
+         Graphics2D g = GraphicsUtil.createGraphics(img);
+ 
+         // Set high quality rendering
+         RenderingHints rh = new RenderingHints(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+         rh.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+         rh.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+         rh.put(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+         rh.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+         rh.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
+         rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+         rh.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+         rh.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
+         rh.put(org.apache.batik.ext.awt.RenderingHintsKeyExt.KEY_TRANSCODING,
+                 org.apache.batik.ext.awt.RenderingHintsKeyExt.VALUE_TRANSCODING_PRINTING);
+         g.setRenderingHints(rh);
+ 
+         // White background
+         g.setBackground(Color.WHITE);
+         g.clearRect(0, 0, fullWidth, imgHeight);
+ 
+         if (nodes != null && !nodes.isEmpty()) {
+             int k = 0;
+             for (GraphicsNode gn : nodes) {
+                 if (gn == null) {
+                     continue;
+                 }
+                 // Scale to fit the clipboard image
+                 var bounds = gn.getBounds();
+                 var yscale = (imgHeight - 20) / bounds.getHeight();
+                 var xscale = (imgWidth - 20) / bounds.getWidth();
+                 var scale = Math.min(yscale, xscale);
+ 
+                 // Calculate position for this sheet (side by side horizontally)
+                 double xOffset = k * imgWidth;
+ 
+                 // Center the sheet in the image
+                 double centerX = (imgWidth - (bounds.getWidth() * scale)) / 2;
+                 double centerY = (imgHeight - (bounds.getHeight() * scale)) / 2;
+ 
+                 // Apply transform for this sheet - scale and position
+                 AffineTransform transform = new AffineTransform();
+                 transform.translate(centerX+xOffset, centerY);
+                 transform.scale(scale, scale);
+                 gn.setTransform(transform);
+ 
+                 // Draw to the clipboard image
+                 gn.paint(g);
+                 k++;
+             }
+ 
+         }
+ 
+         g.dispose();
+ 
+         // Copy to clipboard
+         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new Transferable() {
+             @Override
+             public DataFlavor[] getTransferDataFlavors() {
+                 return new DataFlavor[] { DataFlavor.imageFlavor };
+             }
+ 
+             @Override
+             public boolean isDataFlavorSupported(DataFlavor flavor) {
+                 return DataFlavor.imageFlavor.equals(flavor);
+             }
+ 
+             @Override
+             public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
+                 if (!isDataFlavorSupported(flavor)) {
+                     throw new UnsupportedFlavorException(flavor);
+                 }
+                 return img;
+             }
+         }, null);
+     }
+ 
+     private void setupMouseHandlers() {
+         // Set up mouse wheel for zooming
+         addMouseWheelListener(new MouseWheelListener() {
+             @Override
+             public void mouseWheelMoved(MouseWheelEvent e) {
+                 // Calculate zoom centered on mouse position
+                 Point mousePoint = e.getPoint();
+                 double oldZoom = zoomFactor;
+ 
+                 // Adjust zoom by scroll amount
+                 zoomFactor -= e.getPreciseWheelRotation() * ZOOM_STEP;
+                 zoomFactor = Math.max(minZoom, Math.min(MAX_ZOOM, zoomFactor));
+ 
+                 if (oldZoom != zoomFactor) {
+                     // Adjust pan to keep mouse position fixed
+                     double zoomRatio = zoomFactor / oldZoom;
+ 
+                     panOffset.setLocation(
+                             mousePoint.getX() - (mousePoint.getX() - panOffset.getX()) * zoomRatio,
+                             mousePoint.getY() - (mousePoint.getY() - panOffset.getY()) * zoomRatio);
+                     cachedImage = null; // Invalidate cached image on zoom change
+                     repaint();
+                 }
+             }
+         });
+ 
+         // Mouse listener for double-click and drag init
+         addMouseListener(new MouseAdapter() {
+             @Override
+             public void mousePressed(MouseEvent e) {
+                 if (e.getButton() == MouseEvent.BUTTON1) {
+                     lastMousePoint = e.getPoint();
+                     setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
+                     isPanning = true;
+                     // Switch to low quality during panning for better performance
+                     isHighQuality = false;
+                     // repaint();
+                 }
+             }
+ 
+             @Override
+             public void mouseReleased(MouseEvent e) {
+                 if (e.getButton() == MouseEvent.BUTTON1) {
+                     setCursor(Cursor.getDefaultCursor());
+                     isPanning = false;
+                     isHighQuality = true;
+                     repaint();
+                 }
+             }
+ 
+             @Override
+             public void mouseClicked(MouseEvent e) {
+                 if (e.getClickCount() == 2 && e.getButton() == MouseEvent.BUTTON1) {
+                     resetView();
+                 }
+             }
+         });
+ 
+         // Mouse motion listener for panning
+         addMouseMotionListener(new MouseMotionAdapter() {
+             @Override
+             public void mouseDragged(MouseEvent e) {
+                 if (isPanning && lastMousePoint != null) {
+                     int dx = e.getX() - lastMousePoint.x;
+                     int dy = e.getY() - lastMousePoint.y;
+ 
+                     panOffset.setLocation(panOffset.getX() + dx, panOffset.getY() + dy);
+ 
+                     lastMousePoint = e.getPoint();
+                     repaint();
+                 }
+             }
+         });
+     }
+ 
+     private void resetView() {
+         isHighQuality = true;
+         zoomFactor = getMinimumZoom();
+         initialZoomFactor = zoomFactor;
+         renderCachedImage();
+         BufferedImage img = cachedImage != null ? cachedImage.get() : null;
+         if (img != null) {
+ 
+             // Calculate offsets to center the image
+             double xOffset = (getWidth() - img.getWidth()) / 2;
+             double yOffset = (getHeight() - img.getHeight()) / 2;
+ 
+             // Set pan offset to center the image
+             // Use max(0, value) to avoid negative offsets if image is bigger than panel
+             panOffset.setLocation(
+                     Math.max(0, xOffset),
+                     Math.max(0, yOffset));
+         } else {
+             // Default to 0,0 if no image
+             panOffset.setLocation(0, 0);
+         }
+ 
+         repaint();
+     }
+ 
+     private SoftReference<ArrayList<GraphicsNode>> gnSheets;
+     private List<Entity> entities = new ArrayList<>();
+     private boolean needsViewReset = false;
+ 
+     /**
+      * Sets multiple entities to be displayed side by side horizontally
+      * 
+      * @param entities List of entities to display
+      */
+     public void setEntities(List<Entity> entities) {
+         if (entities == null) {
+             this.entities.clear();
+         } else {
+             this.entities = entities;
+         }
+ 
+         // Reset view and invalidate cached image when entities change
+         gnSheets = null;
+         cachedImage = null;
+ 
+         if (isShowing()) {
+             // If visible, update the view immediately
+             resetView();
+             needsViewReset = false;
+         } else {
+             // If not visible, mark for update when panel becomes visible
+             needsViewReset = true;
+         }
+     }
+ 
+     /**
+      * Sets a single entity to display (clears any previous multi-entity display)
+      * 
+      * @param entity The entity to display
+      */
+     public void setEntity(Entity entity) {
+         this.setEntities(List.of(entity));
+     }
+ 
+     private ArrayList<GraphicsNode> getRecordSheetGraphicsNodes(List<Entity> entities, RecordSheetOptions options) {
+         List<PrintRecordSheet> sheets = UnitPrintManager.createSheets(entities.subList(0, Math.min(entities.size(), MAX_PRINTABLE_ENTITIES)), true, options, true);
+         ArrayList<GraphicsNode> gnSheets = new ArrayList<GraphicsNode>();
+         PageFormat pf = new PageFormat();
+         for (PrintRecordSheet sheet : sheets) {
+             if (sheet instanceof PrintSmallUnitSheet) {
+                 pf.setPaper(options.getPaperSize().createPaper());
+             } else {
+                 pf.setPaper(options.getPaperSize().createPaper(5, 5, 5, 5));
+             }
+             int pagesCount = sheet.getPageCount();
+             for (int i = 0; i < pagesCount; i++) {
+                 sheet.createDocument(i, pf, false);
+                 gnSheets.add(sheet.build());
+             }
+         }
+         return gnSheets;
+     }
+ 
+     private void renderCachedImage() {
+         // Check if we have any entity to render
+         if ((entities == null || entities.isEmpty())) {
+             cachedImage = null;
+             return;
+         }
+ 
+         RecordSheetOptions options = new RecordSheetOptions();
+         PaperSize pz = options.getPaperSize();
+ 
+         ArrayList<GraphicsNode> sheetNodes = gnSheets != null ? gnSheets.get() : null;
+         if (sheetNodes == null || sheetNodes.isEmpty()) {
+             sheetNodes = getRecordSheetGraphicsNodes(entities, options);
+             // Store in SoftReference
+             gnSheets = new SoftReference<>(sheetNodes);
+         }
+ 
+         if (sheetNodes == null || sheetNodes.size() == 0) {
+             cachedImage = null;
+             return;
+         }
+ 
+         int fullWidth = (int) Math.ceil(pz.pxWidth * zoomFactor);
+         int totalWidth = fullWidth * sheetNodes.size();
+         int fullHeight = (int) Math.ceil(pz.pxHeight * zoomFactor);
+ 
+         BufferedImage img;
+         // Try to use hardware-accelerated image if possible
+         try {
+             // Get hardware acceleration configuration
+             java.awt.GraphicsEnvironment ge = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment();
+             java.awt.GraphicsDevice gs = ge.getDefaultScreenDevice();
+             java.awt.GraphicsConfiguration gc = gs.getDefaultConfiguration();
+ 
+             // Create a compatible image (should work better with hardware)
+             img = gc.createCompatibleImage(totalWidth, fullHeight, java.awt.Transparency.OPAQUE);
+         } catch (Exception e) {
+             // Fallback to standard image if hardware acceleration fails
+             img = new BufferedImage(totalWidth, fullHeight, BufferedImage.TYPE_INT_RGB);
+         }
+         Graphics2D g = GraphicsUtil.createGraphics(img);
+         g.setComposite(java.awt.AlphaComposite.SrcOver);
+ 
+         // Set render quality
+         RenderingHints rh = new RenderingHints(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+         rh.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+         rh.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+         rh.put(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+         rh.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+         rh.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
+         rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+         rh.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+         rh.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
+         rh.put(org.apache.batik.ext.awt.RenderingHintsKeyExt.KEY_TRANSCODING,
+                 org.apache.batik.ext.awt.RenderingHintsKeyExt.VALUE_TRANSCODING_VECTOR);
+         rh.put(RenderingHintsKeyExt.KEY_BUFFERED_IMAGE, new WeakReference<BufferedImage>(img));
+         g.setRenderingHints(rh);
+ 
+         // White background
+         g.setBackground(Color.WHITE);
+         g.clearRect(0, 0, totalWidth, fullHeight);
+ 
+         // if (entity != null) {
+         if (sheetNodes != null && !sheetNodes.isEmpty()) {
+             int k = 0;
+             for (int i = 0; i < sheetNodes.size(); i++) {
+                 GraphicsNode gnSheet = sheetNodes.get(i);
+                 if (gnSheet == null) {
+                     continue;
+                 }
+                 AffineTransform originalTransform = gnSheet.getTransform();
+                 try {
+                     var bounds = gnSheet.getBounds();
+                     var yscale = (fullHeight - 20) / bounds.getHeight();
+                     var xscale = (fullWidth - 20) / bounds.getWidth();
+                     var scale = Math.min(yscale, xscale);
+                     // Calculate position for this sheet (side by side horizontally)
+                     double xOffset = k * (pz.pxWidth * zoomFactor);
+ 
+                     // Center the sheet in the image
+                     double centerX = (fullWidth - (bounds.getWidth() * scale)) / 2;
+                     double centerY = (fullHeight - (bounds.getHeight() * scale)) / 2;
+ 
+                     // Apply transform for this sheet - scale and position
+                     AffineTransform transform = new AffineTransform();
+                     transform.translate(centerX+xOffset, centerY);
+                     transform.scale(scale, scale);
+                     gnSheet.setTransform(transform);
+ 
+                     // Paint this sheet
+                     gnSheet.paint(g);
+                     k++;
+                 } finally {
+                     if (originalTransform != null) {
+                         gnSheet.setTransform(originalTransform);
+                     }
+                 }
+             }
+         }
+ 
+         g.dispose();
+         // Store the image in a SoftReference
+         cachedImage = new SoftReference<>(img);
+     }
+ 
+     private void paintComponent(Graphics2D g, int width, int height) {
+         // Set render hints based on quality mode
+         RenderingHints rh = new RenderingHints(
+                 RenderingHints.KEY_RENDERING,
+                 isHighQuality ? RenderingHints.VALUE_RENDER_QUALITY : RenderingHints.VALUE_RENDER_SPEED);
+         rh.put(RenderingHints.KEY_INTERPOLATION,
+                 isHighQuality ? RenderingHints.VALUE_INTERPOLATION_BICUBIC
+                         : RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+         rh.put(RenderingHints.KEY_ANTIALIASING,
+                 isHighQuality ? RenderingHints.VALUE_ANTIALIAS_ON : RenderingHints.VALUE_ANTIALIAS_OFF);
+         rh.put(RenderingHints.KEY_TEXT_ANTIALIASING,
+                 isHighQuality ? RenderingHints.VALUE_TEXT_ANTIALIAS_ON : RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
+         rh.put(RenderingHints.KEY_FRACTIONALMETRICS,
+                 isHighQuality ? RenderingHints.VALUE_FRACTIONALMETRICS_ON : RenderingHints.VALUE_FRACTIONALMETRICS_OFF);
+         rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+ 
+         g.setRenderingHints(rh);
+ 
+         // White background
+         g.setBackground(Color.WHITE);
+         g.clearRect(0, 0, width, height);
+ 
+         if (entities != null && !entities.isEmpty()) {
+             BufferedImage img = cachedImage != null ? cachedImage.get() : null;
+             // Generate image if needed
+             if (img == null) {
+                 renderCachedImage();
+                 img = cachedImage != null ? cachedImage.get() : null;
+             }
+ 
+             if (img != null) {
+                 // Store original transform for restoration later
+                 AffineTransform originalTransform = g.getTransform();
+ 
+                 // Calculate source region (in image coordinates)
+                 double srcX = Math.max(0, -panOffset.getX());
+                 double srcY = Math.max(0, -panOffset.getY());
+ 
+                 // Create a transform that handles positioning and scaling in one step
+                 AffineTransform at = new AffineTransform(originalTransform);
+                 at.translate(Math.max(0, panOffset.getX()), Math.max(0, panOffset.getY()));
+                 g.setTransform(at);
+ 
+                 // Draw the image
+                 g.drawImage(img, -(int) srcX, -(int) srcY, null);
+ 
+                 // Restore original transform
+                 g.setTransform(originalTransform);
+             }
+         }
+     }
+ 
+     @Override
+     public void paintComponent(Graphics g) {
+         super.paintComponent(g);
+         paintComponent((Graphics2D) g, getWidth(), getHeight());
+     }
+ 
+     // Add a component resize listener to adjust the view on resize
+     @Override
+     public void addNotify() {
+         super.addNotify();
+         addComponentListener(new java.awt.event.ComponentAdapter() {
+             @Override
+             public void componentResized(java.awt.event.ComponentEvent e) {
+                 minZoom = getMinimumZoom();
+                 // Only auto-fit if we haven't manually zoomed or panned yet
+                 // (This prevents resetting user's view when window is resized)
+                 if (cachedImage != null && zoomFactor == initialZoomFactor) {
+                     resetView();
+                 }
+             }
+ 
+             @Override
+             public void componentShown(java.awt.event.ComponentEvent e) {
+                 // Perform deferred view reset if needed
+                 if (needsViewReset) {
+                     resetView();
+                     needsViewReset = false;
+                 }
+             }
+         });
+     }
+ }

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -362,7 +362,11 @@
       * @param entity The entity to display
       */
      public void setEntity(Entity entity) {
-         this.setEntities(List.of(entity));
+        if (entity == null) {
+             this.setEntities(null);
+         } else {
+             this.setEntities(List.of(entity));
+         }
      }
  
      private ArrayList<GraphicsNode> getRecordSheetGraphicsNodes(List<Entity> entities, RecordSheetOptions options) {

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -182,7 +182,7 @@ import org.apache.batik.gvt.GraphicsNode;
          g.setBackground(Color.WHITE);
          g.clearRect(0, 0, fullWidth, imgHeight);
  
-         if (nodes != null && !nodes.isEmpty()) {
+         if (!nodes.isEmpty()) {
              int k = 0;
              for (GraphicsNode gn : nodes) {
                  if (gn == null) {

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -29,7 +29,8 @@
  import java.awt.datatransfer.DataFlavor;
  import java.awt.datatransfer.Transferable;
  import java.awt.datatransfer.UnsupportedFlavorException;
- import java.awt.event.MouseAdapter;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.MouseAdapter;
  import java.awt.event.MouseEvent;
  import java.awt.event.MouseMotionAdapter;
  import java.awt.event.MouseWheelEvent;
@@ -47,8 +48,9 @@
  import javax.swing.JMenuItem;
  import javax.swing.JPanel;
  import javax.swing.JPopupMenu;
- 
- import org.apache.batik.gvt.GraphicsNode;
+import javax.swing.SwingUtilities;
+
+import org.apache.batik.gvt.GraphicsNode;
  import org.apache.batik.ext.awt.RenderingHintsKeyExt;
  import org.apache.batik.ext.awt.image.GraphicsUtil;
  
@@ -109,8 +111,18 @@
      public RecordSheetPreviewPanel() {
          addMouseListener(new RightClickListener());
          setupMouseHandlers();
-         // Enable better rendering
          setDoubleBuffered(true);
+
+         // Add hierarchy listener to detect actual visibility changes when in tabs
+        addHierarchyListener(e -> {
+            if ((e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0) {
+                // Only trigger on "becoming visible" events
+                if (needsViewReset && isShowing() {
+                    needsViewReset = false;
+                    resetView();
+                }
+            }
+        });
      }
  
      /**
@@ -563,15 +575,6 @@
                  // (This prevents resetting user's view when window is resized)
                  if (cachedImage != null && zoomFactor == initialZoomFactor) {
                      resetView();
-                 }
-             }
- 
-             @Override
-             public void componentShown(java.awt.event.ComponentEvent e) {
-                 // Perform deferred view reset if needed
-                 if (needsViewReset) {
-                     resetView();
-                     needsViewReset = false;
                  }
              }
          });

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -17,566 +17,591 @@
  * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
 
- package megameklab.ui.generalUnit;
+package megameklab.ui.generalUnit;
 
- import java.awt.Color;
- import java.awt.Cursor;
- import java.awt.Graphics;
- import java.awt.Graphics2D;
- import java.awt.Point;
- import java.awt.RenderingHints;
- import java.awt.Toolkit;
- import java.awt.datatransfer.DataFlavor;
- import java.awt.datatransfer.Transferable;
- import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.RenderingHints;
+import java.awt.Toolkit;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.HierarchyEvent;
 import java.awt.event.MouseAdapter;
- import java.awt.event.MouseEvent;
- import java.awt.event.MouseMotionAdapter;
- import java.awt.event.MouseWheelEvent;
- import java.awt.event.MouseWheelListener;
- import java.awt.geom.AffineTransform;
- import java.awt.geom.Point2D;
- import java.awt.image.BufferedImage;
- import java.awt.print.PageFormat;
- import java.io.IOException;
- import java.lang.ref.SoftReference;
- import java.lang.ref.WeakReference;
- import java.util.ArrayList;
- import java.util.List;
- 
- import javax.swing.JMenuItem;
- import javax.swing.JPanel;
- import javax.swing.JPopupMenu;
-import javax.swing.SwingUtilities;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.awt.image.BufferedImage;
+import java.awt.print.PageFormat;
+import java.io.IOException;
+import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.Timer;
 
 import org.apache.batik.gvt.GraphicsNode;
- import org.apache.batik.ext.awt.RenderingHintsKeyExt;
- import org.apache.batik.ext.awt.image.GraphicsUtil;
- 
- import megamek.common.Entity;
- import megameklab.printing.PaperSize;
- import megameklab.printing.PrintRecordSheet;
- import megameklab.printing.PrintSmallUnitSheet;
- import megameklab.printing.RecordSheetOptions;
- import megameklab.util.UnitPrintManager;
- 
- /**
-  * @author pavelbraginskiy
-  *         Simply fills itself with the record sheet for the given unit.
-  */
- public class RecordSheetPreviewPanel extends JPanel {
-     private class RightClickListener extends MouseAdapter {
-         private final JPopupMenu popup = new JPopupMenu();
-         {
-             var copyItem = new JMenuItem("Copy to clipboard");
-             copyItem.addActionListener(l -> {
-                 copyRecordSheetToClipboard();
-             });
-             popup.add(copyItem);
- 
-             var resetItem = new JMenuItem("Reset view");
-             resetItem.addActionListener(l -> resetView());
-             popup.add(resetItem);
-         }
- 
-         @Override
-         public void mouseClicked(MouseEvent e) {
-             super.mouseClicked(e);
-             if (e.getButton() != MouseEvent.BUTTON3) {
-                 return;
-             }
-             popup.show(e.getComponent(), e.getX(), e.getY());
-         }
-     }
- 
-     // Zoom and pan state
-     public static final int MAX_PRINTABLE_ENTITIES = 10;
-     private final double MIN_ZOOM = 1.0;
-     private final double MAX_ZOOM = 4.0;
-     private final double ZOOM_STEP = 0.2;
-     private final double CLIPBOARD_ZOOM_SCALE = 4.0;
-     private double minZoom = getMinimumZoom();
-     private double zoomFactor = minZoom;
-     private double initialZoomFactor = zoomFactor;
- 
-     private Point2D panOffset = new Point2D.Double(0, 0);
-     private Point lastMousePoint;
-     private boolean isPanning = false;
-     private boolean isHighQuality = true; // Track rendering quality mode
- 
-     // cached image for optimized rendering
-     private SoftReference<BufferedImage> cachedImage;
- 
-     public RecordSheetPreviewPanel() {
-         addMouseListener(new RightClickListener());
-         setupMouseHandlers();
-         setDoubleBuffered(true);
+import org.apache.batik.ext.awt.RenderingHintsKeyExt;
+import org.apache.batik.ext.awt.image.GraphicsUtil;
 
-         // Add hierarchy listener to detect actual visibility changes when in tabs
+import megamek.common.Entity;
+import megameklab.printing.PaperSize;
+import megameklab.printing.PrintRecordSheet;
+import megameklab.printing.PrintSmallUnitSheet;
+import megameklab.printing.RecordSheetOptions;
+import megameklab.util.UnitPrintManager;
+
+/**
+ * @author pavelbraginskiy
+ *         Simply fills itself with the record sheet for the given unit.
+ */
+public class RecordSheetPreviewPanel extends JPanel {
+    private class RightClickListener extends MouseAdapter {
+        private final JPopupMenu popup = new JPopupMenu();
+        {
+            var copyItem = new JMenuItem("Copy to clipboard");
+            copyItem.addActionListener(l -> {
+                copyRecordSheetToClipboard();
+            });
+            popup.add(copyItem);
+
+            var resetItem = new JMenuItem("Reset view");
+            resetItem.addActionListener(l -> resetView());
+            popup.add(resetItem);
+        }
+
+        @Override
+        public void mouseClicked(MouseEvent e) {
+            super.mouseClicked(e);
+            if (e.getButton() != MouseEvent.BUTTON3) {
+                return;
+            }
+            popup.show(e.getComponent(), e.getX(), e.getY());
+        }
+    }
+
+    // Zoom and pan state
+    public static final int MAX_PRINTABLE_ENTITIES = 10;
+    private final double MIN_ZOOM = 1.0;
+    private final double MAX_ZOOM = 4.0;
+    private final double ZOOM_STEP = 0.2;
+    private final double CLIPBOARD_ZOOM_SCALE = 4.0;
+    private double minZoom = getMinimumZoom();
+    private double zoomFactor = minZoom;
+    private double initialZoomFactor = zoomFactor;
+
+    private Point2D panOffset = new Point2D.Double(0, 0);
+    private Point lastMousePoint;
+    private boolean isPanning = false;
+    private boolean isHighQuality = true; // Track rendering quality mode
+
+    private SoftReference<ArrayList<GraphicsNode>> gnSheets;
+    private List<Entity> entities = new ArrayList<>();
+    private boolean needsViewReset = false;
+    private Timer resetViewTimer;
+    private static final int RESET_VIEW_DELAY = 200; // 200ms delay
+
+    // cached image for optimized rendering
+    private SoftReference<BufferedImage> cachedImage;
+
+    public RecordSheetPreviewPanel() {
+        addMouseListener(new RightClickListener());
+        setupMouseHandlers();
+        setDoubleBuffered(true);
+
+        // Initialize the debounce timer
+        resetViewTimer = new javax.swing.Timer(RESET_VIEW_DELAY, e -> {
+            // Stop the timer when it fires
+            resetViewTimer.stop();
+            // Execute the actual reset view operation
+            resetView();
+        });
+        resetViewTimer.setRepeats(false); // Ensure it only fires once
+
+        // Add hierarchy listener to detect actual visibility changes when in tabs
         addHierarchyListener(e -> {
             if ((e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0) {
                 // Only trigger on "becoming visible" events
                 if (needsViewReset && isShowing()) {
-                    needsViewReset = false;
                     resetView();
                 }
             }
         });
-     }
- 
-     /**
-      * Calculate the minimum zoom level needed to fit the record sheet vertically
-      * within the window.
-      * 
-      * @return The minimum zoom factor
-      */
-     private double getMinimumZoom() {
-         RecordSheetOptions options = new RecordSheetOptions();
-         PaperSize pz = options.getPaperSize();
-         double minZoom = getHeight() / (double) pz.pxHeight;
-         return Math.max(MIN_ZOOM, minZoom);
-     }
- 
-     /**
-      * Creates a complete image of the record sheet and copies it to the clipboard
-      */
-     private void copyRecordSheetToClipboard() {
-         if (entities == null || entities.isEmpty()) {
-             return;
-         }
- 
-         // Use standard paper size for the clipboard image
-         RecordSheetOptions options = new RecordSheetOptions();
-         PaperSize pz = options.getPaperSize();
- 
-         // Render the record sheet directly without zoom/pan
-         ArrayList<GraphicsNode> nodes = getRecordSheetGraphicsNodes(entities, options);
- 
-         if (nodes == null || nodes.size() == 0) {
-             return;
-         }
- 
-         int imgWidth = (int) Math.ceil(pz.pxWidth * CLIPBOARD_ZOOM_SCALE);
-         int fullWidth = imgWidth * nodes.size();
-         int imgHeight = (int) Math.ceil(pz.pxHeight * CLIPBOARD_ZOOM_SCALE);
- 
-         BufferedImage img = new BufferedImage(fullWidth, imgHeight, BufferedImage.TYPE_INT_RGB);
-         Graphics2D g = GraphicsUtil.createGraphics(img);
- 
-         // Set high quality rendering
-         RenderingHints rh = new RenderingHints(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-         rh.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-         rh.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-         rh.put(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-         rh.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-         rh.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
-         rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
-         rh.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
-         rh.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
-         rh.put(org.apache.batik.ext.awt.RenderingHintsKeyExt.KEY_TRANSCODING,
-                 org.apache.batik.ext.awt.RenderingHintsKeyExt.VALUE_TRANSCODING_PRINTING);
-         g.setRenderingHints(rh);
- 
-         // White background
-         g.setBackground(Color.WHITE);
-         g.clearRect(0, 0, fullWidth, imgHeight);
- 
-         if (!nodes.isEmpty()) {
-             int k = 0;
-             for (GraphicsNode gn : nodes) {
-                 if (gn == null) {
-                     continue;
-                 }
-                 // Scale to fit the clipboard image
-                 var bounds = gn.getBounds();
-                 var yscale = (imgHeight - 20) / bounds.getHeight();
-                 var xscale = (imgWidth - 20) / bounds.getWidth();
-                 var scale = Math.min(yscale, xscale);
- 
-                 // Calculate position for this sheet (side by side horizontally)
-                 double xOffset = k * imgWidth;
- 
-                 // Center the sheet in the image
-                 double centerX = (imgWidth - (bounds.getWidth() * scale)) / 2;
-                 double centerY = (imgHeight - (bounds.getHeight() * scale)) / 2;
- 
-                 // Apply transform for this sheet - scale and position
-                 AffineTransform transform = new AffineTransform();
-                 transform.translate(centerX+xOffset, centerY);
-                 transform.scale(scale, scale);
-                 gn.setTransform(transform);
- 
-                 // Draw to the clipboard image
-                 gn.paint(g);
-                 k++;
-             }
- 
-         }
- 
-         g.dispose();
- 
-         // Copy to clipboard
-         Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new Transferable() {
-             @Override
-             public DataFlavor[] getTransferDataFlavors() {
-                 return new DataFlavor[] { DataFlavor.imageFlavor };
-             }
- 
-             @Override
-             public boolean isDataFlavorSupported(DataFlavor flavor) {
-                 return DataFlavor.imageFlavor.equals(flavor);
-             }
- 
-             @Override
-             public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
-                 if (!isDataFlavorSupported(flavor)) {
-                     throw new UnsupportedFlavorException(flavor);
-                 }
-                 return img;
-             }
-         }, null);
-     }
- 
-     private void setupMouseHandlers() {
-         // Set up mouse wheel for zooming
-         addMouseWheelListener(new MouseWheelListener() {
-             @Override
-             public void mouseWheelMoved(MouseWheelEvent e) {
-                 // Calculate zoom centered on mouse position
-                 Point mousePoint = e.getPoint();
-                 double oldZoom = zoomFactor;
- 
-                 // Adjust zoom by scroll amount
-                 zoomFactor -= e.getPreciseWheelRotation() * ZOOM_STEP;
-                 zoomFactor = Math.max(minZoom, Math.min(MAX_ZOOM, zoomFactor));
- 
-                 if (oldZoom != zoomFactor) {
-                     // Adjust pan to keep mouse position fixed
-                     double zoomRatio = zoomFactor / oldZoom;
- 
-                     panOffset.setLocation(
-                             mousePoint.getX() - (mousePoint.getX() - panOffset.getX()) * zoomRatio,
-                             mousePoint.getY() - (mousePoint.getY() - panOffset.getY()) * zoomRatio);
-                     cachedImage = null; // Invalidate cached image on zoom change
-                     repaint();
-                 }
-             }
-         });
- 
-         // Mouse listener for double-click and drag init
-         addMouseListener(new MouseAdapter() {
-             @Override
-             public void mousePressed(MouseEvent e) {
-                 if (e.getButton() == MouseEvent.BUTTON1) {
-                     lastMousePoint = e.getPoint();
-                     setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
-                     isPanning = true;
-                     // Switch to low quality during panning for better performance
-                     isHighQuality = false;
-                     // repaint();
-                 }
-             }
- 
-             @Override
-             public void mouseReleased(MouseEvent e) {
-                 if (e.getButton() == MouseEvent.BUTTON1) {
-                     setCursor(Cursor.getDefaultCursor());
-                     isPanning = false;
-                     isHighQuality = true;
-                     repaint();
-                 }
-             }
- 
-             @Override
-             public void mouseClicked(MouseEvent e) {
-                 if (e.getClickCount() == 2 && e.getButton() == MouseEvent.BUTTON1) {
-                     resetView();
-                 }
-             }
-         });
- 
-         // Mouse motion listener for panning
-         addMouseMotionListener(new MouseMotionAdapter() {
-             @Override
-             public void mouseDragged(MouseEvent e) {
-                 if (isPanning && lastMousePoint != null) {
-                     int dx = e.getX() - lastMousePoint.x;
-                     int dy = e.getY() - lastMousePoint.y;
- 
-                     panOffset.setLocation(panOffset.getX() + dx, panOffset.getY() + dy);
- 
-                     lastMousePoint = e.getPoint();
-                     repaint();
-                 }
-             }
-         });
-     }
- 
-     private void resetView() {
-         isHighQuality = true;
-         zoomFactor = getMinimumZoom();
-         initialZoomFactor = zoomFactor;
-         renderCachedImage();
-         BufferedImage img = cachedImage != null ? cachedImage.get() : null;
-         if (img != null) {
- 
-             // Calculate offsets to center the image
-             double xOffset = (getWidth() - img.getWidth()) / 2;
-             double yOffset = (getHeight() - img.getHeight()) / 2;
- 
-             // Set pan offset to center the image
-             // Use max(0, value) to avoid negative offsets if image is bigger than panel
-             panOffset.setLocation(
-                     Math.max(0, xOffset),
-                     Math.max(0, yOffset));
-         } else {
-             // Default to 0,0 if no image
-             panOffset.setLocation(0, 0);
-         }
- 
-         repaint();
-     }
- 
-     private SoftReference<ArrayList<GraphicsNode>> gnSheets;
-     private List<Entity> entities = new ArrayList<>();
-     private boolean needsViewReset = false;
- 
-     /**
-      * Sets multiple entities to be displayed side by side horizontally
-      * 
-      * @param entities List of entities to display
-      */
-     public void setEntities(List<Entity> entities) {
-         if (entities == null) {
-             this.entities.clear();
-         } else {
-             this.entities = entities;
-         }
- 
-         // Reset view and invalidate cached image when entities change
-         gnSheets = null;
-         cachedImage = null;
- 
-         if (isShowing()) {
-             // If visible, update the view immediately
-             resetView();
-             needsViewReset = false;
-         } else {
-             // If not visible, mark for update when panel becomes visible
-             needsViewReset = true;
-         }
-     }
- 
-     /**
-      * Sets a single entity to display (clears any previous multi-entity display)
-      * 
-      * @param entity The entity to display
-      */
-     public void setEntity(Entity entity) {
+    }
+
+    /**
+     * Calculate the minimum zoom level needed to fit the record sheet vertically
+     * within the window.
+     * 
+     * @return The minimum zoom factor
+     */
+    private double getMinimumZoom() {
+        RecordSheetOptions options = new RecordSheetOptions();
+        PaperSize pz = options.getPaperSize();
+        double minZoom = getHeight() / (double) pz.pxHeight;
+        return Math.max(MIN_ZOOM, minZoom);
+    }
+
+    /**
+     * Creates a complete image of the record sheet and copies it to the clipboard
+     */
+    private void copyRecordSheetToClipboard() {
+        if (entities == null || entities.isEmpty()) {
+            return;
+        }
+
+        // Use standard paper size for the clipboard image
+        RecordSheetOptions options = new RecordSheetOptions();
+        PaperSize pz = options.getPaperSize();
+
+        // Render the record sheet directly without zoom/pan
+        ArrayList<GraphicsNode> nodes = getRecordSheetGraphicsNodes(entities, options);
+
+        if (nodes == null || nodes.size() == 0) {
+            return;
+        }
+
+        int imgWidth = (int) Math.ceil(pz.pxWidth * CLIPBOARD_ZOOM_SCALE);
+        int fullWidth = imgWidth * nodes.size();
+        int imgHeight = (int) Math.ceil(pz.pxHeight * CLIPBOARD_ZOOM_SCALE);
+
+        BufferedImage img = new BufferedImage(fullWidth, imgHeight, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = GraphicsUtil.createGraphics(img);
+
+        // Set high quality rendering
+        RenderingHints rh = new RenderingHints(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        rh.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        rh.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        rh.put(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        rh.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+        rh.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
+        rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+        rh.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+        rh.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
+        rh.put(org.apache.batik.ext.awt.RenderingHintsKeyExt.KEY_TRANSCODING,
+                org.apache.batik.ext.awt.RenderingHintsKeyExt.VALUE_TRANSCODING_PRINTING);
+        g.setRenderingHints(rh);
+
+        // White background
+        g.setBackground(Color.WHITE);
+        g.clearRect(0, 0, fullWidth, imgHeight);
+
+        if (!nodes.isEmpty()) {
+            int k = 0;
+            for (GraphicsNode gn : nodes) {
+                if (gn == null) {
+                    continue;
+                }
+                // Scale to fit the clipboard image
+                var bounds = gn.getBounds();
+                var yscale = (imgHeight - 20) / bounds.getHeight();
+                var xscale = (imgWidth - 20) / bounds.getWidth();
+                var scale = Math.min(yscale, xscale);
+
+                // Calculate position for this sheet (side by side horizontally)
+                double xOffset = k * imgWidth;
+
+                // Center the sheet in the image
+                double centerX = (imgWidth - (bounds.getWidth() * scale)) / 2;
+                double centerY = (imgHeight - (bounds.getHeight() * scale)) / 2;
+
+                // Apply transform for this sheet - scale and position
+                AffineTransform transform = new AffineTransform();
+                transform.translate(centerX + xOffset, centerY);
+                transform.scale(scale, scale);
+                gn.setTransform(transform);
+
+                // Draw to the clipboard image
+                gn.paint(g);
+                k++;
+            }
+
+        }
+
+        g.dispose();
+
+        // Copy to clipboard
+        Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new Transferable() {
+            @Override
+            public DataFlavor[] getTransferDataFlavors() {
+                return new DataFlavor[] { DataFlavor.imageFlavor };
+            }
+
+            @Override
+            public boolean isDataFlavorSupported(DataFlavor flavor) {
+                return DataFlavor.imageFlavor.equals(flavor);
+            }
+
+            @Override
+            public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException, IOException {
+                if (!isDataFlavorSupported(flavor)) {
+                    throw new UnsupportedFlavorException(flavor);
+                }
+                return img;
+            }
+        }, null);
+    }
+
+    private void setupMouseHandlers() {
+        // Set up mouse wheel for zooming
+        addMouseWheelListener(new MouseWheelListener() {
+            @Override
+            public void mouseWheelMoved(MouseWheelEvent e) {
+                // Calculate zoom centered on mouse position
+                Point mousePoint = e.getPoint();
+                double oldZoom = zoomFactor;
+
+                // Adjust zoom by scroll amount
+                zoomFactor -= e.getPreciseWheelRotation() * ZOOM_STEP;
+                zoomFactor = Math.max(minZoom, Math.min(MAX_ZOOM, zoomFactor));
+
+                if (oldZoom != zoomFactor) {
+                    // Adjust pan to keep mouse position fixed
+                    double zoomRatio = zoomFactor / oldZoom;
+
+                    panOffset.setLocation(
+                            mousePoint.getX() - (mousePoint.getX() - panOffset.getX()) * zoomRatio,
+                            mousePoint.getY() - (mousePoint.getY() - panOffset.getY()) * zoomRatio);
+                    cachedImage = null; // Invalidate cached image on zoom change
+                    repaint();
+                }
+            }
+        });
+
+        // Mouse listener for double-click and drag init
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON1) {
+                    lastMousePoint = e.getPoint();
+                    setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
+                    isPanning = true;
+                    // Switch to low quality during panning for better performance
+                    isHighQuality = false;
+                    // repaint();
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                if (e.getButton() == MouseEvent.BUTTON1) {
+                    setCursor(Cursor.getDefaultCursor());
+                    isPanning = false;
+                    isHighQuality = true;
+                    repaint();
+                }
+            }
+
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                if (e.getClickCount() == 2 && e.getButton() == MouseEvent.BUTTON1) {
+                    resetView();
+                }
+            }
+        });
+
+        // Mouse motion listener for panning
+        addMouseMotionListener(new MouseMotionAdapter() {
+            @Override
+            public void mouseDragged(MouseEvent e) {
+                if (isPanning && lastMousePoint != null) {
+                    int dx = e.getX() - lastMousePoint.x;
+                    int dy = e.getY() - lastMousePoint.y;
+
+                    panOffset.setLocation(panOffset.getX() + dx, panOffset.getY() + dy);
+
+                    lastMousePoint = e.getPoint();
+                    repaint();
+                }
+            }
+        });
+    }
+
+    /**
+     * Schedules a view reset with debounce behavior
+     */
+    private void scheduleResetView() {
+        if (resetViewTimer.isRunning()) {
+            resetViewTimer.stop();
+        }
+        resetViewTimer.start();
+    }
+
+    /**
+     * Performs the actual view reset operation
+     */
+    private void resetView() {
+        needsViewReset = false;
+        isHighQuality = true;
+        zoomFactor = getMinimumZoom();
+        initialZoomFactor = zoomFactor;
+        renderCachedImage();
+        BufferedImage img = cachedImage != null ? cachedImage.get() : null;
+        if (img != null) {
+
+            // Calculate offsets to center the image
+            double xOffset = (getWidth() - img.getWidth()) / 2;
+            double yOffset = (getHeight() - img.getHeight()) / 2;
+
+            // Set pan offset to center the image
+            // Use max(0, value) to avoid negative offsets if image is bigger than panel
+            panOffset.setLocation(
+                    Math.max(0, xOffset),
+                    Math.max(0, yOffset));
+        } else {
+            // Default to 0,0 if no image
+            panOffset.setLocation(0, 0);
+        }
+
+        repaint();
+    }
+
+    /**
+     * Sets multiple entities to be displayed side by side horizontally
+     * 
+     * @param entities List of entities to display
+     */
+    public void setEntities(List<Entity> entities) {
+        if (entities == null) {
+            this.entities.clear();
+        } else {
+            this.entities = entities;
+        }
+
+        // Reset view and invalidate cached image when entities change
+        gnSheets = null;
+        cachedImage = null;
+
+        if (isShowing()) {
+            // If visible, update the view immediately
+            scheduleResetView();
+        } else {
+            // If not visible, mark for update when panel becomes visible
+            needsViewReset = true;
+        }
+    }
+
+    /**
+     * Sets a single entity to display (clears any previous multi-entity display)
+     * 
+     * @param entity The entity to display
+     */
+    public void setEntity(Entity entity) {
         if (entity == null) {
-             this.setEntities(null);
-         } else {
-             this.setEntities(List.of(entity));
-         }
-     }
- 
-     private ArrayList<GraphicsNode> getRecordSheetGraphicsNodes(List<Entity> entities, RecordSheetOptions options) {
-         List<PrintRecordSheet> sheets = UnitPrintManager.createSheets(entities.subList(0, Math.min(entities.size(), MAX_PRINTABLE_ENTITIES)), true, options, true);
-         ArrayList<GraphicsNode> gnSheets = new ArrayList<GraphicsNode>();
-         PageFormat pf = new PageFormat();
-         for (PrintRecordSheet sheet : sheets) {
-             if (sheet instanceof PrintSmallUnitSheet) {
-                 pf.setPaper(options.getPaperSize().createPaper());
-             } else {
-                 pf.setPaper(options.getPaperSize().createPaper(5, 5, 5, 5));
-             }
-             int pagesCount = sheet.getPageCount();
-             for (int i = 0; i < pagesCount; i++) {
-                 sheet.createDocument(i, pf, false);
-                 gnSheets.add(sheet.build());
-             }
-         }
-         return gnSheets;
-     }
- 
-     private void renderCachedImage() {
-         // Check if we have any entity to render
-         if ((entities == null || entities.isEmpty())) {
-             cachedImage = null;
-             return;
-         }
- 
-         RecordSheetOptions options = new RecordSheetOptions();
-         PaperSize pz = options.getPaperSize();
- 
-         ArrayList<GraphicsNode> sheetNodes = gnSheets != null ? gnSheets.get() : null;
-         if (sheetNodes == null || sheetNodes.isEmpty()) {
-             sheetNodes = getRecordSheetGraphicsNodes(entities, options);
-             // Store in SoftReference
-             gnSheets = new SoftReference<>(sheetNodes);
-         }
- 
-         if (sheetNodes == null || sheetNodes.size() == 0) {
-             cachedImage = null;
-             return;
-         }
- 
-         int fullWidth = (int) Math.ceil(pz.pxWidth * zoomFactor);
-         int totalWidth = fullWidth * sheetNodes.size();
-         int fullHeight = (int) Math.ceil(pz.pxHeight * zoomFactor);
- 
-         BufferedImage img;
-         // Try to use hardware-accelerated image if possible
-         try {
-             // Get hardware acceleration configuration
-             java.awt.GraphicsEnvironment ge = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment();
-             java.awt.GraphicsDevice gs = ge.getDefaultScreenDevice();
-             java.awt.GraphicsConfiguration gc = gs.getDefaultConfiguration();
- 
-             // Create a compatible image (should work better with hardware)
-             img = gc.createCompatibleImage(totalWidth, fullHeight, java.awt.Transparency.OPAQUE);
-         } catch (Exception e) {
-             // Fallback to standard image if hardware acceleration fails
-             img = new BufferedImage(totalWidth, fullHeight, BufferedImage.TYPE_INT_RGB);
-         }
-         Graphics2D g = GraphicsUtil.createGraphics(img);
-         g.setComposite(java.awt.AlphaComposite.SrcOver);
- 
-         // Set render quality
-         RenderingHints rh = new RenderingHints(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-         rh.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-         rh.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-         rh.put(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-         rh.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
-         rh.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
-         rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
-         rh.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
-         rh.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
-         rh.put(org.apache.batik.ext.awt.RenderingHintsKeyExt.KEY_TRANSCODING,
-                 org.apache.batik.ext.awt.RenderingHintsKeyExt.VALUE_TRANSCODING_VECTOR);
-         rh.put(RenderingHintsKeyExt.KEY_BUFFERED_IMAGE, new WeakReference<BufferedImage>(img));
-         g.setRenderingHints(rh);
- 
-         // White background
-         g.setBackground(Color.WHITE);
-         g.clearRect(0, 0, totalWidth, fullHeight);
- 
-         if (!sheetNodes.isEmpty()) {
-             int k = 0;
-             for (int i = 0; i < sheetNodes.size(); i++) {
-                 GraphicsNode gnSheet = sheetNodes.get(i);
-                 if (gnSheet == null) {
-                     continue;
-                 }
-                 AffineTransform originalTransform = gnSheet.getTransform();
-                 try {
-                     var bounds = gnSheet.getBounds();
-                     var yscale = (fullHeight - 20) / bounds.getHeight();
-                     var xscale = (fullWidth - 20) / bounds.getWidth();
-                     var scale = Math.min(yscale, xscale);
-                     // Calculate position for this sheet (side by side horizontally)
-                     double xOffset = k * (pz.pxWidth * zoomFactor);
- 
-                     // Center the sheet in the image
-                     double centerX = (fullWidth - (bounds.getWidth() * scale)) / 2;
-                     double centerY = (fullHeight - (bounds.getHeight() * scale)) / 2;
- 
-                     // Apply transform for this sheet - scale and position
-                     AffineTransform transform = new AffineTransform();
-                     transform.translate(centerX+xOffset, centerY);
-                     transform.scale(scale, scale);
-                     gnSheet.setTransform(transform);
- 
-                     // Paint this sheet
-                     gnSheet.paint(g);
-                     k++;
-                 } finally {
-                     if (originalTransform != null) {
-                         gnSheet.setTransform(originalTransform);
-                     }
-                 }
-             }
-         }
- 
-         g.dispose();
-         // Store the image in a SoftReference
-         cachedImage = new SoftReference<>(img);
-     }
- 
-     private void paintComponent(Graphics2D g, int width, int height) {
-         // Set render hints based on quality mode
-         RenderingHints rh = new RenderingHints(
-                 RenderingHints.KEY_RENDERING,
-                 isHighQuality ? RenderingHints.VALUE_RENDER_QUALITY : RenderingHints.VALUE_RENDER_SPEED);
-         rh.put(RenderingHints.KEY_INTERPOLATION,
-                 isHighQuality ? RenderingHints.VALUE_INTERPOLATION_BICUBIC
-                         : RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-         rh.put(RenderingHints.KEY_ANTIALIASING,
-                 isHighQuality ? RenderingHints.VALUE_ANTIALIAS_ON : RenderingHints.VALUE_ANTIALIAS_OFF);
-         rh.put(RenderingHints.KEY_TEXT_ANTIALIASING,
-                 isHighQuality ? RenderingHints.VALUE_TEXT_ANTIALIAS_ON : RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
-         rh.put(RenderingHints.KEY_FRACTIONALMETRICS,
-                 isHighQuality ? RenderingHints.VALUE_FRACTIONALMETRICS_ON : RenderingHints.VALUE_FRACTIONALMETRICS_OFF);
-         rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
- 
-         g.setRenderingHints(rh);
- 
-         // White background
-         g.setBackground(Color.WHITE);
-         g.clearRect(0, 0, width, height);
- 
-         if (entities != null && !entities.isEmpty()) {
-             BufferedImage img = cachedImage != null ? cachedImage.get() : null;
-             // Generate image if needed
-             if (img == null) {
-                 renderCachedImage();
-                 img = cachedImage != null ? cachedImage.get() : null;
-             }
- 
-             if (img != null) {
-                 // Store original transform for restoration later
-                 AffineTransform originalTransform = g.getTransform();
- 
-                 // Calculate source region (in image coordinates)
-                 double srcX = Math.max(0, -panOffset.getX());
-                 double srcY = Math.max(0, -panOffset.getY());
- 
-                 // Create a transform that handles positioning and scaling in one step
-                 AffineTransform at = new AffineTransform(originalTransform);
-                 at.translate(Math.max(0, panOffset.getX()), Math.max(0, panOffset.getY()));
-                 g.setTransform(at);
- 
-                 // Draw the image
-                 g.drawImage(img, -(int) srcX, -(int) srcY, null);
- 
-                 // Restore original transform
-                 g.setTransform(originalTransform);
-             }
-         }
-     }
- 
-     @Override
-     public void paintComponent(Graphics g) {
-         super.paintComponent(g);
-         paintComponent((Graphics2D) g, getWidth(), getHeight());
-     }
- 
-     // Add a component resize listener to adjust the view on resize
-     @Override
-     public void addNotify() {
-         super.addNotify();
-         addComponentListener(new java.awt.event.ComponentAdapter() {
-             @Override
-             public void componentResized(java.awt.event.ComponentEvent e) {
-                 minZoom = getMinimumZoom();
-                 // Only auto-fit if we haven't manually zoomed or panned yet
-                 // (This prevents resetting user's view when window is resized)
-                 if (cachedImage != null && zoomFactor == initialZoomFactor) {
-                     resetView();
-                 }
-             }
- 
-         });
-     }
- }
+            this.setEntities(null);
+        } else {
+            this.setEntities(List.of(entity));
+        }
+    }
+
+    private ArrayList<GraphicsNode> getRecordSheetGraphicsNodes(List<Entity> entities, RecordSheetOptions options) {
+        List<PrintRecordSheet> sheets = UnitPrintManager.createSheets(
+                entities.subList(0, Math.min(entities.size(), MAX_PRINTABLE_ENTITIES)), true, options, true);
+        ArrayList<GraphicsNode> gnSheets = new ArrayList<GraphicsNode>();
+        PageFormat pf = new PageFormat();
+        for (PrintRecordSheet sheet : sheets) {
+            if (sheet instanceof PrintSmallUnitSheet) {
+                pf.setPaper(options.getPaperSize().createPaper());
+            } else {
+                pf.setPaper(options.getPaperSize().createPaper(5, 5, 5, 5));
+            }
+            int pagesCount = sheet.getPageCount();
+            for (int i = 0; i < pagesCount; i++) {
+                sheet.createDocument(i, pf, false);
+                gnSheets.add(sheet.build());
+            }
+        }
+        return gnSheets;
+    }
+
+    private void renderCachedImage() {
+        // Check if we have any entity to render
+        if ((entities == null || entities.isEmpty())) {
+            cachedImage = null;
+            return;
+        }
+
+        RecordSheetOptions options = new RecordSheetOptions();
+        PaperSize pz = options.getPaperSize();
+
+        ArrayList<GraphicsNode> sheetNodes = gnSheets != null ? gnSheets.get() : null;
+        if (sheetNodes == null || sheetNodes.isEmpty()) {
+
+            sheetNodes = getRecordSheetGraphicsNodes(entities, options);
+            // Store in SoftReference
+            gnSheets = new SoftReference<>(sheetNodes);
+        }
+
+        if (sheetNodes == null || sheetNodes.size() == 0) {
+            cachedImage = null;
+            return;
+        }
+
+        int fullWidth = (int) Math.ceil(pz.pxWidth * zoomFactor);
+        int totalWidth = fullWidth * sheetNodes.size();
+        int fullHeight = (int) Math.ceil(pz.pxHeight * zoomFactor);
+
+        BufferedImage img;
+        // Try to use hardware-accelerated image if possible
+        try {
+            // Get hardware acceleration configuration
+            java.awt.GraphicsEnvironment ge = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment();
+            java.awt.GraphicsDevice gs = ge.getDefaultScreenDevice();
+            java.awt.GraphicsConfiguration gc = gs.getDefaultConfiguration();
+
+            // Create a compatible image (should work better with hardware)
+            img = gc.createCompatibleImage(totalWidth, fullHeight, java.awt.Transparency.OPAQUE);
+        } catch (Exception e) {
+            // Fallback to standard image if hardware acceleration fails
+            img = new BufferedImage(totalWidth, fullHeight, BufferedImage.TYPE_INT_RGB);
+        }
+        Graphics2D g = GraphicsUtil.createGraphics(img);
+        g.setComposite(java.awt.AlphaComposite.SrcOver);
+
+        // Set render quality
+        RenderingHints rh = new RenderingHints(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        rh.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        rh.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        rh.put(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        rh.put(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+        rh.put(RenderingHints.KEY_COLOR_RENDERING, RenderingHints.VALUE_COLOR_RENDER_QUALITY);
+        rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+        rh.put(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+        rh.put(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
+        rh.put(org.apache.batik.ext.awt.RenderingHintsKeyExt.KEY_TRANSCODING,
+                org.apache.batik.ext.awt.RenderingHintsKeyExt.VALUE_TRANSCODING_VECTOR);
+        rh.put(RenderingHintsKeyExt.KEY_BUFFERED_IMAGE, new WeakReference<BufferedImage>(img));
+        g.setRenderingHints(rh);
+
+        // White background
+        g.setBackground(Color.WHITE);
+        g.clearRect(0, 0, totalWidth, fullHeight);
+
+        if (!sheetNodes.isEmpty()) {
+            int k = 0;
+            for (int i = 0; i < sheetNodes.size(); i++) {
+                GraphicsNode gnSheet = sheetNodes.get(i);
+                if (gnSheet == null) {
+                    continue;
+                }
+                AffineTransform originalTransform = gnSheet.getTransform();
+                try {
+                    var bounds = gnSheet.getBounds();
+                    var yscale = (fullHeight - 20) / bounds.getHeight();
+                    var xscale = (fullWidth - 20) / bounds.getWidth();
+                    var scale = Math.min(yscale, xscale);
+                    // Calculate position for this sheet (side by side horizontally)
+                    double xOffset = k * (pz.pxWidth * zoomFactor);
+
+                    // Center the sheet in the image
+                    double centerX = (fullWidth - (bounds.getWidth() * scale)) / 2;
+                    double centerY = (fullHeight - (bounds.getHeight() * scale)) / 2;
+
+                    // Apply transform for this sheet - scale and position
+                    AffineTransform transform = new AffineTransform();
+                    transform.translate(centerX + xOffset, centerY);
+                    transform.scale(scale, scale);
+                    gnSheet.setTransform(transform);
+
+                    // Paint this sheet
+                    gnSheet.paint(g);
+                    k++;
+                } finally {
+                    if (originalTransform != null) {
+                        gnSheet.setTransform(originalTransform);
+                    }
+                }
+            }
+        }
+
+        g.dispose();
+        // Store the image in a SoftReference
+        cachedImage = new SoftReference<>(img);
+    }
+
+    private void paintComponent(Graphics2D g, int width, int height) {
+        // Set render hints based on quality mode
+        RenderingHints rh = new RenderingHints(
+                RenderingHints.KEY_RENDERING,
+                isHighQuality ? RenderingHints.VALUE_RENDER_QUALITY : RenderingHints.VALUE_RENDER_SPEED);
+        rh.put(RenderingHints.KEY_INTERPOLATION,
+                isHighQuality ? RenderingHints.VALUE_INTERPOLATION_BICUBIC
+                        : RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        rh.put(RenderingHints.KEY_ANTIALIASING,
+                isHighQuality ? RenderingHints.VALUE_ANTIALIAS_ON : RenderingHints.VALUE_ANTIALIAS_OFF);
+        rh.put(RenderingHints.KEY_TEXT_ANTIALIASING,
+                isHighQuality ? RenderingHints.VALUE_TEXT_ANTIALIAS_ON : RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
+        rh.put(RenderingHints.KEY_FRACTIONALMETRICS,
+                isHighQuality ? RenderingHints.VALUE_FRACTIONALMETRICS_ON : RenderingHints.VALUE_FRACTIONALMETRICS_OFF);
+        rh.put(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+
+        g.setRenderingHints(rh);
+
+        // White background
+        g.setBackground(Color.WHITE);
+        g.clearRect(0, 0, width, height);
+
+        if (entities != null && !entities.isEmpty()) {
+            BufferedImage img = cachedImage != null ? cachedImage.get() : null;
+            // Generate image if needed
+            if (img == null) {
+                renderCachedImage();
+                img = cachedImage != null ? cachedImage.get() : null;
+            }
+
+            if (img != null) {
+                // Store original transform for restoration later
+                AffineTransform originalTransform = g.getTransform();
+
+                // Calculate source region (in image coordinates)
+                double srcX = Math.max(0, -panOffset.getX());
+                double srcY = Math.max(0, -panOffset.getY());
+
+                // Create a transform that handles positioning and scaling in one step
+                AffineTransform at = new AffineTransform(originalTransform);
+                at.translate(Math.max(0, panOffset.getX()), Math.max(0, panOffset.getY()));
+                g.setTransform(at);
+
+                // Draw the image
+                g.drawImage(img, -(int) srcX, -(int) srcY, null);
+
+                // Restore original transform
+                g.setTransform(originalTransform);
+            }
+        }
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        paintComponent((Graphics2D) g, getWidth(), getHeight());
+    }
+
+    // Add a component resize listener to adjust the view on resize
+    @Override
+    public void addNotify() {
+        super.addNotify();
+        addComponentListener(new java.awt.event.ComponentAdapter() {
+            @Override
+            public void componentResized(java.awt.event.ComponentEvent e) {
+                minZoom = getMinimumZoom();
+                // Only auto-fit if we haven't manually zoomed or panned yet
+                // (This prevents resetting user's view when window is resized)
+                if (cachedImage != null && zoomFactor == initialZoomFactor) {
+                    scheduleResetView();
+                }
+            }
+
+        });
+    }
+}

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -117,7 +117,7 @@ import org.apache.batik.gvt.GraphicsNode;
         addHierarchyListener(e -> {
             if ((e.getChangeFlags() & HierarchyEvent.SHOWING_CHANGED) != 0) {
                 // Only trigger on "becoming visible" events
-                if (needsViewReset && isShowing() {
+                if (needsViewReset && isShowing()) {
                     needsViewReset = false;
                     resetView();
                 }
@@ -577,6 +577,7 @@ import org.apache.batik.gvt.GraphicsNode;
                      resetView();
                  }
              }
+ 
          });
      }
  }

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -153,7 +153,7 @@ import org.apache.batik.gvt.GraphicsNode;
          // Render the record sheet directly without zoom/pan
          ArrayList<GraphicsNode> nodes = getRecordSheetGraphicsNodes(entities, options);
  
-         if (nodes.size() == 0) {
+         if (nodes == null || nodes.size() == 0) {
              return;
          }
  
@@ -462,7 +462,6 @@ import org.apache.batik.gvt.GraphicsNode;
          g.setBackground(Color.WHITE);
          g.clearRect(0, 0, totalWidth, fullHeight);
  
-         // if (entity != null) {
          if (sheetNodes != null && !sheetNodes.isEmpty()) {
              int k = 0;
              for (int i = 0; i < sheetNodes.size(); i++) {

--- a/megameklab/src/megameklab/util/UnitPrintManager.java
+++ b/megameklab/src/megameklab/util/UnitPrintManager.java
@@ -128,7 +128,12 @@ public class UnitPrintManager {
     }
 
     public static List<PrintRecordSheet> createSheets(List<? extends BTObject> entities, boolean singlePrint,
-            RecordSheetOptions options) {
+    RecordSheetOptions options) {
+        return createSheets(entities, singlePrint, options, false);
+    }
+
+    public static List<PrintRecordSheet> createSheets(List<? extends BTObject> entities, boolean singlePrint,
+            RecordSheetOptions options, boolean noWarningsOnUnprintable) {
         List<PrintRecordSheet> sheets = new ArrayList<>();
         List<Infantry> infList = new ArrayList<>();
         List<BattleArmor> baList = new ArrayList<>();
@@ -224,10 +229,12 @@ public class UnitPrintManager {
             }
         }
 
-        if (!unprintable.isEmpty()) {
-            JOptionPane.showMessageDialog(null, "Exporting is not currently supported for the following units:\n"
-                    + unprintable.stream().map(en -> en.generalName() + ' ' + en.specificName())
-                            .collect(Collectors.joining("\n")));
+        if (!noWarningsOnUnprintable) {
+            if (!unprintable.isEmpty()) {
+                JOptionPane.showMessageDialog(null, "Exporting is not currently supported for the following units:\n"
+                        + unprintable.stream().map(en -> en.generalName() + ' ' + en.specificName())
+                                .collect(Collectors.joining("\n")));
+            }
         }
 
         if (null != tank1) {


### PR DESCRIPTION
- Added support for viewing record sheets of units with multiple pages ("Leviathan II" for example)
- Fix for AdvAero units that had a broken label on their 2nd page (%s)
- Optimized record sheet preview (no rendering if not visible)
- Implemented record sheets visible directly from the unit selection list
- Limited multi-unit visualization to 10