### PR TITLE
MML #44: Mek jump boosters and jump jets

### DIFF
--- a/megameklab/src/megameklab/printing/PrintEntity.java
+++ b/megameklab/src/megameklab/printing/PrintEntity.java
@@ -588,7 +588,12 @@ public abstract class PrintEntity extends PrintRecordSheet {
     }
 
     protected String formatJump() {
-        return formatMovement(getEntity().getAnyTypeMaxJumpMP());
+        if (getEntity().getJumpMP() > 0 && getEntity().getMechanicalJumpBoosterMP() > 0) {
+            return formatMovement(getEntity().getJumpMP())
+                  + " (%d)".formatted(getEntity().getMechanicalJumpBoosterMP());
+        } else {
+            return formatMovement(getEntity().getAnyTypeMaxJumpMP());
+        }
     }
 
     protected String formatTechBase() {

--- a/megameklab/src/megameklab/printing/PrintEntity.java
+++ b/megameklab/src/megameklab/printing/PrintEntity.java
@@ -588,7 +588,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
     }
 
     protected String formatJump() {
-        return formatMovement(getEntity().getJumpMP());
+        return formatMovement(getEntity().getAnyTypeMaxJumpMP());
     }
 
     protected String formatTechBase() {

--- a/megameklab/src/megameklab/printing/reference/GroundToHitMods.java
+++ b/megameklab/src/megameklab/printing/reference/GroundToHitMods.java
@@ -62,7 +62,8 @@ public class GroundToHitMods extends ReferenceTable {
         addRow("", bundle.getString("stationary"), "+0");
         addRow("", bundle.getString("walked"), "+1");
         addRow("", bundle.getString("ran"), "+2");
-        if (entity.getOriginalJumpMP() > 0) {
+        if (entity.getOriginalJumpMP() > 0 ||
+              ((entity instanceof Mek mek) && (mek.getOriginalMechanicalJumpBoosterMP() > 0))) {
             addRow("", bundle.getString("jumped"), "+3");
         }
         if (!(entity instanceof QuadMek)) {

--- a/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
+++ b/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
@@ -198,7 +198,7 @@ public class StatusBar extends ITab {
             if (getEntity().getOriginalJumpMP() > 0) {
                 if (getEntity().getJumpType() == Mek.JUMP_IMPROVED) {
                     heat += Math.max(3, Math.ceil(getMek().getOriginalJumpMP() / 2.0f));
-                } else if (getEntity().getJumpType() != Mek.JUMP_BOOSTER) {
+                } else {
                     heat += Math.max(3, getEntity().getOriginalJumpMP());
                 }
                 if (getEntity().getEngineType() == Engine.XXL_ENGINE) {

--- a/megameklab/src/megameklab/ui/mek/BMCriticalTransferHandler.java
+++ b/megameklab/src/megameklab/ui/mek/BMCriticalTransferHandler.java
@@ -325,12 +325,17 @@ public class BMCriticalTransferHandler extends AbstractCriticalTransferHandler {
             location = list.getCritLocation();
         }
         if (mount != null) {
-            if (UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
-                parentView.markUnavailableLocations(location);
-                return new StringSelection("%d:%d".formatted(getUnit().getEquipmentNum(mount), location));
+            if (mount.is(EquipmentTypeLookup.MECHANICAL_JUMP_BOOSTER)) {
+                // cannot be moved
+                return null;
             } else {
-                parentView.markUnavailableLocations(mount);
-                return new StringSelection(Integer.toString(getUnit().getEquipmentNum(mount)));
+                if (UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
+                    parentView.markUnavailableLocations(location);
+                    return new StringSelection("%d:%d".formatted(getUnit().getEquipmentNum(mount), location));
+                } else {
+                    parentView.markUnavailableLocations(mount);
+                    return new StringSelection(Integer.toString(getUnit().getEquipmentNum(mount)));
+                }
             }
         } else {
             return null;

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -1107,32 +1107,29 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         if (jumpJet == null) {
             getMek().setOriginalJumpMP(0);
             jumpMP = 0;
-        } else if (jumpJet.hasFlag(MiscType.F_JUMP_JET) || jumpJet.hasFlag(MiscType.F_JUMP_BOOSTER)) {
+        } else if (jumpJet.is(EquipmentTypeLookup.MECHANICAL_JUMP_BOOSTER)) {
+            addOrRemoveMekMechanicalJumpBoosters(jumpMP, jumpJet);
+        } else if (jumpJet.hasFlag(MiscType.F_JUMP_JET)) {
             getMek().setOriginalJumpMP(jumpMP);
         } else {
             getMek().setOriginalJumpMP(0);
         }
 
-        if (jumpJet != null) {
+        // Remove or add jump jet equipment according to jump MP (if not Mek Mechanical Jump Boosters)
+        if (jumpJet != null && !jumpJet.is(EquipmentTypeLookup.MECHANICAL_JUMP_BOOSTER)) {
             List<Mounted<?>> jjs = getMek().getMisc().stream()
-                    .filter(m -> jumpJet.equals(m.getType()))
-                    .collect(Collectors.toList());
-            if (jumpJet.hasFlag(MiscType.F_JUMP_BOOSTER)) {
-                if (!getMek().hasWorkingMisc(MiscType.F_JUMP_BOOSTER)) {
-                    MekUtil.createSpreadMounts(getMek(), jumpJet);
+                  .filter(m -> jumpJet.equals(m.getType()))
+                  .collect(Collectors.toList());
+            while (jjs.size() > jumpMP) {
+                UnitUtil.removeMounted(getMek(), jjs.remove(jjs.size() - 1));
+            }
+            while (jumpMP > jjs.size()) {
+                try {
+                    UnitUtil.addMounted(getMek(), Mounted.createMounted(getMek(), jumpJet), Entity.LOC_NONE, false);
+                } catch (LocationFullException ignored) {
+                    // Adding to LOC_NONE
                 }
-            } else {
-                while (jjs.size() > jumpMP) {
-                    UnitUtil.removeMounted(getMek(), jjs.remove(jjs.size() - 1));
-                }
-                while (jumpMP > jjs.size()) {
-                    try {
-                        UnitUtil.addMounted(getMek(), Mounted.createMounted(getMek(), jumpJet), Entity.LOC_NONE, false);
-                    } catch (LocationFullException ignored) {
-                        // Adding to LOC_NONE
-                    }
-                    jumpMP--;
-                }
+                jumpMP--;
             }
         }
 
@@ -1143,12 +1140,30 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         panMovement.setFromEntity(getMek());
     }
 
+    private void addOrRemoveMekMechanicalJumpBoosters(final int jumpMP, EquipmentType jumpJet) {
+        assert (jumpJet.is(EquipmentTypeLookup.MECHANICAL_JUMP_BOOSTER));
+        if (jumpMP == 0) {
+            UnitUtil.removeAllMounteds(getMek(), jumpJet);
+        } else {
+            Optional<MiscMounted> mekMechanicalJumpBooster = getMek().getMisc().stream()
+                  .filter(m -> m.is(EquipmentTypeLookup.MECHANICAL_JUMP_BOOSTER))
+                  .findFirst();
+            if (mekMechanicalJumpBooster.isEmpty()) {
+                MiscMounted createdMount = (MiscMounted) MekUtil.createSpreadMounts(getMek(), jumpJet);
+                if (createdMount != null) {
+                    mekMechanicalJumpBooster = Optional.of(createdMount);
+                }
+            }
+            mekMechanicalJumpBooster.ifPresent(m -> m.setSize(jumpMP));
+        }
+    }
+
+
     @Override
     public void jumpTypeChanged(final EquipmentType jumpJet) {
         List<Mounted<?>> jjs = getMek().getMisc().stream()
                 .filter(m -> m.getType().hasFlag(MiscType.F_JUMP_JET)
-                        || m.getType().hasFlag(MiscType.F_UMU)
-                        || m.getType().hasFlag(MiscType.F_JUMP_BOOSTER))
+                        || m.getType().hasFlag(MiscType.F_UMU))
                 .filter(m -> !jumpJet.equals(m.getType()))
                 .collect(Collectors.toList());
         jjs.forEach(jj -> UnitUtil.removeMounted(getMek(), jj));

--- a/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
@@ -75,7 +75,7 @@ public enum EquipmentDatabaseCategory {
                     && !UnitUtil.isJumpJet(eq)
                     && !UnitUtil.isHeatSink(eq)
                     && !(isIndustrialEquipment(eq) && ((en instanceof Tank) || en.isSupportVehicle() || en instanceof Mek))
-                    && !eq.isAnyOf(LAM_FUEL_TANK)
+                    && !eq.isAnyOf(LAM_FUEL_TANK, MECHANICAL_JUMP_BOOSTER)
                     && !eq.hasFlag(F_TSM)
                     && !eq.hasFlag(F_INDUSTRIAL_TSM)
                     && !(eq.hasFlag(F_MASC)

--- a/megameklab/src/megameklab/util/MekUtil.java
+++ b/megameklab/src/megameklab/util/MekUtil.java
@@ -476,22 +476,15 @@ public final class MekUtil {
         }
         // if this is the same jump jet type, then only remove if too many
         // and add if too low
-        if (jjType == Mek.JUMP_BOOSTER) {
-            removeJumpJets(unit, unit.getJumpMP());
-            createSpreadMounts(
-                    unit,
-                    EquipmentType.get(UnitUtil.getJumpJetType(jjType)));
-        } else {
-            while (jjAmount > 0) {
-                try {
-                    unit.addEquipment(
-                            Mounted.createMounted(unit, EquipmentType.get(UnitUtil.getJumpJetType(jjType))),
-                            Entity.LOC_NONE, false);
-                } catch (Exception ex) {
-                    logger.error("", ex);
-                }
-                jjAmount--;
+        while (jjAmount > 0) {
+            try {
+                unit.addEquipment(
+                      Mounted.createMounted(unit, EquipmentType.get(UnitUtil.getJumpJetType(jjType))),
+                      Entity.LOC_NONE, false);
+            } catch (Exception ex) {
+                logger.error("", ex);
             }
+            jjAmount--;
         }
     }
 

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -586,8 +586,6 @@ public class UnitUtil {
             return EquipmentTypeLookup.IMPROVED_JUMP_JET;
         } else if (type == Mek.JUMP_PROTOTYPE) {
             return EquipmentTypeLookup.PROTOTYPE_JUMP_JET;
-        } else if (type == Mek.JUMP_BOOSTER) {
-            return EquipmentTypeLookup.MECHANICAL_JUMP_BOOSTER;
         } else if (type == Mek.JUMP_PROTOTYPE_IMPROVED) {
             return EquipmentTypeLookup.PROTOTYPE_IMPROVED_JJ;
         }


### PR DESCRIPTION
This is the MML part of allowing both jump jets and Mek mechanical jump boosters.
- In the movement view, there is now a spinner control to set the desired MMJB jump MP. MMJB are added or removed accordingly if there is room
- JJ are independently set as before (but boosters can no longer be selected as JJs)
- as MMJB MP can no longer be saved to file as the unit's jump MP, MMJB are now variable size and store the MP (not the weight) as the size value. Code has been added to read legacy MTFs.
- On RS and the Mekview, the equipment line for MMJB now shows the MP; the jumping movement entry is unchanged unless a Mek has both systems in which case see screenshot
- MMJB are no longer available from the equipment tab and cannot be manipulated in the crit view except switching pod/fixed

Requires Megamek/megamek#6752 and MHQ PR

![image](https://github.com/user-attachments/assets/3fa1aad6-cca0-457f-b061-7e2516d934da)
![image](https://github.com/user-attachments/assets/575934de-482b-4c6b-8d46-59ce3823103f)
