### PR TITLE
Add HHW to new unit/switch unit type menus

### DIFF
--- a/megameklab/resources/megameklab/resources/Menu.properties
+++ b/megameklab/resources/megameklab/resources/Menu.properties
@@ -29,6 +29,7 @@ miSwitchToSupportVehicle.text=Support Vehicle
 miSwitchToBattleArmor.text=Battle Armor
 miSwitchToInfantry.text=Infantry
 miSwitchToProtoMek.text=ProtoMek
+miSwitchToHandheldWeapon.text=Handheld Weapon
 # Primitive Menu
 primitiveMenu.text=Primitive/Retro
 miSwitchToAero.text=Aero

--- a/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
@@ -264,6 +264,7 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
         menu.add(newUnitItem("New Battle Armor", Entity.ETYPE_BATTLEARMOR, false));
         menu.add(newUnitItem("New Conventional Infantry", Entity.ETYPE_INFANTRY, false));
         menu.add(newUnitItem("New ProtoMek", Entity.ETYPE_PROTOMEK, false));
+        menu.add(newUnitItem("New Handheld Weapon", Entity.ETYPE_HANDHELD_WEAPON, false));
 
         JMenu primitive = new JMenu("New Primitive...");
         primitive.add(newUnitItem("New Mek", Entity.ETYPE_MEK, true));
@@ -390,6 +391,7 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
         tabs.setEnabledAt(tabs.getSelectedIndex(), true);
         oldUi.dispose();
         refreshMenuBar();
+        newUi.refreshHeader();
     }
 
     /**

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -14,6 +14,25 @@
  */
 package megameklab.ui;
 
+import java.awt.Component;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.ClipboardOwner;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.util.ResourceBundle;
+import javax.swing.*;
+import javax.swing.UIManager.LookAndFeelInfo;
+import javax.swing.filechooser.FileNameExtensionFilter;
+import javax.swing.text.DefaultCaret;
+import javax.swing.text.html.HTMLEditorKit;
+
 import megamek.client.ui.dialogs.BVDisplayDialog;
 import megamek.client.ui.dialogs.CostDisplayDialog;
 import megamek.client.ui.dialogs.WeightDisplayDialog;
@@ -34,24 +53,6 @@ import megameklab.ui.util.MegaMekLabFileSaver;
 import megameklab.util.CConfig;
 import megameklab.util.UnitPrintManager;
 import megameklab.util.UnitUtil;
-
-import javax.swing.*;
-import javax.swing.UIManager.LookAndFeelInfo;
-import javax.swing.filechooser.FileNameExtensionFilter;
-import javax.swing.text.DefaultCaret;
-import javax.swing.text.html.HTMLEditorKit;
-import java.awt.*;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.ClipboardOwner;
-import java.awt.datatransfer.StringSelection;
-import java.awt.datatransfer.Transferable;
-import java.awt.event.ActionEvent;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
-import java.util.ResourceBundle;
 
 /**
  * @author jtighe (torren@users.sourceforge.net)
@@ -280,6 +281,14 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
             miSwitchToProtoMek.setMnemonic(KeyEvent.VK_P);
             miSwitchToProtoMek.addActionListener(evt -> switchUnitType(Entity.ETYPE_PROTOMEK));
             switchUnitTypeMenu.add(miSwitchToProtoMek);
+        }
+
+        if ((entity == null) || (!entity.hasETypeFlag(Entity.ETYPE_HANDHELD_WEAPON))) {
+            final JMenuItem miSwitchToHandheldWeapon = new JMenuItem(resources.getString("miSwitchToHandheldWeapon.text"));
+            miSwitchToHandheldWeapon.setName("miSwitchToHandheldWeapon");
+            miSwitchToHandheldWeapon.setMnemonic(KeyEvent.VK_H);
+            miSwitchToHandheldWeapon.addActionListener(evt -> switchUnitType(Entity.ETYPE_HANDHELD_WEAPON));
+            switchUnitTypeMenu.add(miSwitchToHandheldWeapon);
         }
 
         switchUnitTypeMenu.add(createPrimitiveMenu(entity));


### PR DESCRIPTION
Updates the File->Switch Unit Type menu and the New Tab right click context menu to include Handheld Weapons, now that HHWs have record sheets and someone might actually want to build one.

Also fixes a bug where switching unit type wouldn't update the tab name.