### PR TITLE
Custom armor kit in Record Sheets

### DIFF
--- a/megameklab/src/megameklab/printing/PrintInfantry.java
+++ b/megameklab/src/megameklab/printing/PrintInfantry.java
@@ -403,21 +403,26 @@ public class PrintInfantry extends PrintEntity {
         EquipmentType armor = infantry.getArmorKit();
         if (armor != null) {
             setTextField(ARMOR_KIT, armor.getName());
-        } else if (infantry.hasDEST()) {
-            setTextField(ARMOR_KIT, "DEST");
         } else {
-            StringJoiner sj = new StringJoiner("/");
-            if (infantry.hasSneakCamo()) {
-                sj.add("Camo");
-            }
-            if (infantry.hasSneakIR()) {
-                sj.add("IR");
-            }
-            if (infantry.hasSneakECM()) {
-                sj.add("ECM");
-            }
-            if (sj.length() > 0) {
-                setTextField(ARMOR_KIT, "Sneak(" + sj + ")");
+
+            if (infantry.hasDEST()) {
+                setTextField(ARMOR_KIT, "Custom DEST");
+            } else {
+                StringJoiner sj = new StringJoiner("/");
+                if (infantry.hasSneakCamo()) {
+                    sj.add("Camo");
+                }
+                if (infantry.hasSneakIR()) {
+                    sj.add("IR");
+                }
+                if (infantry.hasSneakECM()) {
+                    sj.add("ECM");
+                }
+                if (sj.length() > 0) {
+                    setTextField(ARMOR_KIT, "Custom Sneak(" + sj + ")");
+                } else if (infantry.getArmorDamageDivisor() != 1.0) {
+                    setTextField(ARMOR_KIT, "Custom");
+                }
             }
         }
         setTextField(ARMOR_DIVISOR, infantry.calcDamageDivisor()

--- a/megameklab/src/megameklab/ui/infantry/CIArmorView.java
+++ b/megameklab/src/megameklab/ui/infantry/CIArmorView.java
@@ -15,6 +15,28 @@
  */
 package megameklab.ui.infantry;
 
+import java.awt.BorderLayout;
+import java.awt.CardLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import javax.swing.*;
+import javax.swing.JSpinner.DefaultEditor;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
+
 import megamek.client.ui.models.XTableColumnModel;
 import megamek.common.EquipmentType;
 import megamek.common.ITechManager;
@@ -25,17 +47,6 @@ import megameklab.ui.util.EquipmentTableModel;
 import megameklab.ui.util.IView;
 import megameklab.ui.util.RefreshListener;
 import megameklab.util.CConfig;
-
-import javax.swing.*;
-import javax.swing.JSpinner.DefaultEditor;
-import javax.swing.event.*;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.util.ArrayList;
-import java.util.Enumeration;
 
 public class CIArmorView extends IView implements ActionListener, ChangeListener {
     private RefreshListener refresh = null;
@@ -64,6 +75,10 @@ public class CIArmorView extends IView implements ActionListener, ChangeListener
     JCheckBox chSneakIR = new JCheckBox();
     JCheckBox chSneakECM = new JCheckBox();
     private JSpinner armorValue = new JSpinner(new SpinnerNumberModel(1.0, 0.5, 3.0, 0.5));
+
+    private final JLabel lblSneakWarning = new JLabel("Warning: Setting both DEST and Sneak properties on custom armor " +
+                                                         "may cause issues in the display of the armor kit " +
+                                                         "information.");
     
     public CIArmorView(EntitySource eSource, ITechManager techManager) {
         super(eSource);
@@ -255,11 +270,21 @@ public class CIArmorView extends IView implements ActionListener, ChangeListener
         chSneakECM.setText("Sneak (ECM)");
         gbc.gridx = 1;
         gbc.gridy = 3;
-        gbc.weightx = 1.0;
-        gbc.weighty = 1.0;
+        gbc.weightx = 1;
+        gbc.weighty = 0.01;
         customView.add(chSneakECM, gbc);
 
-        equipmentView.add(customView, CARD_CUSTOM);        
+        lblSneakWarning.setForeground(Color.RED);
+        lblSneakWarning.setVisible(false);
+        gbc.gridx = 0;
+        gbc.gridy = 4;
+        gbc.weightx = 0;
+        gbc.weighty = 1;
+        gbc.gridwidth = 2;
+        customView.add(lblSneakWarning, gbc);
+
+        equipmentView.add(customView, CARD_CUSTOM);
+//        equipmentView.add(lblSneakWarning);
     }
 
     public JLabel createLabel(String text, Dimension maxSize) {
@@ -300,6 +325,16 @@ public class CIArmorView extends IView implements ActionListener, ChangeListener
             chSneakIR.setEnabled(true);
             chSneakECM.setEnabled(true);
         }
+
+        if (getInfantry().hasDEST() && (
+              getInfantry().hasSneakCamo() || getInfantry().hasSneakIR() || getInfantry().hasSneakECM()
+              )) {
+            lblSneakWarning.setVisible(true);
+        } else {
+            lblSneakWarning.setVisible(false);
+        }
+
+
         filterEquipment();
         btnRemoveArmor.setEnabled(hasArmor());
         rbtnCustom.setEnabled(getInfantry().getArmorKit() == null);


### PR DESCRIPTION
Depends on MegaMek/megamek#6832.
Fixes #1808.

When setting a custom armor kit, it is now included in the record sheet:
![image](https://github.com/user-attachments/assets/76f5ce1a-7325-457f-9531-d43ea2b60366)
![image](https://github.com/user-attachments/assets/43895b97-a6d5-4f11-a920-15f91e7d00ec)
![image](https://github.com/user-attachments/assets/4d74f24d-b4a5-4ec7-9244-257e879305e5)

Also adds a warning that if you enable both DEST and Sneak, things may break. The record sheet will not properly display both DEST and Sneak because you really _shouldn't_ do that, even though we're not stopping you. 
![image](https://github.com/user-attachments/assets/133845c8-cf72-4df1-8547-5c07f824199b)

