### PR TITLE
Include BA Camo System in record sheets

### DIFF
--- a/megameklab/src/megameklab/printing/PrintUtil.java
+++ b/megameklab/src/megameklab/printing/PrintUtil.java
@@ -129,7 +129,6 @@ public final class PrintUtil {
         if ((eq instanceof MiscType)
                 && ((eq.hasFlag(MiscType.F_AP_MOUNT) && !eq.hasFlag(MiscType.F_BA_MANIPULATOR))
                         || eq.hasFlag(MiscType.F_FIRE_RESISTANT)
-                        || eq.hasFlag(MiscType.F_STEALTH)
                         || eq.hasFlag(MiscType.F_ARTEMIS)
                         || eq.hasFlag(MiscType.F_ARTEMIS_V)
                         || eq.hasFlag(MiscType.F_APOLLO)


### PR DESCRIPTION
Fixes #1807.

The BA Camo System used to have a special section just for it in old sheets, and no longer does, so we want to include it in the main inventory.