### PR TITLE
Fixes for RS preview and enhanced tabbed pane

### DIFF
--- a/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
@@ -186,6 +186,9 @@ public class BAMainUI extends MegaMekLabMainUI {
 
     @Override
     public List<Mounted<?>> getUnallocatedMounted() {
+        if (buildTab == null) {
+            return List.of();
+        }
         return buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
@@ -241,6 +241,9 @@ public class CVMainUI extends MegaMekLabMainUI {
 
     @Override
     public List<Mounted<?>> getUnallocatedMounted() {
+        if (buildTab == null) {
+            return List.of();
+        }
         return buildTab.getUnallocatedView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
@@ -229,6 +229,9 @@ public class ASMainUI extends MegaMekLabMainUI {
 
     @Override
     public List<Mounted<?>> getUnallocatedMounted() {
+        if (buildTab == null) {
+            return List.of();
+        }
         return buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/generalUnit/QuirksTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/QuirksTab.java
@@ -384,10 +384,14 @@ public class QuirksTab extends ITab implements DialogOptionListener {
         gbc.fill = GridBagConstraints.HORIZONTAL;
 
         // Add quirks to the group panel in a grid layout
+        int lastColIndex = 0;
         for (int i = 0; i < totalItems; i++) {
-            final int colIndex = i % itemsPerCol;
+            final int rowIndex = i % itemsPerCol;
             gbc.gridx = i / itemsPerCol;
-            gbc.gridy = colIndex;
+            gbc.gridy = rowIndex;
+            if (gbc.gridx > lastColIndex) {
+                lastColIndex = gbc.gridx;
+            }
 
             DialogOptionComponent comp = quirks.get(i);
             // Set preferred width so we match the width of the widest item
@@ -401,10 +405,9 @@ public class QuirksTab extends ITab implements DialogOptionListener {
         // Because we are auto-spacing them horizontally (bgc.weightx = 1 above), we
         // create fake columns in case
         // this group doesn't have enough (usually weapons)
-        final int lastColUsed = totalItems % itemsPerCol;
-        for (int i = lastColUsed + 1; i < numCols; i++) {
-            gbc.gridx = numCols - 1;
-            gbc.gridy = i;
+        for (int i = lastColIndex + 1; i < numCols; i++) {
+            gbc.gridx = i;
+            gbc.gridy = 0;
             groupPanel.add(Box.createHorizontalStrut(globalMaxItemWidth), gbc);
         }
 

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -491,7 +491,7 @@ private double constrainPanX(double panX) {
             this.currentEntities = processedEntities;
             regenerateAndReset();
         } else {
-            updateTimer.restart(); // Restart update timer to debounce
+            updateSheetContentInPlace();
         }
     }
 

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -772,8 +772,9 @@ private double constrainPanX(double panX) {
                     return;
                 }
                 if (finalStructureChanged) {
-                    // If structure changed (or error occurred), fall back to full reset
-                    logger.warn(
+                    // If structure changed (or error occurred), fall back to full reset.
+                    // It can happen when the tab is re-attached
+                    logger.debug(
                             "Sheet structure changed during in-place update or error occurred. Performing full reset.");
                     regenerateAndReset(); // Use the full reset logic
                     return;

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -478,7 +478,7 @@ private double constrainPanX(double panX) {
      * 
      * @param selectedEntities The list of entities to display.
      */
-    public void setEntities(List<BTObject> selectedEntities) {
+    public void setEntities(List<? extends BTObject> selectedEntities) {
         List<BTObject> processedEntities;
         if (selectedEntities == null) {
             processedEntities = Collections.emptyList();
@@ -494,31 +494,6 @@ private double constrainPanX(double panX) {
             updateTimer.restart(); // Restart update timer to debounce
         }
     }
-
-    /**
-     * Set the entities to be displayed in the record sheet preview.
-     * 
-     * @param selectedEntities The list of entities to display.
-     */
-    public void setEntities(ArrayList<Entity> selectedEntities) {
-        List<BTObject> processedEntities;
-        if (selectedEntities == null) {
-            processedEntities = Collections.emptyList();
-        } else {
-            // Create a new list to avoid external modifications affecting us
-            processedEntities = new ArrayList<>(selectedEntities);
-        }
-        boolean entitiesChanged = !areEntityListsEffectivelyEqual(this.currentEntities, processedEntities);
-        if (entitiesChanged) {
-            this.currentEntities = processedEntities;
-            regenerateAndReset();
-        } else {
-            updateTimer.restart(); // Restart update timer to debounce
-        }
-    }
-
-    
-
 
     /**
      * Set a single entity to be displayed in the record sheet preview.

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -194,7 +194,7 @@ public class RecordSheetPreviewPanel extends JPanel {
             if (e.getButton() != MouseEvent.BUTTON3) {
                 return;
             }
-            if (e.getComponent().isShowing()) {
+            if ((e.getComponent() != null) && (e.getComponent().isShowing())) {
                 popup.show(e.getComponent(), e.getX(), e.getY());
             }
         }

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -256,6 +256,9 @@ public class DSMainUI extends MegaMekLabMainUI {
 
     @Override
     public List<Mounted<?>> getUnallocatedMounted() {
+        if (buildTab == null) {
+            return List.of();
+        }
         return buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
@@ -271,6 +271,9 @@ public class WSMainUI extends MegaMekLabMainUI {
 
     @Override
     public List<Mounted<?>> getUnallocatedMounted() {
+        if (buildTab == null) {
+            return List.of();
+        }
         return buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/mek/BMMainUI.java
+++ b/megameklab/src/megameklab/ui/mek/BMMainUI.java
@@ -260,6 +260,9 @@ public class BMMainUI extends MegaMekLabMainUI {
 
     @Override
     public List<Mounted<?>> getUnallocatedMounted() {
+        if (buildTab == null) {
+            return List.of();
+        }
         return this.buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
@@ -209,6 +209,9 @@ public class PMMainUI extends MegaMekLabMainUI {
 
     @Override
     public List<Mounted<?>> getUnallocatedMounted() {
+        if (buildTab == null) {
+            return List.of();
+        }
         return buildTab.getBuildView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
@@ -256,6 +256,9 @@ public class SVMainUI extends MegaMekLabMainUI {
 
     @Override
     public List<Mounted<?>> getUnallocatedMounted() {
+        if (buildTab == null) {
+            return List.of();
+        }
         return buildTab.getUnallocatedView().getEquipment();
     }
 }

--- a/megameklab/src/megameklab/ui/util/EnhancedTabbedPane.java
+++ b/megameklab/src/megameklab/ui/util/EnhancedTabbedPane.java
@@ -220,8 +220,13 @@ public class EnhancedTabbedPane extends JTabbedPane {
                 }
             }
         });
-        // Add double-click listener for tab area reattachment
+        // Add double-click listener for tab area reattachment and cursor reset
         addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseExited(MouseEvent e) {
+                // Reset cursor when mouse exits the tabbed pane
+                setCursor(Cursor.getDefaultCursor());
+            }
             @Override
             public void mouseClicked(MouseEvent e) {
                 if (e.getClickCount() == 2 && hasDetachedTabs()) {


### PR DESCRIPTION
- changed setEntities to use wildcard type
- corrected a debounce call to use the proper method
- during inplace updates we get the updated sheets in EDT (prevents CME)
- fixed hand cursor not properly reset to default when leaving a tabbed pane
- fixed NPE caused by UnitMemento when opening multiple units