### PR TITLE
Update armor slot count on superheavy status change

### DIFF
--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -13,6 +13,23 @@
  */
 package megameklab.ui.mek;
 
+import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import megamek.codeUtilities.MathUtility;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
@@ -36,13 +53,6 @@ import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
 import megameklab.util.MekUtil;
 import megameklab.util.UnitUtil;
-
-import javax.swing.*;
-import java.awt.*;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 public class BMStructureTab extends ITab implements MekBuildListener, ArmorAllocationListener {
     private static final MMLogger logger = MMLogger.create(BMStructureTab.class);
@@ -743,6 +753,18 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         if (changedSuperHeavyStatus) {
             // Internal structure crits may change
             UnitUtil.removeISorArmorMounts(getMek(), true);
+
+            // The number of critical slots that the armor should take up may have changed.
+            // You might notice this doesn't handle patchwork armor.
+            // This is because to my knowledge how patchwork armor is
+            //      supposed to work on superheavies has never been explained.
+            if (!getMek().hasPatchworkArmor()) {
+                int at = getMek().getArmorType(0);
+                int aTechLevel = getMek().getArmorTechLevel(0);
+                UnitUtil.removeISorArmorMounts(getMek(), false);
+                createArmorMountsAndSetArmorType(at, aTechLevel);
+            }
+
             createISMounts(panChassis.getStructure());
             resetSystemCrits();
             panMovement.setFromEntity(getMek());


### PR DESCRIPTION
Requires MegaMek/megamek#6893.

Fixes #1815.

Re-add the Mek's armor slots when it becomes or stops being a Superheavy Mek to ensure the correct armor slot count.