### PR TITLE
Security Fix for File open when passing via command line arguments

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,6 +36,7 @@ jobs:
           languages: java-kotlin
           queries: security-and-quality
           build-mode: none
+          source-root: megameklab
           config: |
             paths:
               - megameklab

--- a/megameklab/src/megameklab/MegaMekLab.java
+++ b/megameklab/src/megameklab/MegaMekLab.java
@@ -339,7 +339,7 @@ public class MegaMekLab {
             }
 
             if (!file.exists()) {
-                throw new IllegalArgumentException("File not found: " + filePath);
+                throw new IllegalArgumentException("Error processing file:: " + filePath);
             }
 
             if (file.getName().toLowerCase().endsWith(".blk") || file.getName().toLowerCase().endsWith(".mtf")) {
@@ -366,9 +366,6 @@ public class MegaMekLab {
                     return false;
                 }
             }
-        } catch (java.nio.file.NoSuchFileException fileNotFound) {
-            LOGGER.error("File not found: {}", fileNotFound.getMessage());
-            return false;
         } catch (Exception ex) {
             LOGGER.error(ex, "Error processing file: {}", filePath);
         }

--- a/megameklab/src/megameklab/MegaMekLab.java
+++ b/megameklab/src/megameklab/MegaMekLab.java
@@ -31,6 +31,7 @@ import java.awt.Window;
 import java.io.File;
 import java.io.ObjectInputFilter;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
 import java.util.Locale;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
@@ -319,17 +320,21 @@ public class MegaMekLab {
     private static boolean openUnitFile(String filePath, boolean noStartup) {
         try {
             final File file = new File(filePath).getCanonicalFile();
+            final Path fullPath = file.toPath().toRealPath();
 
-            if (!file.toString().toLowerCase().endsWith(".blk") &&
-                      !file.toString().toLowerCase().endsWith(".mtf") &&
-                      !file.toString().toLowerCase().endsWith(".mul")) {
-                LOGGER.info("Non-supported file extension: {}", file);
+            if (!fullPath.toString().toLowerCase().endsWith(".blk") &&
+                      !fullPath.toString().toLowerCase().endsWith(".mtf") &&
+                      !fullPath.toString().toLowerCase().endsWith(".mul")) {
+                LOGGER.info("Non-supported file extension: {}", fullPath);
                 return false;
             }
 
-            if (file.toString().toLowerCase().startsWith("/etc") ||
-                      file.toString().toLowerCase().startsWith("/system")) {
-                LOGGER.error("Attempting to load from System folders.");
+            LOGGER.info("Opening file: {}", fullPath);
+
+            if (fullPath.toString().toLowerCase().startsWith("/etc") ||
+                      fullPath.toString().toLowerCase().startsWith("/private") ||
+                      fullPath.toString().toLowerCase().startsWith("/system")) {
+                LOGGER.error("Attempting to load from protected system folders.");
                 return false;
             }
 
@@ -361,6 +366,9 @@ public class MegaMekLab {
                     return false;
                 }
             }
+        } catch (java.nio.file.NoSuchFileException fileNotFound) {
+            LOGGER.error("File not found: {}", fileNotFound.getMessage());
+            return false;
         } catch (Exception ex) {
             LOGGER.error(ex, "Error processing file: {}", filePath);
         }

--- a/megameklab/src/megameklab/MegaMekLab.java
+++ b/megameklab/src/megameklab/MegaMekLab.java
@@ -82,7 +82,7 @@ public class MegaMekLab {
 
         // Skip single instance check if in multi-instance mode
         if (!multiInstanceMode) {
-            // Initialize single instance service
+            // Initialize a single instance service
             singleInstanceService = new SingleInstanceService(APPLICATION_ID);
 
             boolean isFirstInstance = singleInstanceService.register();
@@ -117,7 +117,7 @@ public class MegaMekLab {
                 });
             });
 
-            // Add shutdown hook to clean up resources
+            // Add a shutdown hook to clean up resources
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 if (singleInstanceService != null) {
                     singleInstanceService.cleanup();
@@ -161,7 +161,7 @@ public class MegaMekLab {
     }
 
     /**
-     * Check if arguments contains specific argument
+     * Check if arguments contain specific argument
      *
      * @param args Command line arguments
      * @param arg  Argument to check for
@@ -311,12 +311,24 @@ public class MegaMekLab {
     }
 
     /**
-     * Opens a unit file. This is called from command line
+     * Opens a unit file. This is called from the command line
      *
      * @param filePath  The path to the file to open
      * @param noStartup for .mul files
      */
     private static boolean openUnitFile(String filePath, boolean noStartup) {
+        if (!filePath.toLowerCase().endsWith(".blk") ||
+                  !filePath.toLowerCase().endsWith(".mtf") ||
+                  !filePath.toLowerCase().endsWith(".mul")) {
+            LOGGER.info("Non-supported file extension: {}", filePath);
+            return false;
+        }
+
+        if (filePath.contains("..") || filePath.contains("/") || filePath.contains("\\")) {
+            LOGGER.error("Security Violation: Invalid filename: {}", filePath);
+            return false;
+        }
+
         try {
             final File file = new File(filePath).getCanonicalFile();
             if (!file.exists()) {


### PR DESCRIPTION
This is a security issue recently found that would potentially allow opening of any file on the system and checking for its existence. This fixes that issue by confirming it ends with the extensions we want and doesn't include any known issues within the filename.