### PR TITLE
fixes MUL print from console and memory leaks on dialogs

### DIFF
--- a/megameklab/src/megameklab/ui/dialog/PrintQueueDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/PrintQueueDialog.java
@@ -332,7 +332,9 @@ public class PrintQueueDialog extends AbstractMMLButtonDialog {
                 return;
             }
         } else {
-            UnitPrintManager.printAllUnits(units, oneUnitPerSheetCheck.isSelected(), options);
+            if (!UnitPrintManager.printAllUnits(units, oneUnitPerSheetCheck.isSelected(), options)) {
+                return;
+            }
         }
         super.okButtonActionPerformed(evt);
     }
@@ -561,6 +563,16 @@ public class PrintQueueDialog extends AbstractMMLButtonDialog {
             var end   = indices[indices.length - 1];
             return end - start == indices.length - 1;
         }
+    }
+
+    @Override
+    protected void okAction() {
+        dispose();
+    }
+
+    @Override
+    protected void cancelAction() {
+        dispose();
     }
 
     // TODO: Move to UIUtil

--- a/megameklab/src/megameklab/ui/dialog/settings/SettingsDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/SettingsDialog.java
@@ -83,11 +83,13 @@ public class SettingsDialog extends AbstractMMLButtonDialog {
             GUIPreferences.getInstance().setValue(GUIPreferences.GUI_SCALE, miscSettingsPanel.guiScale());
             MegaMekLab.updateGuiScaling();
         }
+        dispose();
     }
 
     @Override
     protected void cancelAction() {
         CConfig.loadConfigFile();
+        dispose();
     }
 
     private static class SettingsScrollPane extends JScrollPane {

--- a/megameklab/src/megameklab/util/MULManager.java
+++ b/megameklab/src/megameklab/util/MULManager.java
@@ -54,19 +54,22 @@ public class MULManager {
         if (behaviourValue >= 0 && behaviourValue < allValues.length) {
             selectedBehaviour = allValues[behaviourValue];
         }
-        switch (selectedBehaviour) {
-            case PRINT:
-                // Print
-                UnitPrintManager.printMUL(owner, false, file);
-                break;
-            case EXPORT:
-                // Export to PDF
-                UnitPrintManager.printMUL(owner, true, file);
-                break;
-            case LOAD_FORCE:
-                // Load into Force Builder
-                loadForceFromMUL(file);
-                break;
+        if (selectedBehaviour == MulDndBehaviour.LOAD_FORCE) {
+            loadForceFromMUL(file);
+            return;
+        }
+        JFrame dummyOwner = null;
+        if (owner == null) {
+            dummyOwner = new JFrame();
+            dummyOwner.setUndecorated(true);
+            dummyOwner.setSize(0, 0);
+            dummyOwner.setLocationRelativeTo(null);
+            dummyOwner.setVisible(true);
+            owner = dummyOwner;
+        }
+        UnitPrintManager.printMUL(owner, selectedBehaviour == MulDndBehaviour.EXPORT, file);
+        if (dummyOwner != null) {
+            dummyOwner.dispose();
         }
     }
 

--- a/megameklab/src/megameklab/util/MULManager.java
+++ b/megameklab/src/megameklab/util/MULManager.java
@@ -60,7 +60,7 @@ public class MULManager {
         }
         JFrame dummyOwner = null;
         if (owner == null) {
-            dummyOwner = new JFrame();
+            dummyOwner = new JFrame("MegaMekLab - Print Queue");
             dummyOwner.setUndecorated(true);
             dummyOwner.setSize(0, 0);
             dummyOwner.setLocationRelativeTo(null);

--- a/megameklab/src/megameklab/util/MULManager.java
+++ b/megameklab/src/megameklab/util/MULManager.java
@@ -67,9 +67,12 @@ public class MULManager {
             dummyOwner.setVisible(true);
             owner = dummyOwner;
         }
-        UnitPrintManager.printMUL(owner, selectedBehaviour == MulDndBehaviour.EXPORT, file);
-        if (dummyOwner != null) {
-            dummyOwner.dispose();
+        try {
+            UnitPrintManager.printMUL(owner, selectedBehaviour == MulDndBehaviour.EXPORT, file);
+        } finally {
+            if (dummyOwner != null) {
+                dummyOwner.dispose();
+            }
         }
     }
 

--- a/megameklab/src/megameklab/util/UnitPrintManager.java
+++ b/megameklab/src/megameklab/util/UnitPrintManager.java
@@ -303,8 +303,8 @@ public class UnitPrintManager {
      * @param loadedUnits The units to print
      * @param singlePrint Whether to limit each record sheet to a single unit
      */
-    public static void printAllUnits(List<? extends BTObject> loadedUnits, boolean singlePrint) {
-        printAllUnits(loadedUnits, singlePrint, new RecordSheetOptions());
+    public static boolean printAllUnits(List<? extends BTObject> loadedUnits, boolean singlePrint) {
+        return printAllUnits(loadedUnits, singlePrint, new RecordSheetOptions());
     }
 
     /**
@@ -314,7 +314,7 @@ public class UnitPrintManager {
      * @param singlePrint Whether to limit each record sheet to a single unit
      * @param options     The options to use for this print job
      */
-    public static void printAllUnits(List<? extends BTObject> loadedUnits, boolean singlePrint,
+    public static boolean printAllUnits(List<? extends BTObject> loadedUnits, boolean singlePrint,
             RecordSheetOptions options) {
         HashPrintRequestAttributeSet aset = new HashPrintRequestAttributeSet();
         aset.add(options.getPaperSize().sizeName);
@@ -322,7 +322,7 @@ public class UnitPrintManager {
         aset.add(DialogTypeSelection.COMMON);
         PrinterJob masterPrintJob = PrinterJob.getPrinterJob();
         if (!masterPrintJob.printDialog(aset)) {
-            return;
+            return false;
         }
 
         PageFormat pageFormat = masterPrintJob.getPageFormat(aset);
@@ -352,6 +352,7 @@ public class UnitPrintManager {
 
         RecordSheetTask task = RecordSheetTask.createPrintTask(sheets, masterPrintJob, aset, pageFormat);
         task.execute(CConfig.getBooleanParam(CConfig.RS_PROGRESS_BAR));
+        return true;
     }
 
     public static void printSelectedUnit(JFrame parent, boolean pdf) {
@@ -372,7 +373,7 @@ public class UnitPrintManager {
         }
     }
 
-    public static void printUnitFile(JFrame parent, boolean singleUnit, boolean pdf) {
+    public static boolean printUnitFile(JFrame parent, boolean singleUnit, boolean pdf) {
         String filePathName = System.getProperty("user.dir") + "/data/mekfiles/"; // TODO : Remove inline file path
 
         JFileChooser f = new JFileChooser(filePathName);
@@ -388,7 +389,7 @@ public class UnitPrintManager {
         int returnVal = f.showOpenDialog(parent);
         if ((returnVal != JFileChooser.APPROVE_OPTION) || (f.getSelectedFile() == null)) {
             // I want a file, y'know!
-            return;
+            return false;
         }
 
         try {
@@ -404,10 +405,12 @@ public class UnitPrintManager {
                     exportUnits(unitList, exportFile, singleUnit);
                 }
             } else {
-                printAllUnits(unitList, singleUnit);
+                return printAllUnits(unitList, singleUnit);
             }
+            return true;
         } catch (Exception ex) {
             logger.error("", ex);
+            return false;
         }
     }
 }


### PR DESCRIPTION
this PR is a variant of #1857
- instead of using a System.exit(0) it fixes the closing of the the application by fixing the memory leak in the dialogs (they are never released).
- the dummy frame is implemented directly in the MULManager
- canceling a system print dialog will bring you back to the print queue dialog with closing it
