### PR TITLE
fixed misleading switch and create unit methods

### DIFF
--- a/megameklab/docs/history.txt
+++ b/megameklab/docs/history.txt
@@ -7,6 +7,7 @@ MEGAMEKLAB VERSION HISTORY:
 + Fix #1060: Adds weapon sort opion to record sheets.
 + Fix #1854: Maintain Zoom and Position on Record Sheets
 + PR #1835: Force Builder
++ PR #1864: properly implemented createNewUnit() and switchUnit() instead of the mislabeled newUnit() acting as a switch unit.
 
 0.50.05 (2025-04-25 1800 UTC)
 + PR #1766 and #1790: enhanced tabs 

--- a/megameklab/resources/megameklab/resources/Menu.properties
+++ b/megameklab/resources/megameklab/resources/Menu.properties
@@ -8,14 +8,12 @@ FromMUL.text=From MUL...
 Save.text=Save
 SaveAs.text=Save As...
 
-
-
 #### MenuBar Class
 MenuBar.accessibleName=Main Menu Bar
 ### File Menu
 fileMenu.text=File
 miResetCurrentUnit.text=Reset Current Unit
-miNewTab.text=New Tab
+miNewTab.text=New...
 miCloseTab.text=Close Tab
 miReopenTab.text=Reopen Closed Tab
 ## Switch Unit Type Menu

--- a/megameklab/resources/megameklab/resources/Menu.properties
+++ b/megameklab/resources/megameklab/resources/Menu.properties
@@ -14,8 +14,8 @@ MenuBar.accessibleName=Main Menu Bar
 fileMenu.text=File
 miResetCurrentUnit.text=Reset Current Unit
 miNewTab.text=New...
-miCloseTab.text=Close Tab
-miReopenTab.text=Reopen Closed Tab
+miCloseTab.text=Close current tab
+miReopenTab.text=Reopen last closed tab
 ## Switch Unit Type Menu
 switchUnitTypeMenu.text=Switch Unit Type
 miSwitchToMek.text=Mek

--- a/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
@@ -246,9 +246,7 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
             public void mousePressed(MouseEvent e) {
                 if (e.getButton() == MouseEvent.BUTTON1) {
                     // Left click - directly create a new unit
-                    MegaMekLabMainUI newUi = UiLoader.getUI(Entity.ETYPE_MEK, false, false);
-                    newUi.setTabOwner(MegaMekLabTabbedUI.this);
-                    addTab(newUi);
+                    createNewUnit(Entity.ETYPE_MEK, false, false);
                 } else if (e.getButton() == MouseEvent.BUTTON3) {
                     // Right click - show popup menu
                     showNewUnitPopupMenu(button);
@@ -326,9 +324,7 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
     private JMenuItem newUnitItem(String name, long entityType, boolean primitive) {
         JMenuItem item = new JMenuItem(name);
         item.addActionListener(e -> {
-            MegaMekLabMainUI newUi = UiLoader.getUI(entityType, primitive, false);
-            newUi.setTabOwner(MegaMekLabTabbedUI.this);
-            addTab(newUi);
+            createNewUnit(entityType, primitive, primitive);
         });
         return item;
     }
@@ -516,7 +512,37 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
     }
 
     /**
-     * The name is misleading, this is actually the Switch Unit Type operation!
+     * Create a new blank editor of the given unit type.
+     *
+     * @param type       the type of unit to load for the new editor UI
+     * @param primitive  whether the unit is primitive
+     * @param industrial whether the unit is an IndustrialMek
+     * @return the index of the newly created tab
+     */
+    public void createNewUnit(long type, boolean primitive, boolean industrial) {
+        createNewUnit(type, primitive, industrial, tabs.getTabCount());
+    }
+
+    /**
+     * Create a new blank editor of the given unit type.
+     *
+     * @param type       the type of unit to load for the new editor UI
+     * @param primitive  whether the unit is primitive
+     * @param industrial whether the unit is an IndustrialMek
+     * @param tabIndex  the index at which to insert the new tab
+     * @return the index of the newly created tab
+     */
+    private void createNewUnit(long type, boolean primitive, boolean industrial, int tabIndex) {
+        MegaMekLabMainUI editor = UiLoader.getUI(type, primitive, industrial);
+        editors.add(editor);
+        final Entity entity = editor.getEntity();
+        final String tabName = entity.getShortNameRaw();
+        tabs.addCloseableTab(tabName, null, editor, tabIndex);
+        editor.setTabOwner(this);
+        tabs.setSelectedIndex(tabIndex);
+    }
+
+    /**
      * Replaces the current editor with a new blank one of the given unit type.
      * Disposes of the old editor UI after the new one is initialized.
      *
@@ -524,34 +550,24 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
      * @param primitive  whether the unit is primitive
      * @param industrial whether the unit is an IndustrialMek
      */
-    private void newUnit(long type, boolean primitive, boolean industrial) {
+    private void switchUnit(long type, boolean primitive, boolean industrial) {
         final int index = tabs.getSelectedIndex();
         if (index < 0) {
             return; // No tab selected, nothing to do
         }
-        MegaMekLabMainUI editor = UiLoader.getUI(type, primitive, industrial);
-        if (!editors.contains(editor)) {
-            editors.add(editor);
-        }
-        final Entity entity = editor.getEntity();
-        final String tabName = entity.getShortNameRaw();
-        tabs.addCloseableTab(tabName, null, editor, index);
-        editor.setTabOwner(this);
-        tabs.setSelectedIndex(index);
+        createNewUnit(type, primitive, industrial, index);
         closeTabAt(index+1); // Close the old tab
     }
 
     /**
-     * The name is misleading, this is actually the Switch Unit Type operation!
      * Replaces the current editor with a new blank one of the given unit type.
      * Disposes of the old editor UI after the new one is initialized.
      *
      * @param type      the type of unit to load for the new editor UI
      * @param primitive whether the unit is primitive
      */
-    @Override
-    public void newUnit(long type, boolean primitive) {
-        newUnit(type, primitive, false);
+    public void switchUnit(long type, boolean primitive) {
+        switchUnit(type, primitive, false);
     }
 
     /**

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -122,18 +122,50 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
                 "png", "jpg", "jpeg", "gif"));
     }
 
+    private JMenuItem newUnitItem(String text, int mnemonic, long type, boolean primitive) {
+        final JMenuItem miNewUnit = new JMenuItem(text);
+        if (mnemonic > 0) {
+            miNewUnit.setMnemonic(mnemonic);
+        }
+        miNewUnit.addActionListener(evt -> {
+            if (owner instanceof MegaMekLabTabbedUI tabbedUI) {
+                tabbedUI.createNewUnit(type, primitive, false);
+            }
+        });
+        return miNewUnit;
+    }
+
     private JMenu createFileMenu() {
         fileMenu.removeAll();
         fileMenu.setName("fileMenu");
         fileMenu.setMnemonic(KeyEvent.VK_F);
 
         if (owner instanceof MegaMekLabTabbedUI tabbedUI) {
-            final JMenuItem miNewTab = new JMenuItem(resources.getString("miNewTab.text"));
+            final JMenu miNewTab = new JMenu(resources.getString("miNewTab.text"));
             miNewTab.setName("miNewTab");
             miNewTab.setMnemonic(KeyEvent.VK_N);
-            miNewTab.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.CTRL_DOWN_MASK));
-            miNewTab.addActionListener(e -> tabbedUI.newTab());
             fileMenu.add(miNewTab);
+
+            JMenuItem newMek = newUnitItem("Mek", KeyEvent.VK_M, Entity.ETYPE_MEK, false);
+            newMek.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.CTRL_DOWN_MASK));
+            miNewTab.add(newMek);
+            miNewTab.add(newUnitItem("Fighter", KeyEvent.VK_F, Entity.ETYPE_AERO, false));
+            miNewTab.add(newUnitItem("DropShip/Small Craft", KeyEvent.VK_D, Entity.ETYPE_DROPSHIP, false));
+            miNewTab.add(newUnitItem("Advanced Aerospace", KeyEvent.VK_A, Entity.ETYPE_JUMPSHIP, false));
+            miNewTab.add(newUnitItem("Tank", KeyEvent.VK_T, Entity.ETYPE_TANK, false));
+            miNewTab.add(newUnitItem("Support Vehicle", KeyEvent.VK_V, Entity.ETYPE_SUPPORT_TANK, false));
+            miNewTab.add(newUnitItem("Battle Armor", KeyEvent.VK_B, Entity.ETYPE_BATTLEARMOR, false));
+            miNewTab.add(newUnitItem("Conventional Infantry", KeyEvent.VK_I, Entity.ETYPE_INFANTRY, false));
+            miNewTab.add(newUnitItem("ProtoMek", KeyEvent.VK_P, Entity.ETYPE_PROTOMEK, false));
+            miNewTab.add(newUnitItem("Handheld Weapon", KeyEvent.VK_H, Entity.ETYPE_HANDHELD_WEAPON, false));
+    
+            JMenu primitive = new JMenu("Primitive...");
+            primitive.add(newUnitItem("Mek", KeyEvent.VK_M, Entity.ETYPE_MEK, true));
+            primitive.add(newUnitItem("Fighter", KeyEvent.VK_F, Entity.ETYPE_AERO, true));
+            primitive.add(newUnitItem("DropShip/Small Craft", KeyEvent.VK_D, Entity.ETYPE_DROPSHIP, true));
+            primitive.add(newUnitItem("JumpShip", KeyEvent.VK_J, Entity.ETYPE_JUMPSHIP, true));
+            miNewTab.add(primitive);
+    
 
             final JMenuItem miCloseTab = new JMenuItem(resources.getString("miCloseTab.text"));
             miCloseTab.setName("miCloseTab");
@@ -194,7 +226,9 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         if (!isStartupGui() && !getUnitMainUi().safetyPrompt()) {
             return;
         }
-        owner.newUnit(type, primitive);
+        if (owner instanceof MegaMekLabTabbedUI tabbedUI) {
+            tabbedUI.switchUnit(type, primitive);
+        }
     }
 
     private JMenu createSwitchUnitTypeMenu() {

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -109,7 +109,9 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
     private void initialize() {
         getAccessibleContext().setAccessibleName(resources.getString("MenuBar.accessibleName"));
         add(createFileMenu());
-        add(createEditMenu());
+        if (!isStartupGui()) {
+            add(createEditMenu());
+        }
         add(createUnitValidationMenu());
         add(createForceBuildMenu());
         add(createReportsMenu());
@@ -128,9 +130,18 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
             miNewUnit.setMnemonic(mnemonic);
         }
         miNewUnit.addActionListener(evt -> {
-            if (owner instanceof MegaMekLabTabbedUI tabbedUI) {
-                tabbedUI.createNewUnit(type, primitive, false);
+            MegaMekLabTabbedUI tabbedUI = null;
+            if (owner instanceof MegaMekLabTabbedUI) {
+                tabbedUI = (MegaMekLabTabbedUI) owner;
+            } else {
+                tabbedUI = new MegaMekLabTabbedUI();
+                tabbedUI.setVisible(true);
+                if (isStartupGui()) {
+                    owner.getFrame().setVisible(false);
+                    owner.getFrame().dispose();
+                }
             }
+            tabbedUI.createNewUnit(type, primitive, false);
         });
         return miNewUnit;
     }
@@ -140,33 +151,32 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         fileMenu.setName("fileMenu");
         fileMenu.setMnemonic(KeyEvent.VK_F);
 
+        final JMenu miNewTab = new JMenu(resources.getString("miNewTab.text"));
+        miNewTab.setName("miNewTab");
+        miNewTab.setMnemonic(KeyEvent.VK_N);
+        fileMenu.add(miNewTab);
+
+        JMenuItem newMek = newUnitItem("Mek", KeyEvent.VK_M, Entity.ETYPE_MEK, false);
+        newMek.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.CTRL_DOWN_MASK));
+        miNewTab.add(newMek);
+        miNewTab.add(newUnitItem("Fighter", KeyEvent.VK_F, Entity.ETYPE_AERO, false));
+        miNewTab.add(newUnitItem("DropShip/Small Craft", KeyEvent.VK_D, Entity.ETYPE_DROPSHIP, false));
+        miNewTab.add(newUnitItem("Advanced Aerospace", KeyEvent.VK_A, Entity.ETYPE_JUMPSHIP, false));
+        miNewTab.add(newUnitItem("Tank", KeyEvent.VK_T, Entity.ETYPE_TANK, false));
+        miNewTab.add(newUnitItem("Support Vehicle", KeyEvent.VK_V, Entity.ETYPE_SUPPORT_TANK, false));
+        miNewTab.add(newUnitItem("Battle Armor", KeyEvent.VK_B, Entity.ETYPE_BATTLEARMOR, false));
+        miNewTab.add(newUnitItem("Conventional Infantry", KeyEvent.VK_I, Entity.ETYPE_INFANTRY, false));
+        miNewTab.add(newUnitItem("ProtoMek", KeyEvent.VK_P, Entity.ETYPE_PROTOMEK, false));
+        miNewTab.add(newUnitItem("Handheld Weapon", KeyEvent.VK_H, Entity.ETYPE_HANDHELD_WEAPON, false));
+
+        JMenu primitive = new JMenu("Primitive...");
+        primitive.add(newUnitItem("Mek", KeyEvent.VK_M, Entity.ETYPE_MEK, true));
+        primitive.add(newUnitItem("Fighter", KeyEvent.VK_F, Entity.ETYPE_AERO, true));
+        primitive.add(newUnitItem("DropShip/Small Craft", KeyEvent.VK_D, Entity.ETYPE_DROPSHIP, true));
+        primitive.add(newUnitItem("JumpShip", KeyEvent.VK_J, Entity.ETYPE_JUMPSHIP, true));
+        miNewTab.add(primitive);
+
         if (owner instanceof MegaMekLabTabbedUI tabbedUI) {
-            final JMenu miNewTab = new JMenu(resources.getString("miNewTab.text"));
-            miNewTab.setName("miNewTab");
-            miNewTab.setMnemonic(KeyEvent.VK_N);
-            fileMenu.add(miNewTab);
-
-            JMenuItem newMek = newUnitItem("Mek", KeyEvent.VK_M, Entity.ETYPE_MEK, false);
-            newMek.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.CTRL_DOWN_MASK));
-            miNewTab.add(newMek);
-            miNewTab.add(newUnitItem("Fighter", KeyEvent.VK_F, Entity.ETYPE_AERO, false));
-            miNewTab.add(newUnitItem("DropShip/Small Craft", KeyEvent.VK_D, Entity.ETYPE_DROPSHIP, false));
-            miNewTab.add(newUnitItem("Advanced Aerospace", KeyEvent.VK_A, Entity.ETYPE_JUMPSHIP, false));
-            miNewTab.add(newUnitItem("Tank", KeyEvent.VK_T, Entity.ETYPE_TANK, false));
-            miNewTab.add(newUnitItem("Support Vehicle", KeyEvent.VK_V, Entity.ETYPE_SUPPORT_TANK, false));
-            miNewTab.add(newUnitItem("Battle Armor", KeyEvent.VK_B, Entity.ETYPE_BATTLEARMOR, false));
-            miNewTab.add(newUnitItem("Conventional Infantry", KeyEvent.VK_I, Entity.ETYPE_INFANTRY, false));
-            miNewTab.add(newUnitItem("ProtoMek", KeyEvent.VK_P, Entity.ETYPE_PROTOMEK, false));
-            miNewTab.add(newUnitItem("Handheld Weapon", KeyEvent.VK_H, Entity.ETYPE_HANDHELD_WEAPON, false));
-    
-            JMenu primitive = new JMenu("Primitive...");
-            primitive.add(newUnitItem("Mek", KeyEvent.VK_M, Entity.ETYPE_MEK, true));
-            primitive.add(newUnitItem("Fighter", KeyEvent.VK_F, Entity.ETYPE_AERO, true));
-            primitive.add(newUnitItem("DropShip/Small Craft", KeyEvent.VK_D, Entity.ETYPE_DROPSHIP, true));
-            primitive.add(newUnitItem("JumpShip", KeyEvent.VK_J, Entity.ETYPE_JUMPSHIP, true));
-            miNewTab.add(primitive);
-    
-
             final JMenuItem miCloseTab = new JMenuItem(resources.getString("miCloseTab.text"));
             miCloseTab.setName("miCloseTab");
             miCloseTab.setMnemonic(KeyEvent.VK_W);

--- a/megameklab/src/megameklab/ui/MenuBarOwner.java
+++ b/megameklab/src/megameklab/ui/MenuBarOwner.java
@@ -78,33 +78,6 @@ public interface MenuBarOwner extends AppCloser {
     void refreshMenuBar();
 
     /**
-     * Creates a new main UI frame for the given unit type and disposes the
-     * existing frame (this MenuBarOwner).
-     *
-     * @param type an int corresponding to the unit type to construct
-     */
-    default void newUnit(long type) {
-        newUnit(type, false);
-    }
-
-    /**
-     * Creates a new main UI frame for the given unit type and disposes the
-     * existing frame (this MenuBarOwner).
-     *
-     * @param type an int corresponding to the unit type to construct
-     * @param primitive true when the new unit should be a primitive type
-     */
-    default void newUnit(long type, boolean primitive) {
-        if (safetyPrompt()) {
-            getFrame().setVisible(false);
-            getFrame().dispose();
-            CConfig.setParam(CConfig.GUI_FULLSCREEN, Integer.toString(getFrame().getExtendedState()));
-            CConfig.saveConfig();
-            UiLoader.loadUi(type, primitive, false);
-        }
-    }
-
-    /**
      * Sets the look and feel for the application and lets Swing update the current
      * components.
      *

--- a/megameklab/src/megameklab/ui/StartupGUI.java
+++ b/megameklab/src/megameklab/ui/StartupGUI.java
@@ -25,6 +25,7 @@ import megamek.common.Configuration;
 import megamek.common.Entity;
 import megameklab.MMLConstants;
 import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
+import megameklab.ui.dialog.UiLoader;
 import megameklab.ui.util.ExitOnWindowClosingListener;
 import megameklab.ui.util.MegaMekLabFileSaver;
 import megameklab.ui.util.TabUtil;
@@ -104,6 +105,14 @@ public class StartupGUI extends SkinnedJPanel implements MenuBarOwner {
         }
     }
 
+    private void createNewUnit(long type) {
+        getFrame().setVisible(false);
+        CConfig.setParam(CConfig.GUI_FULLSCREEN, Integer.toString(getFrame().getExtendedState()));
+        CConfig.saveConfig();
+        UiLoader.loadUi(type, false, false);
+        getFrame().dispose();
+    }
+
     private void initComponents() {
         SkinSpecification skinSpec = SkinXMLHandler.getSkin(UIComponents.MainMenuBorder.getComp(), true);
 
@@ -128,39 +137,39 @@ public class StartupGUI extends SkinnedJPanel implements MenuBarOwner {
 
         MegaMekButton btnNewMek = new MegaMekButton(resourceMap.getString("btnNewMek.text"),
                 UIComponents.MainMenuButton.getComp(), true);
-        btnNewMek.addActionListener(evt -> newUnit(Entity.ETYPE_MEK));
+        btnNewMek.addActionListener(evt -> createNewUnit(Entity.ETYPE_MEK));
 
         MegaMekButton btnNewVee = new MegaMekButton(resourceMap.getString("btnNewVee.text"),
                 UIComponents.MainMenuButton.getComp(), true);
-        btnNewVee.addActionListener(evt -> newUnit(Entity.ETYPE_TANK));
+        btnNewVee.addActionListener(evt -> createNewUnit(Entity.ETYPE_TANK));
 
         MegaMekButton btnNewSupportVee = new MegaMekButton(resourceMap.getString("btnNewSupportVee.text"),
                 UIComponents.MainMenuButton.getComp(), true);
-        btnNewSupportVee.addActionListener(evt -> newUnit(Entity.ETYPE_SUPPORT_TANK));
+        btnNewSupportVee.addActionListener(evt -> createNewUnit(Entity.ETYPE_SUPPORT_TANK));
 
         MegaMekButton btnNewBA = new MegaMekButton(resourceMap.getString("btnNewBA.text"),
                 UIComponents.MainMenuButton.getComp(), true);
-        btnNewBA.addActionListener(evt -> newUnit(Entity.ETYPE_BATTLEARMOR));
+        btnNewBA.addActionListener(evt -> createNewUnit(Entity.ETYPE_BATTLEARMOR));
 
         MegaMekButton btnNewAero = new MegaMekButton(resourceMap.getString("btnNewAero.text"),
                 UIComponents.MainMenuButton.getComp(), true);
-        btnNewAero.addActionListener(evt -> newUnit(Entity.ETYPE_AERO));
+        btnNewAero.addActionListener(evt -> createNewUnit(Entity.ETYPE_AERO));
 
         MegaMekButton btnNewDropper = new MegaMekButton(resourceMap.getString("btnNewDropper.text"),
                 UIComponents.MainMenuButton.getComp(), true);
-        btnNewDropper.addActionListener(evt -> newUnit(Entity.ETYPE_DROPSHIP));
+        btnNewDropper.addActionListener(evt -> createNewUnit(Entity.ETYPE_DROPSHIP));
 
         MegaMekButton btnNewLargeCraft = new MegaMekButton(resourceMap.getString("btnNewLargeCraft.text"),
                 UIComponents.MainMenuButton.getComp(), true);
-        btnNewLargeCraft.addActionListener(evt -> newUnit(Entity.ETYPE_JUMPSHIP));
+        btnNewLargeCraft.addActionListener(evt -> createNewUnit(Entity.ETYPE_JUMPSHIP));
 
         MegaMekButton btnNewProto = new MegaMekButton(resourceMap.getString("btnNewProto.text"),
                 UIComponents.MainMenuButton.getComp(), true);
-        btnNewProto.addActionListener(evt -> newUnit(Entity.ETYPE_PROTOMEK));
+        btnNewProto.addActionListener(evt -> createNewUnit(Entity.ETYPE_PROTOMEK));
 
         MegaMekButton btnNewPbi = new MegaMekButton(resourceMap.getString("btnNewPbi.text"),
                 UIComponents.MainMenuButton.getComp(), true);
-        btnNewPbi.addActionListener(evt -> newUnit(Entity.ETYPE_INFANTRY));
+        btnNewPbi.addActionListener(evt -> createNewUnit(Entity.ETYPE_INFANTRY));
 
         MegaMekButton btnQuit = new MegaMekButton(resourceMap.getString("btnQuit.text"),
                 UIComponents.MainMenuButton.getComp(), true);


### PR DESCRIPTION
this PR:
- fixes the misleading methods of newUnit() and implements proper createNewUnit() and switchUnit()
- add a new File->New... menu structure where you can directly choose what type of unit you want (solves the need to create a mek unit first and then switch it to another type)
- CTRL+N accelerator is kept as before, will create a new mek as before