### PR TITLE
fix: resets walk MP to 0 when setting an SV engine as None

### DIFF
--- a/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
@@ -405,6 +405,11 @@ public class SVStructureTab extends ITab implements SVBuildListener {
     @Override
     public void engineChanged(Engine engine) {
         getSV().setEngine(engine);
+
+        if (engine.getEngineType() == Engine.NONE) {
+            getSV().setOriginalWalkMP(0);
+        }
+
         // Switching between maglev and non-maglev engines changes movement mode
         if (TestSupportVehicle.SVType.RAIL.equals(TestSupportVehicle.SVType.getVehicleType(getSV()))) {
             getSV().setMovementMode(


### PR DESCRIPTION
# What this does?

This fix makes sure that if you are creating a trailer with no engine it will set the walk MP to zero.

If you set an SV as a trailer, the minWalk MP is set to 0, meaning you can set the MP of the unit to 0, but if you change the engine to `None` right after you set the SV as a trailer, then both minWalk and maxWalk becomes 0, making it impossible to set in the entity a new walkMP value, this means that any value it had before it will keep on having. It will then persist the cruising MP and will always be considered a valid unit.

To avoid this situation, whenever the engine is set as `None`, this will also reset the originalWalkMP of the unit to 0, if there are any cases which would allow you to increaase your walkMP to anything different, this won't interfere, as it just forces the reset when you change the engine to None on MML while editing a SV.

## Closes

- MegaMek/megamek#6919