### PR TITLE
Aero fixes

### DIFF
--- a/megameklab/resources/megameklab/resources/Menu.properties
+++ b/megameklab/resources/megameklab/resources/Menu.properties
@@ -94,14 +94,10 @@ miRecordSheetImages.text=Record Sheet Images...
 
 menu.help.about.title=MegaMekLab Info
 menu.help.about.version.format=MegaMekLab Version: %s
-menu.help.about.license.1=MegaMekLab software is under GPL. See
-menu.help.about.license.2=license.txt in ./Docs/licenses for details.
-menu.help.about.info.1=Project Info:
-menu.help.about.info.2=https://github.com/MegaMek/megameklab
+menu.help.about.text=MegaMekLab software is under GPL.<br/>See license.txt in ./Docs/licenses for details.<br/><br/>Project Info:<br/><a href="https://github.com/MegaMek/megameklab">https://github.com/MegaMek/megameklab</a>
 
 menu.help.imageHelp.title=Image Help
-menu.help.imageHelp.text=To add a fluff image to a record sheet. Please see the following link\n\
-https://github.com/MegaMek/megamek/wiki/How-do-I-get-Fluff-Images-to-work
+menu.help.imageHelp.text=To add a fluff image to a record sheet. Please see the following link<br/><a href="https://github.com/MegaMek/megamek/wiki/How-do-I-get-Fluff-Images-to-work">https://github.com/MegaMek/megamek/wiki/How-do-I-get-Fluff-Images-to-work</a>
 
 dialog.chooseUnit.title=Choose Unit
 dialog.imagePath.title=Image Path

--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -874,7 +874,7 @@ public class InventoryWriter {
                 case MRV:
                 case LRV:
                 case ERV:
-                    sheet.addTextElement(canvas, bayColX[i], currY, columnTypes[i].header, FONT_SIZE_MEDIUM,
+                    sheet.addTextElement(canvas, bayColX[i], currY, Column.BAY_COLUMNS[i].header, FONT_SIZE_MEDIUM,
                             SVGConstants.SVG_MIDDLE_VALUE, SVGConstants.SVG_BOLD_VALUE);
                     break;
                 default:

--- a/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
@@ -60,6 +60,20 @@ public class WeaponBayInventoryEntry implements InventoryEntry {
         processBay();
     }
 
+
+    
+            // // Streaks / iATMs will _all_ hit, if they hit at all.
+            // if (((wt.getAmmoType() == AmmoType.T_SRM_STREAK)
+            //         || (wt.getAmmoType() == AmmoType.T_LRM_STREAK))
+            //         || (wt.getAmmoType() == AmmoType.T_IATM)
+            //                 && !ComputeECM.isAffectedByAngelECM(attacker, attacker
+            //                         .getPosition(), waa.getTarget(g).getPosition(),
+            //                         allECMInfo)) {
+            //     fHits = wt.getRackSize();
+            // }
+
+
+
     private void processBay() {
         for (WeaponType weaponType : bay.weapons.keySet()) {
             int numWeapons = bay.weapons.get(weaponType);
@@ -72,7 +86,12 @@ public class WeaponBayInventoryEntry implements InventoryEntry {
             } else if (weaponType instanceof ATMWeapon || weaponType instanceof CLIATMWeapon) {
                 // The default AVs assume standard ammo. Per footnote on TW, p. 304, the SRV is multiplied
                 // by 1.5 for HE and the long and extreme by 0.5 for ER, both rounded up.
-                double av = Math.ceil(weaponType.getShortAV() * numWeapons * 0.5);
+                double av;
+                if (weaponType instanceof CLIATMWeapon) {
+                    av = weaponType.getShortAV() * numWeapons;
+                } else {
+                    av = Math.ceil(weaponType.getShortAV() * numWeapons * 0.5);
+                }
                 baySRV += Math.round(Math.ceil(av * 1.5) / 10.0);
                 bayMRV += Math.round(av / 10.0);
                 bayLRV += Math.round(Math.ceil(av * 0.5) / 10.0);

--- a/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
@@ -29,6 +29,7 @@ import megamek.common.EquipmentType;
 import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.WeaponType;
+import megamek.common.equipment.AmmoMounted;
 import megamek.common.weapons.CLIATMWeapon;
 import megamek.common.weapons.missiles.ATMWeapon;
 import megamek.common.weapons.missiles.MMLWeapon;
@@ -153,9 +154,34 @@ public class WeaponBayInventoryEntry implements InventoryEntry {
             location = locString.toString();
             StringBuilder nameString = new StringBuilder(weaponType.getShortName());
             if (bay.weaponAmmo.containsKey(weaponType)) {
-                Mounted<?> ammo = bay.weaponAmmo.get(weaponType);
+                List<Mounted<?>> ammoList = bay.weaponAmmo.get(weaponType);
+                Mounted<?> ammo = ammoList.get(0);
                 if (weaponType.getAmmoType() == AmmoType.T_AR10) {
-                    nameString.append(" (").append((int) ammo.getSize()).append(" ton capacity)");
+                    nameString.append(" (");
+                    
+                    StringJoiner ammoDetails = new StringJoiner(", ");
+                    ammoList.forEach(e -> {
+                            if (e instanceof AmmoMounted am) {
+                                String originalAmmoShortName = am.getShortName();
+                                String displayAmmoName;
+                                switch (originalAmmoShortName) {
+                                    case "Barracuda":
+                                        displayAmmoName = "B";
+                                        break;
+                                    case "White Shark":
+                                        displayAmmoName = "WS";
+                                        break;
+                                    case "Killer Whale":
+                                        displayAmmoName = "KW";
+                                        break;
+                                    default:
+                                        displayAmmoName = originalAmmoShortName;
+                                }
+                                ammoDetails.add(am.getBaseShotsLeft() + " " + displayAmmoName);
+                            }
+                        });
+                    nameString.append(ammoDetails.toString());
+                    nameString.append(")");
                 } else if (weaponType.isCapital() && weaponType.hasFlag(WeaponType.F_MISSILE)) {
                     nameString.append(" (").append(ammo.getBaseShotsLeft()).append(" missiles)");
                 } else {

--- a/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
@@ -60,20 +60,6 @@ public class WeaponBayInventoryEntry implements InventoryEntry {
         processBay();
     }
 
-
-    
-            // // Streaks / iATMs will _all_ hit, if they hit at all.
-            // if (((wt.getAmmoType() == AmmoType.T_SRM_STREAK)
-            //         || (wt.getAmmoType() == AmmoType.T_LRM_STREAK))
-            //         || (wt.getAmmoType() == AmmoType.T_IATM)
-            //                 && !ComputeECM.isAffectedByAngelECM(attacker, attacker
-            //                         .getPosition(), waa.getTarget(g).getPosition(),
-            //                         allECMInfo)) {
-            //     fHits = wt.getRackSize();
-            // }
-
-
-
     private void processBay() {
         for (WeaponType weaponType : bay.weapons.keySet()) {
             int numWeapons = bay.weapons.get(weaponType);

--- a/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
@@ -162,22 +162,7 @@ public class WeaponBayInventoryEntry implements InventoryEntry {
                     StringJoiner ammoDetails = new StringJoiner(", ");
                     ammoList.forEach(e -> {
                             if (e instanceof AmmoMounted am) {
-                                String originalAmmoShortName = am.getShortName();
-                                String displayAmmoName;
-                                switch (originalAmmoShortName) {
-                                    case "Barracuda":
-                                        displayAmmoName = "B";
-                                        break;
-                                    case "White Shark":
-                                        displayAmmoName = "WS";
-                                        break;
-                                    case "Killer Whale":
-                                        displayAmmoName = "KW";
-                                        break;
-                                    default:
-                                        displayAmmoName = originalAmmoShortName;
-                                }
-                                ammoDetails.add(am.getBaseShotsLeft() + " " + displayAmmoName);
+                                ammoDetails.add(am.getBaseShotsLeft() + " " + am.getShortName());
                             }
                         });
                     nameString.append(ammoDetails.toString());

--- a/megameklab/src/megameklab/printing/WeaponBayText.java
+++ b/megameklab/src/megameklab/printing/WeaponBayText.java
@@ -156,14 +156,14 @@ public class WeaponBayText implements Comparable<WeaponBayText> {
         if (!weaponAmmo.keySet().equals(other.weaponAmmo.keySet())) {
             return false;
         }
-        // Now, for each weapon type, compare the 
+        // Now we compare the ammo sets of each weapon
         for (WeaponType weaponType : weaponAmmo.keySet()) {
-            // Calculate total shots for this weapon type in 'this' bay
             List<Mounted<?>> ammoListThis = weaponAmmo.get(weaponType);
             List<Mounted<?>> ammoListOther = other.weaponAmmo.get(weaponType);
             if (ammoListThis == null || ammoListOther == null) {
                 return false;
             }
+            // If the number of ammo types is different, the ammo doesn't match
             if (ammoListThis.size() != ammoListOther.size()) {
                 return false;
             }

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -1211,32 +1211,38 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         // set up the contents
         JPanel child = new JPanel();
         child.setLayout(new BoxLayout(child, BoxLayout.Y_AXIS));
+        child.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
         // set the text up.
         JLabel version = new JLabel(String.format(resources.getString("menu.help.about.version.format"),
                 MMLConstants.VERSION));
-        JLabel license1 = new JLabel(resources.getString("menu.help.about.license.1"));
-        JLabel license2 = new JLabel(resources.getString("menu.help.about.license.2"));
-        JLabel license3 = new JLabel(resources.getString("menu.help.about.info.1"));
-        JLabel license4 = new JLabel(resources.getString("menu.help.about.info.2"));
+        JEditorPane body = new JEditorPane();
+        body.setContentType("text/html");
+        body.setEditable(false);
+        body.setOpaque(false);
+        body.setText(resources.getString("menu.help.about.text"));
+
+        body.addHyperlinkListener(e -> {
+            if (e.getEventType() == javax.swing.event.HyperlinkEvent.EventType.ACTIVATED) {
+                if (java.awt.Desktop.isDesktopSupported()) {
+                    try {
+                        java.awt.Desktop.getDesktop().browse(e.getURL().toURI());
+                    } catch (Exception ex) {
+                        logger.error("Could not open link: " + e.getURL(), ex);
+                    }
+                }
+            }
+        });
 
         // center everything
         version.setAlignmentX(Component.CENTER_ALIGNMENT);
-        license1.setAlignmentX(Component.CENTER_ALIGNMENT);
-        license2.setAlignmentX(Component.CENTER_ALIGNMENT);
-        license3.setAlignmentX(Component.CENTER_ALIGNMENT);
-        license4.setAlignmentX(Component.CENTER_ALIGNMENT);
+        body.setAlignmentX(Component.CENTER_ALIGNMENT);
 
         // add to child panel
         child.add(new JLabel("\n"));
         child.add(version);
         child.add(new JLabel("\n"));
-        child.add(license1);
-        child.add(license2);
-        child.add(new JLabel("\n"));
-        child.add(license3);
-        child.add(license4);
-        child.add(new JLabel("\n"));
+        child.add(body);
 
         // then add child panel to the content pane.
         dlg.getContentPane().add(child);
@@ -1257,13 +1263,25 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         child.setLayout(new BoxLayout(child, BoxLayout.Y_AXIS));
 
         // set the text up.
-        JTextArea recordSheetImageHelp = new JTextArea();
-
+        JEditorPane recordSheetImageHelp = new JEditorPane();
+        recordSheetImageHelp.setContentType("text/html");
         recordSheetImageHelp.setEditable(false);
+        recordSheetImageHelp.setOpaque(false);
+        recordSheetImageHelp.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
         recordSheetImageHelp.setText(resources.getString("menu.help.imageHelp.text"));
-        // center everything
-        recordSheetImageHelp.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        recordSheetImageHelp.addHyperlinkListener(e -> {
+            if (e.getEventType() == javax.swing.event.HyperlinkEvent.EventType.ACTIVATED) {
+                if (java.awt.Desktop.isDesktopSupported()) {
+                    try {
+                        java.awt.Desktop.getDesktop().browse(e.getURL().toURI());
+                    } catch (Exception ex) {
+                        logger.error("Could not open link: " + e.getURL(), ex);
+                    }
+                }
+            }
+        });
 
         // add to child panel
         child.add(recordSheetImageHelp);

--- a/megameklab/src/megameklab/ui/generalUnit/FluffTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/FluffTab.java
@@ -150,18 +150,23 @@ public class FluffTab extends ITab implements FocusListener {
 
         addLabeledTextArea.accept(resourceMap.getString("FluffTab.txtCapabilities"), txtCapabilities);
         txtCapabilities.setText(getFluff().getCapabilities());
+        txtCapabilities.setCaretPosition(0);
 
         addLabeledTextArea.accept(resourceMap.getString("FluffTab.txtOverview"), txtOverview);
         txtOverview.setText(getFluff().getOverview());
+        txtOverview.setCaretPosition(0);
 
         addLabeledTextArea.accept(resourceMap.getString("FluffTab.txtDeployment"), txtDeployment);
         txtDeployment.setText(getFluff().getDeployment());
+        txtDeployment.setCaretPosition(0);
 
         addLabeledTextArea.accept(resourceMap.getString("FluffTab.txtHistory"), txtHistory);
         txtHistory.setText(getFluff().getHistory());
+        txtHistory.setCaretPosition(0);
 
         addLabeledTextArea.accept(resourceMap.getString("FluffTab.txtNotes"), txtNotes);
         txtNotes.setText(getFluff().getNotes());
+        txtNotes.setCaretPosition(0);
 
         // Add a filler component at the bottom of panLeft to push content up
         gbcLeft.gridy++;


### PR DESCRIPTION
This PR contains few fixes for Aero stuffs:
- fixed columns for AR10 Munition Table
- fixed multi-ammo weapons in bays (AR10 specifically) by adding "multi-ammo to single weapon" support to bays
- fixed visualization of LBX weapons damage on Aero (this comes from the linked MM PR)
- fixed visualization of the IATM weapons damage on Aero
 
Fixes #1810
Fixes #1811

Linked to https://github.com/MegaMek/megamek/pull/6972

extra minor fixes:
- help->about and help->images have now clickable links, no need to type them manually...
- fluff page have the textarea fields showing the first line