### PR TITLE
heat view now displays also total dissipation and total heat

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -203,6 +203,10 @@ HeatSinkView.lblCritFree.text=Engine Free:
 HeatSinkView.lblCritFree.tooltip=<html>These heat sinks are an integral part of the engine and do not have to be assigned critical space.<br/>Omni units must assign critical space to any pod-mounted heat sinks even if they would be part of the engine in standard Meks.</html>
 HeatSinkView.lblWeightFree.text=Weight Free:
 HeatSinkView.lblWeightFree.tooltip=<html>These heat sinks are included in the weight of the engine.</html>
+HeatSinkView.lblTotalDissipation.text=Total Dissipation:
+HeatSinkView.lblTotalDissipation.tooltip=<html>This is the total amount of heat the unit can dissipate in a single turn.</html>
+HeatSinkView.lblMaxHeat.text=Total Equipment Heat:
+HeatSinkView.lblMaxHeat.tooltip=<html>This is the total amount of heat this unit can potentially generate</html>
 HeatSinkView.lblRiscHeatSinkKit.text=RISC Heat Sink Override Kit:
 HeatSinkView.lblRiscHeatSinkKit.tooltip=<html>Reduces chance of heat-induced shutdown. IO:AE p86.<br/>\
   Construction only, not implemented for gameplay in MegaMek.</html>

--- a/megameklab/src/megameklab/printing/PrintEntity.java
+++ b/megameklab/src/megameklab/printing/PrintEntity.java
@@ -52,6 +52,7 @@ import megamek.common.options.PilotOptions;
 import megamek.common.options.Quirks;
 import megameklab.util.CConfig;
 import megameklab.util.RSScale;
+import megameklab.util.UnitUtil;
 
 /**
  * Base class for printing Entity record sheets
@@ -110,7 +111,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
      * @return A String showing the total weapon heat and dissipation.
      */
     protected String heatProfileText() {
-        int heat = getEntity().getEquipment().stream().mapToInt(m -> m.getType().getHeat()).sum();
+        int heat = UnitUtil.getTotalHeatGeneration(getEntity());
         return "Total Heat (Dissipation): " + heat + " (" + getEntity().formatHeat() + ")";
     }
 

--- a/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
@@ -398,6 +398,7 @@ public class ASStructureTab extends ITab implements AeroBuildListener, ArmorAllo
         if (getAero().isOmni()) {
             getAero().setPodHeatSinks(Math.max(0, count - panHeat.getBaseCount()));
         }
+        panHeat.setFromAero(getAero());
         panSummary.refresh();
         refresh.refreshStatus();
         refresh.refreshPreview();

--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -89,9 +89,13 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     private final JLabel lblPrototypeCount = new JLabel();
     private final JSpinner spnPrototypeCount = new JSpinner();
     private final JLabel lblCritFreeText = new JLabel();
-    private final JLabel lblCritFreeCount = new JLabel();
+    private final JTextField lblCritFreeCount = new JTextField();
     private final JLabel lblWeightFreeText = new JLabel();
-    private final JLabel lblWeightFreeCount = new JLabel();
+    private final JTextField lblWeightFreeCount = new JTextField();
+    private final JLabel lblTotalDissipationText = new JLabel();
+    private final JTextField lblTotalDissipationCount = new JTextField();
+    private final JLabel lblMaxHeatText = new JLabel();
+    private final JTextField lblMaxHeatCount = new JTextField();
     private final JLabel lblRiscHeatSinkKit = new JLabel();
     private final JCheckBox chkRiscHeatSinkKit = new JCheckBox();
 
@@ -150,6 +154,8 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         add(lblCritFreeText, gbc);
         gbc.gridx = 4;
         lblCritFreeCount.setToolTipText(resourceMap.getString("HeatSinkView.lblCritFree.tooltip"));
+        lblCritFreeCount.setEditable(false);
+        lblCritFreeCount.setHorizontalAlignment(JTextField.RIGHT);
         add(lblCritFreeCount, gbc);
 
         spnBaseCount.setModel(baseCountModel);
@@ -178,7 +184,29 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         add(lblWeightFreeText, gbc);
         gbc.gridx = 1;
         lblWeightFreeCount.setToolTipText(resourceMap.getString("HeatSinkView.lblWeightFree.tooltip"));
+        lblWeightFreeCount.setEditable(false);
+        lblWeightFreeCount.setHorizontalAlignment(JTextField.RIGHT);
         add(lblWeightFreeCount, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        lblTotalDissipationText.setText(resourceMap.getString("HeatSinkView.lblTotalDissipation.text"));
+        add(lblTotalDissipationText, gbc);
+        gbc.gridx = 1;
+        lblTotalDissipationCount.setToolTipText(resourceMap.getString("HeatSinkView.lblTotalDissipation.tooltip"));
+        lblTotalDissipationCount.setEditable(false);
+        lblTotalDissipationCount.setHorizontalAlignment(JTextField.RIGHT);
+        add(lblTotalDissipationCount, gbc);
+
+        gbc.gridx = 0;
+        gbc.gridy++;
+        lblMaxHeatText.setText(resourceMap.getString("HeatSinkView.lblMaxHeat.text"));
+        add(lblMaxHeatText, gbc);
+        gbc.gridx = 1;
+        lblMaxHeatCount.setToolTipText(resourceMap.getString("HeatSinkView.lblMaxHeat.tooltip"));
+        lblMaxHeatCount.setEditable(false);
+        lblMaxHeatCount.setHorizontalAlignment(JTextField.RIGHT);
+        add(lblMaxHeatCount, gbc);
 
 
         lblRiscHeatSinkKit.setText(resourceMap.getString("HeatSinkView.lblRiscHeatSinkKit.text"));
@@ -252,6 +280,8 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         spnPrototypeCount.addChangeListener(this);
         lblCritFreeCount.setText(String.valueOf(UnitUtil.getCriticalFreeHeatSinks(mek, isCompact)));
         lblWeightFreeCount.setText(String.valueOf(mek.getEngine().getWeightFreeEngineHeatSinks()));
+        lblTotalDissipationCount.setText(String.valueOf(mek.formatHeat()));
+        lblMaxHeatCount.setText(String.valueOf(getTotalHeatGeneration(mek)));
 
         showRiscKit(techManager.isLegal(Mek.getRiscHeatSinkOverrideKitAdvancement()));
         if (mek.hasRiscHeatSinkOverrideKit()) {
@@ -285,6 +315,8 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         baseCountModel.setValue(Math.max(0, aero.getHeatSinks() - aero.getPodHeatSinks()));
         spnBaseCount.addChangeListener(this);
         lblWeightFreeCount.setText(String.valueOf(TestAero.weightFreeHeatSinks(aero)));
+        lblTotalDissipationCount.setText(String.valueOf(aero.formatHeat()));
+        lblMaxHeatCount.setText(String.valueOf(getTotalHeatGeneration(aero)));
         lblBaseCount.setVisible(aero.isOmni());
         spnBaseCount.setVisible(aero.isOmni());
         lblPrototypeCount.setVisible(false);
@@ -393,6 +425,11 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         } else {
             listeners.forEach(l -> l.heatSinksChanged(getHeatSinkType(), getCount()));
         }
+    }
+
+    private int getTotalHeatGeneration(Entity entity) {
+        int heat = entity.getEquipment().stream().mapToInt(m -> m.getType().getHeat()).sum();
+        return heat;
     }
 
 }

--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -281,7 +281,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         lblCritFreeCount.setText(String.valueOf(UnitUtil.getCriticalFreeHeatSinks(mek, isCompact)));
         lblWeightFreeCount.setText(String.valueOf(mek.getEngine().getWeightFreeEngineHeatSinks()));
         lblTotalDissipationCount.setText(String.valueOf(mek.formatHeat()));
-        lblMaxHeatCount.setText(String.valueOf(getTotalHeatGeneration(mek)));
+        lblMaxHeatCount.setText(String.valueOf(UnitUtil.getTotalHeatGeneration(mek)));
 
         showRiscKit(techManager.isLegal(Mek.getRiscHeatSinkOverrideKitAdvancement()));
         if (mek.hasRiscHeatSinkOverrideKit()) {
@@ -316,7 +316,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         spnBaseCount.addChangeListener(this);
         lblWeightFreeCount.setText(String.valueOf(TestAero.weightFreeHeatSinks(aero)));
         lblTotalDissipationCount.setText(String.valueOf(aero.formatHeat()));
-        lblMaxHeatCount.setText(String.valueOf(getTotalHeatGeneration(aero)));
+        lblMaxHeatCount.setText(String.valueOf(UnitUtil.getTotalHeatGeneration(aero)));
         lblBaseCount.setVisible(aero.isOmni());
         spnBaseCount.setVisible(aero.isOmni());
         lblPrototypeCount.setVisible(false);
@@ -425,11 +425,6 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         } else {
             listeners.forEach(l -> l.heatSinksChanged(getHeatSinkType(), getCount()));
         }
-    }
-
-    private int getTotalHeatGeneration(Entity entity) {
-        int heat = entity.getEquipment().stream().mapToInt(m -> m.getType().getHeat()).sum();
-        return heat;
     }
 
 }

--- a/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
@@ -302,6 +302,7 @@ public class DSStructureTab extends ITab implements DropshipBuildListener, Armor
         getSmallCraft().setHeatType(index);
         getSmallCraft().setHeatSinks(count);
         getSmallCraft().setOHeatSinks(count);
+        panHeat.setFromAero(getSmallCraft());
         panSummary.refresh();
         refresh.refreshStatus();
         refresh.refreshPreview();

--- a/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
@@ -314,6 +314,7 @@ public class WSStructureTab extends ITab implements AdvancedAeroBuildListener, A
         getJumpship().setHeatType(index);
         getJumpship().setHeatSinks(count);
         getJumpship().setOHeatSinks(count);
+        panHeat.setFromAero(getJumpship());
         panSummary.refresh();
         refresh.refreshStatus();
         refresh.refreshPreview();

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -1223,6 +1223,14 @@ public class UnitUtil {
     }
 
     /**
+     * Returns the total heat generation of the entity
+     */
+    public static int getTotalHeatGeneration(Entity entity) {
+        int heat = entity.getEquipment().stream().mapToInt(m -> m.getType().getHeat()).sum();
+        return heat;
+    }
+
+    /**
      * Determines if the previous critical slot is empty.
      *
      * @param unit     Unit to check.


### PR DESCRIPTION
With this, all units that are tracking heat/heatsinks will now display, in the HeatSink group of the Structure Tab, also how much they are dissipating and the total heat generated by all the equipment.

Closes #568

![image](https://github.com/user-attachments/assets/b615cbbf-cb6c-4a75-afe0-32ea0f899f26)
