### PR TITLE
fixes on critical slots and unified reset of criticals

### DIFF
--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -273,6 +273,17 @@ public class InventoryWriter {
                     && m.getType().hasFlag(MiscType.F_TRACKS)) {
                 continue;
             }
+            /**
+             * BattleArmor have their own special mount points.
+             * We can't rely on LOC_NONE as a filter because it matches LOC_SQUAD (which is a valid location for BA).
+             * The solution is to filter out everything that has critical slots (means can't be for squad only)
+             * and is mounted on MOUNT_LOC_NONE
+             */
+            if ((sheet.getEntity() instanceof BattleArmor)
+                && (m.getCriticals() > 0)
+                && (m.getBaMountLoc() == BattleArmor.MOUNT_LOC_NONE)) {
+                continue;
+            }
             StandardInventoryEntry entry = new StandardInventoryEntry(m);
             StandardInventoryEntry same = equipment.stream().filter(entry::equals).findFirst().orElse(null);
             if (null == same) {

--- a/megameklab/src/megameklab/printing/reference/ClusterHitsTable.java
+++ b/megameklab/src/megameklab/printing/reference/ClusterHitsTable.java
@@ -94,6 +94,8 @@ public class ClusterHitsTable extends ReferenceTable {
             }
             if (entity instanceof BattleArmor) {
                 for (Mounted<?> mounted : entity.getIndividualWeaponList()) {
+                    // We skip equipment that has critical slots and is not in valid a mount location
+                    if ((mounted.getCriticals()>0) && (mounted.getBaMountLoc() == BattleArmor.MOUNT_LOC_NONE)) continue;
                     if (mounted.getType() instanceof MissileWeapon) {
                         for (int troopers = 1; troopers <= size; troopers++) {
                             clusterSizes.add(Math.min(40, troopers * ((MissileWeapon) mounted.getType()).getRackSize()));

--- a/megameklab/src/megameklab/printing/reference/ClusterHitsTable.java
+++ b/megameklab/src/megameklab/printing/reference/ClusterHitsTable.java
@@ -94,7 +94,7 @@ public class ClusterHitsTable extends ReferenceTable {
             }
             if (entity instanceof BattleArmor) {
                 for (Mounted<?> mounted : entity.getIndividualWeaponList()) {
-                    // We skip equipment that has critical slots and is not in valid a mount location
+                    // We skip equipment that has critical slots and is not in a valid mount location
                     if ((mounted.getCriticals()>0) && (mounted.getBaMountLoc() == BattleArmor.MOUNT_LOC_NONE)) continue;
                     if (mounted.getType() instanceof MissileWeapon) {
                         for (int troopers = 1; troopers <= size; troopers++) {

--- a/megameklab/src/megameklab/ui/battleArmor/BABuildTab.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BABuildTab.java
@@ -140,12 +140,7 @@ public class BABuildTab extends ITab {
     }
 
     private void resetCrits() {
-        for (Mounted<?> mount : getBattleArmor().getEquipment()) {
-            if (UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
-                continue;
-            }
-            mount.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
-        }
+        UnitUtil.removeAllCriticals(getBattleArmor());
         refreshAll();
     }
 

--- a/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
@@ -81,8 +81,7 @@ public class BAMainUI extends MegaMekLabMainUI {
         floatingEquipmentDatabase = new FloatingEquipmentDatabaseDialog(getParentFrame(), new BAFloatingEquipmentDatabaseView(this));
         floatingEquipmentDatabase.setRefresh(this);
 
-        statusbar.refresh();
-        refreshHeader();
+        refreshAll();
         validate();
     }
 

--- a/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
@@ -531,6 +531,7 @@ public class BAStructureTab extends ITab
     @Override
     public void chassisTypeChanged(int chassisType) {
         getBattleArmor().setChassisType(chassisType);
+        UnitUtil.removeAllCriticalsFrom(getBattleArmor(), List.of(BattleArmor.MOUNT_LOC_LARM, BattleArmor.MOUNT_LOC_RARM, BattleArmor.MOUNT_LOC_TURRET));
         panBasicInfo.setFromEntity(getBattleArmor());
         panChassis.setFromEntity(getBattleArmor());
         panMovement.setFromEntity(getBattleArmor());

--- a/megameklab/src/megameklab/ui/combatVehicle/CVBuildTab.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVBuildTab.java
@@ -126,14 +126,7 @@ public class CVBuildTab extends ITab implements ActionListener {
     }
 
     private void resetCrits() {
-        for (Mounted<?> mount : getTank().getEquipment()) {
-            // Fixed shouldn't be removed
-            if (UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
-                continue;
-            }
-            UnitUtil.removeCriticals(getTank(), mount);
-            UnitUtil.changeMountStatus(getTank(), mount, Entity.LOC_NONE, Entity.LOC_NONE, false);
-        }
+        UnitUtil.removeAllCriticals(getTank());
         // Check linking after you remove everything.
         try {
             MekFileParser.postLoadInit(getTank());

--- a/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
@@ -89,8 +89,7 @@ public class CVMainUI extends MegaMekLabMainUI {
                 new CVFloatingEquipmentDatabaseView(this));
         floatingEquipmentDatabase.setRefresh(this);
 
-        statusbar.refresh();
-        refreshHeader();
+        refreshAll();
         validate();
     }
 

--- a/megameklab/src/megameklab/ui/fighterAero/ASCriticalView.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASCriticalView.java
@@ -49,11 +49,11 @@ import megameklab.util.UnitUtil;
 public class ASCriticalView extends IView {
     private static final MMLogger logger = MMLogger.create(ASCriticalView.class);
 
-    private final BAASBMDropTargetCriticalList<String> noseCrits;
-    private final BAASBMDropTargetCriticalList<String> leftWingCrits;
-    private final BAASBMDropTargetCriticalList<String> rightWingCrits;
-    private final BAASBMDropTargetCriticalList<String> aftCrits;
-    private final BAASBMDropTargetCriticalList<String> fuselageCrits;
+    private BAASBMDropTargetCriticalList<String> noseCrits;
+    private BAASBMDropTargetCriticalList<String> leftWingCrits;
+    private BAASBMDropTargetCriticalList<String> rightWingCrits;
+    private BAASBMDropTargetCriticalList<String> aftCrits;
+    private BAASBMDropTargetCriticalList<String> fuselageCrits;
 
     private final JLabel noseSpace = new JLabel();
     private final JLabel leftSpace = new JLabel();
@@ -68,7 +68,11 @@ public class ASCriticalView extends IView {
     public ASCriticalView(EntitySource eSource, RefreshListener refreshListener) {
         super(eSource);
         this.refreshListener = refreshListener;
+        setUI();
+        fillSlots();
+    }
 
+    private void setUI() {
         noseCrits = new BAASBMDropTargetCriticalList<>(
                 new ArrayList<>(), eSource, refreshListener, true, this);
         noseCrits.setPrototypeCellValue(CritCellUtil.CRITCELL_WIDTH_STRING);
@@ -135,16 +139,7 @@ public class ASCriticalView extends IView {
         add(mainPanel);
     }
 
-    public void updateRefresh(RefreshListener refresh) {
-        this.refreshListener = refresh;
-        noseCrits.setRefresh(refresh);
-        leftWingCrits.setRefresh(refresh);
-        rightWingCrits.setRefresh(refresh);
-        aftCrits.setRefresh(refresh);
-        fuselageCrits.setRefresh(refresh);
-    }
-
-    public void refresh() {
+    private void fillSlots() {
         for (int location = 0; location < getAero().locations(); location++) {
             if (location == Aero.LOC_WINGS) {
                 continue;
@@ -192,6 +187,21 @@ public class ASCriticalView extends IView {
                 aftSpace.setText(usedCritText);
             }
         }
+    }
+
+    public void updateRefresh(RefreshListener refresh) {
+        this.refreshListener = refresh;
+        noseCrits.setRefresh(refresh);
+        leftWingCrits.setRefresh(refresh);
+        rightWingCrits.setRefresh(refresh);
+        aftCrits.setRefresh(refresh);
+        fuselageCrits.setRefresh(refresh);
+    }
+
+    public void refresh() {
+        removeAll();
+        setUI();
+        fillSlots();
     }
 
     private String availableSpace(int location) {

--- a/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
@@ -91,8 +91,7 @@ public class ASMainUI extends MegaMekLabMainUI {
                 new ASFloatingEquipmentDatabaseView(this));
         floatingEquipmentDatabase.setRefresh(this);
 
-        statusbar.refresh();
-        refreshHeader();
+        refreshAll();
         validate();
     }
 

--- a/megameklab/src/megameklab/ui/handheldWeapon/HHWMainUI.java
+++ b/megameklab/src/megameklab/ui/handheldWeapon/HHWMainUI.java
@@ -71,8 +71,7 @@ public class HHWMainUI extends MegaMekLabMainUI {
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
 
-        statusbar.refresh();
-        refreshHeader();
+        refreshAll();
         validate();
     }
 

--- a/megameklab/src/megameklab/ui/infantry/CIMainUI.java
+++ b/megameklab/src/megameklab/ui/infantry/CIMainUI.java
@@ -67,8 +67,7 @@ public class CIMainUI extends MegaMekLabMainUI {
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
 
-        statusbar.refresh();
-        refreshHeader();
+        refreshAll();
         validate();
     }
 

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -191,8 +191,7 @@ public class DSMainUI extends MegaMekLabMainUI {
                 new LAFloatingEquipmentDatabaseView(this));
         floatingEquipmentDatabase.setRefresh(this);
 
-        statusbar.refresh();
-        refreshHeader();
+        refreshAll();
         validate();
     }
 

--- a/megameklab/src/megameklab/ui/largeAero/LABuildTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/LABuildTab.java
@@ -93,13 +93,7 @@ public class LABuildTab extends ITab implements ActionListener {
     }
 
     private void resetCrits() {
-        for (Mounted<?> mount : getAero().getEquipment()) {
-            if (!UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
-                UnitUtil.removeCriticals(getAero(), mount);
-                UnitUtil.changeMountStatus(getAero(), mount, Entity.LOC_NONE, Entity.LOC_NONE, false);
-            }
-        }
-
+        UnitUtil.removeAllCriticals(getAero());
         refresh.refreshAll();
     }
 

--- a/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
@@ -207,8 +207,7 @@ public class WSMainUI extends MegaMekLabMainUI {
                 new LAFloatingEquipmentDatabaseView(this));
         floatingEquipmentDatabase.setRefresh(this);
 
-        statusbar.refresh();
-        refreshHeader();
+        refreshAll();
         validate();
     }
 

--- a/megameklab/src/megameklab/ui/mek/BMBuildTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildTab.java
@@ -148,12 +148,7 @@ public class BMBuildTab extends ITab {
     }
 
     private void resetCrits() {
-        for (Mounted<?> mounted : getMek().getEquipment()) {
-            if (!UnitUtil.isFixedLocationSpreadEquipment(mounted.getType())) {
-                UnitUtil.removeCriticals(getMek(), mounted);
-                MekUtil.clearMountedLocationAndLinked(mounted);
-            }
-        }
+        UnitUtil.removeAllCriticals(getMek());
         refresh.refreshAll();
     }
 

--- a/megameklab/src/megameklab/ui/mek/BMCriticalTransferHandler.java
+++ b/megameklab/src/megameklab/ui/mek/BMCriticalTransferHandler.java
@@ -238,12 +238,13 @@ public class BMCriticalTransferHandler extends AbstractCriticalTransferHandler {
                 if (!fixedEquipment) {
                     if (eq.getLocation() != Entity.LOC_NONE || eq.getSecondLocation() != Entity.LOC_NONE) {
                         UnitUtil.removeCriticals(getUnit(), eq);
-                        UnitUtil.changeMountStatus(getUnit(), eq, Entity.LOC_NONE, -1, false);
+                        UnitUtil.changeMountStatus(getUnit(), eq, Entity.LOC_NONE, Entity.LOC_NONE, false);
                     } else {
                         eq.setOmniPodMounted(UnitUtil.canPodMount(getUnit(), eq));
                     }
                 } else {
                     UnitUtil.removeCriticals(getUnit(), eq, fixedLocation);
+                    UnitUtil.changeMountStatus(getUnit(), eq, Entity.LOC_NONE, Entity.LOC_NONE, false);
                 }
 
                 StringBuffer errors = new StringBuffer();

--- a/megameklab/src/megameklab/ui/mek/BMMainUI.java
+++ b/megameklab/src/megameklab/ui/mek/BMMainUI.java
@@ -87,8 +87,7 @@ public class BMMainUI extends MegaMekLabMainUI {
                 new BMFloatingEquipmentDatabaseView(this));
         floatingEquipmentDatabase.setRefresh(this);
 
-        statusbar.refresh();
-        refreshHeader();
+        refreshAll();
         validate();
     }
 

--- a/megameklab/src/megameklab/ui/protoMek/PMBuildTab.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMBuildTab.java
@@ -133,13 +133,7 @@ public class PMBuildTab extends ITab implements ActionListener {
     }
 
     private void resetCrits() {
-        for (Mounted<?> mount : getProtoMek().getEquipment()) {
-            // Fixed shouldn't be removed
-            if (TestProtoMek.requiresSlot(mount.getType())) {
-                UnitUtil.changeMountStatus(getProtoMek(), mount, Entity.LOC_NONE, Entity.LOC_NONE, false);
-            }
-        }
-
+        UnitUtil.removeAllCriticals(getProtoMek());
         refresh.refreshAll();
     }
 

--- a/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
@@ -88,8 +88,7 @@ public class PMMainUI extends MegaMekLabMainUI {
         floatingEquipmentDatabase = new FloatingEquipmentDatabaseDialog(getParentFrame(), new PMFloatingEquipmentDatabaseView(this));
         floatingEquipmentDatabase.setRefresh(this);
 
-        statusbar.refresh();
-        refreshHeader();
+        refreshAll();
         validate();
     }
 

--- a/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
@@ -96,8 +96,7 @@ public class SVMainUI extends MegaMekLabMainUI {
         floatingEquipmentDatabase = new FloatingEquipmentDatabaseDialog(getParentFrame(), new SVFloatingEquipmentDatabaseView(this));
         floatingEquipmentDatabase.setRefresh(this);
 
-        statusbar.refresh();
-        refreshHeader();
+        refreshAll();
         validate();
     }
 

--- a/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
@@ -466,6 +466,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
             getSV().getMisc().remove(current);
             getSV().getEquipment().remove(current);
             UnitUtil.removeCriticals(getSV(), current);
+            UnitUtil.changeMountStatus(getSV(), current, Entity.LOC_NONE, Entity.LOC_NONE, false);
         }
         if (mod.equals(TestSupportVehicle.ChassisModification.OMNI.equipment)) {
             getEntity().setOmni(installed);
@@ -559,6 +560,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
                 getSV().getMisc().remove(sponson);
                 getSV().getEquipment().remove(sponson);
                 UnitUtil.removeCriticals(getSV(), sponson);
+                UnitUtil.changeMountStatus(getSV(), sponson, Entity.LOC_NONE, Entity.LOC_NONE, false);
             }
         }
         resetSponsonPintleWeight();
@@ -589,9 +591,11 @@ public class SVStructureTab extends ITab implements SVBuildListener {
                     m.setPintleTurretMounted(false);
                 }
             }
-            getSV().getMisc().remove(installedPintle.get());
-            getSV().getEquipment().remove(installedPintle.get());
-            UnitUtil.removeCriticals(getSV(), installedPintle.get());
+            MiscMounted pintle = installedPintle.get();
+            getSV().getMisc().remove(pintle);
+            getSV().getEquipment().remove(pintle);
+            UnitUtil.removeCriticals(getSV(), pintle);
+            UnitUtil.changeMountStatus(getSV(), pintle, Entity.LOC_NONE, Entity.LOC_NONE, false);
         }
         resetSponsonPintleWeight();
 
@@ -647,6 +651,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
             getSV().getMisc().remove(current);
             getSV().getEquipment().remove(current);
             UnitUtil.removeCriticals(getSV(), current);
+            UnitUtil.changeMountStatus(getSV(), current, Entity.LOC_NONE, Entity.LOC_NONE, false);
         }
         EquipmentType eq = null;
         if (index == SVBuildListener.FIRECON_BASIC) {

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -467,7 +467,7 @@ public class UnitUtil {
         // Special handling for BattleArmor
         if (unit instanceof BattleArmor ba) {
             ba.getEquipment().stream()
-                .filter(m -> m.getBaMountLoc() != BattleArmor.MOUNT_LOC_NONE)
+                .filter(m -> (m != null) && (m.getBaMountLoc() != BattleArmor.MOUNT_LOC_NONE))
                 .filter(m -> locations.contains(m.getBaMountLoc()))
                 .forEach(m -> {
                     m.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -456,7 +456,7 @@ public class UnitUtil {
     /**
      * Removes all criticals of the given unit.
      */
-    public static void removeAllCriticals(Entity unit) {
+    synchronized public static void removeAllCriticals(Entity unit) {
         removeAllCriticalsFrom(unit, IntStream.range(0, unit.locations()).boxed().toList());
         // cleanup of remnants if any (should not be needed but we never know)
         unit.getEquipment().stream()
@@ -469,7 +469,7 @@ public class UnitUtil {
     /**
      * Removes all criticals from the given locations for the given unit.
      */
-    public static void removeAllCriticalsFrom(Entity unit, List<Integer> locations) {
+    synchronized public static void removeAllCriticalsFrom(Entity unit, List<Integer> locations) {
         // Special handling for BattleArmor
         if (unit instanceof BattleArmor ba) {
             ba.getEquipment().stream()

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -463,6 +463,7 @@ public class UnitUtil {
         unit.getEquipment().stream()
             .filter(m -> (m != null) && (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
             .forEach(m -> {
+                UnitUtil.removeCriticals(unit, m);
                 UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
             });
     }
@@ -508,6 +509,7 @@ public class UnitUtil {
             .filter(m -> (m != null) && locations.contains(m.getLocation()))
             .filter(m -> (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
             .forEach(m -> {
+                UnitUtil.removeCriticals(unit, m);
                 UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
             });
     }

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -499,8 +499,8 @@ public class UnitUtil {
         }
         // cleanup of remnants if any (should not be needed but we never know)
         unit.getEquipment().stream()
-            .filter(m -> locations.contains(m.getLocation()))
-            .filter(m -> (m != null) && (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
+            .filter(m -> (m != null) && locations.contains(m.getLocation()))
+            .filter(m -> (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
             .forEach(m -> {
                 UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
             });

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -460,8 +460,7 @@ public class UnitUtil {
         removeAllCriticalsFrom(unit, IntStream.range(0, unit.locations()).boxed().toList());
         // cleanup of remnants if any (should not be needed but we never know)
         unit.getEquipment().stream()
-            .filter(m -> (m != null))
-            .filter(m -> (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
+            .filter(m -> (m != null) && (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
             .forEach(m -> {
                 UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
             });

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -458,6 +458,13 @@ public class UnitUtil {
      */
     public static void removeAllCriticals(Entity unit) {
         removeAllCriticalsFrom(unit, IntStream.range(0, unit.locations()).boxed().toList());
+        // cleanup of remnants if any (should not be needed but we never know)
+        unit.getEquipment().stream()
+            .filter(m -> (m != null))
+            .filter(m -> (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
+            .forEach(m -> {
+                UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
+            });
     }
 
     /**

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -453,6 +453,106 @@ public class UnitUtil {
     }
 
     /**
+     * Removes all criticals of the given unit.
+     */
+    public static void removeAllCriticals(Entity unit) {
+        // Special handling for BattleArmor
+        if (unit instanceof BattleArmor ba) {
+            ba.getEquipment().stream()
+                .filter(m -> m.getBaMountLoc() != BattleArmor.MOUNT_LOC_NONE)
+                .forEach(m -> {
+                    m.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
+                    UnitUtil.changeMountStatus(unit, m, BattleArmor.LOC_SQUAD, BattleArmor.LOC_SQUAD, false);
+                });
+            return;
+        }
+        // first we remove all criticals
+        for (int loc = 0; loc < unit.locations(); loc++) {
+            for (int i = 0; i < unit.getNumberOfCriticals(loc); i++) {
+                CriticalSlot cs = unit.getCritical(loc, i);
+                if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
+                    Mounted<?> m1 = cs.getMount();
+                    Mounted<?> m2 = cs.getMount2();
+                    if (unit instanceof ProtoMek) {
+                        if (TestProtoMek.requiresSlot(m1.getType())) continue;
+                    }
+                    if ((m2 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m2.getType()))) {
+                        cs.setMount2(null);
+                        UnitUtil.changeMountStatus(unit, m2, Entity.LOC_NONE, Entity.LOC_NONE, false);
+                    }
+                    if ((m1 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m1.getType()))) {
+                        cs.setMount(null);
+                        unit.setCritical(loc, i, null);
+                        UnitUtil.changeMountStatus(unit, m1, Entity.LOC_NONE, Entity.LOC_NONE, false);
+                    }
+                }
+            }
+        }
+
+        // cleanup of remnants if any (should not be needed but we never know)
+        unit.getEquipment().stream()
+            .filter(m -> (m != null) && (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
+            .forEach(m -> {
+                if (unit instanceof ProtoMek) {
+                    if (TestProtoMek.requiresSlot(m.getType())) return;
+                }
+                UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
+            });
+    }
+
+    /**
+     * Removes all criticals from the given locations for the given unit.
+     */
+    public static void removeAllCriticalsFrom(Entity unit, List<Integer> locations) {
+        // Special handling for BattleArmor
+        if (unit instanceof BattleArmor ba) {
+            ba.getEquipment().stream()
+                .filter(m -> m.getBaMountLoc() != BattleArmor.MOUNT_LOC_NONE)
+                .filter(m -> locations.contains(m.getBaMountLoc()))
+                .forEach(m -> {
+                    m.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
+                    UnitUtil.changeMountStatus(unit, m, BattleArmor.LOC_SQUAD, BattleArmor.LOC_SQUAD, false);
+                });
+            return;
+        }
+        // first we remove all criticals
+        for (int loc = 0; loc < unit.locations(); loc++) {
+            if (locations.contains(loc)) {
+                continue;
+            }
+            for (int i = 0; i < unit.getNumberOfCriticals(loc); i++) {
+                CriticalSlot cs = unit.getCritical(loc, i);
+                if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
+                    Mounted<?> m1 = cs.getMount();
+                    Mounted<?> m2 = cs.getMount2();
+                    if (unit instanceof ProtoMek) {
+                        if (TestProtoMek.requiresSlot(m1.getType())) continue;
+                    }
+                    if ((m2 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m2.getType()))) {
+                        cs.setMount2(null);
+                        UnitUtil.changeMountStatus(unit, m2, Entity.LOC_NONE, Entity.LOC_NONE, false);
+                    }
+                    if ((m1 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m1.getType()))) {
+                        cs.setMount(null);
+                        unit.setCritical(loc, i, null);
+                        UnitUtil.changeMountStatus(unit, m1, Entity.LOC_NONE, Entity.LOC_NONE, false);
+                    }
+                }
+            }
+        }
+        // cleanup of remnants if any (should not be needed but we never know)
+        unit.getEquipment().stream()
+            .filter(m -> locations.contains(m.getLocation()))
+            .filter(m -> (m != null) && (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
+            .forEach(m -> {
+                if (unit instanceof ProtoMek) {
+                    if (TestProtoMek.requiresSlot(m.getType())) return;
+                }
+                UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
+            });
+    }
+
+    /**
      * Sets the corresponding critical slots to null for the Mounted object.
      *
      * @param unit The entity
@@ -467,7 +567,7 @@ public class UnitUtil {
             for (int slot = 0; slot < unit.getNumberOfCriticals(loc); slot++) {
                 CriticalSlot cs = unit.getCritical(loc, slot);
                 if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
-                    if (cs.getMount().equals(eq)) {
+                    if ((cs.getMount() != null) && (cs.getMount().equals(eq))) {
                         // If there are two pieces of equipment in this slot, remove first one, and replace it with the
                         // second
                         if (cs.getMount2() != null) {
@@ -478,7 +578,7 @@ public class UnitUtil {
                             cs = null;
                             unit.setCritical(loc, slot, cs);
                         }
-                    } else if ((cs.getMount2() != null) && cs.getMount2().equals(eq)) {
+                    } else if ((cs.getMount2() != null) && (cs.getMount2().equals(eq))) {
                         cs.setMount2(null);
                     }
                 }
@@ -501,7 +601,7 @@ public class UnitUtil {
         for (int slot = 0; slot < unit.getNumberOfCriticals(loc); slot++) {
             CriticalSlot cs = unit.getCritical(loc, slot);
             if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
-                if (cs.getMount().equals(eq)) {
+                if ((cs.getMount() != null) && (cs.getMount().equals(eq))) {
                     // If there are two pieces of equipment in this slot,
                     // remove first one, and replace it with the second
                     if (cs.getMount2() != null) {
@@ -512,7 +612,7 @@ public class UnitUtil {
                         cs = null;
                         unit.setCritical(loc, slot, cs);
                     }
-                } else if ((cs.getMount2() != null) && cs.getMount2().equals(eq)) {
+                } else if ((cs.getMount2() != null) && (cs.getMount2().equals(eq))) {
                     cs.setMount2(null);
                 }
             }

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -456,48 +457,7 @@ public class UnitUtil {
      * Removes all criticals of the given unit.
      */
     public static void removeAllCriticals(Entity unit) {
-        // Special handling for BattleArmor
-        if (unit instanceof BattleArmor ba) {
-            ba.getEquipment().stream()
-                .filter(m -> m.getBaMountLoc() != BattleArmor.MOUNT_LOC_NONE)
-                .forEach(m -> {
-                    m.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
-                    UnitUtil.changeMountStatus(unit, m, BattleArmor.LOC_SQUAD, BattleArmor.LOC_SQUAD, false);
-                });
-            return;
-        }
-        // first we remove all criticals
-        for (int loc = 0; loc < unit.locations(); loc++) {
-            for (int i = 0; i < unit.getNumberOfCriticals(loc); i++) {
-                CriticalSlot cs = unit.getCritical(loc, i);
-                if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
-                    Mounted<?> m1 = cs.getMount();
-                    Mounted<?> m2 = cs.getMount2();
-                    if (unit instanceof ProtoMek) {
-                        if (TestProtoMek.requiresSlot(m1.getType())) continue;
-                    }
-                    if ((m2 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m2.getType()))) {
-                        cs.setMount2(null);
-                        UnitUtil.changeMountStatus(unit, m2, Entity.LOC_NONE, Entity.LOC_NONE, false);
-                    }
-                    if ((m1 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m1.getType()))) {
-                        cs.setMount(null);
-                        unit.setCritical(loc, i, null);
-                        UnitUtil.changeMountStatus(unit, m1, Entity.LOC_NONE, Entity.LOC_NONE, false);
-                    }
-                }
-            }
-        }
-
-        // cleanup of remnants if any (should not be needed but we never know)
-        unit.getEquipment().stream()
-            .filter(m -> (m != null) && (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
-            .forEach(m -> {
-                if (unit instanceof ProtoMek) {
-                    if (TestProtoMek.requiresSlot(m.getType())) return;
-                }
-                UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
-            });
+        removeAllCriticalsFrom(unit, IntStream.range(0, unit.locations()).boxed().toList());
     }
 
     /**
@@ -525,9 +485,6 @@ public class UnitUtil {
                 if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
                     Mounted<?> m1 = cs.getMount();
                     Mounted<?> m2 = cs.getMount2();
-                    if (unit instanceof ProtoMek) {
-                        if (TestProtoMek.requiresSlot(m1.getType())) continue;
-                    }
                     if ((m2 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m2.getType()))) {
                         cs.setMount2(null);
                         UnitUtil.changeMountStatus(unit, m2, Entity.LOC_NONE, Entity.LOC_NONE, false);
@@ -545,9 +502,6 @@ public class UnitUtil {
             .filter(m -> locations.contains(m.getLocation()))
             .filter(m -> (m != null) && (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
             .forEach(m -> {
-                if (unit instanceof ProtoMek) {
-                    if (TestProtoMek.requiresSlot(m.getType())) return;
-                }
                 UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
             });
     }

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -457,7 +457,8 @@ public class UnitUtil {
      * Removes all criticals of the given unit.
      */
     synchronized public static void removeAllCriticals(Entity unit) {
-        removeAllCriticalsFrom(unit, IntStream.range(0, unit.locations()).boxed().toList());
+        removeAllCriticalsFrom(unit, IntStream.range(1, unit.locations()).boxed().toList());
+
         // cleanup of remnants if any (should not be needed but we never know)
         unit.getEquipment().stream()
             .filter(m -> (m != null) && (m.getLocation() != Entity.LOC_NONE) && (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
@@ -483,7 +484,7 @@ public class UnitUtil {
         }
         // first we remove all criticals
         for (int loc = 0; loc < unit.locations(); loc++) {
-            if (locations.contains(loc)) {
+            if (!locations.contains(loc)) {
                 continue;
             }
             for (int i = 0; i < unit.getNumberOfCriticals(loc); i++) {
@@ -492,12 +493,11 @@ public class UnitUtil {
                     Mounted<?> m1 = cs.getMount();
                     Mounted<?> m2 = cs.getMount2();
                     if ((m2 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m2.getType()))) {
-                        cs.setMount2(null);
+                        UnitUtil.removeCriticals(unit, m2);
                         UnitUtil.changeMountStatus(unit, m2, Entity.LOC_NONE, Entity.LOC_NONE, false);
                     }
                     if ((m1 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m1.getType()))) {
-                        cs.setMount(null);
-                        unit.setCritical(loc, i, null);
+                        UnitUtil.removeCriticals(unit, m1);
                         UnitUtil.changeMountStatus(unit, m1, Entity.LOC_NONE, Entity.LOC_NONE, false);
                     }
                 }

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -457,7 +457,7 @@ public class UnitUtil {
      * Removes all criticals of the given unit.
      */
     synchronized public static void removeAllCriticals(Entity unit) {
-        removeAllCriticalsFrom(unit, IntStream.range(1, unit.locations()).boxed().toList());
+        removeAllCriticalsFrom(unit, IntStream.range(0, unit.locations()).boxed().toList());
 
         // cleanup of remnants if any (should not be needed but we never know)
         unit.getEquipment().stream()


### PR DESCRIPTION
This PR fixes various bugs with Critical Slots:
- after switching Aerospace chassis Aerospace Fighter<->Conventional Fighter: no more bugged Critical Slots with wrong entries after adding new equipment
- when switching BattleArmor chassis humanoid<->quad: the equipment on the arms and turret will be dismounted (no more hidden equipment)
- BattleArmor equipment that should be assigned to critical slots but is not yet assigned, will not appear in the record sheets and will not count for the columns to use for the Cluster Hit Table.
- add proper call, where missing, to changeMountStatus() after removing a mount from a critical slot
- fixed issue with new units requiring a "refresh ui" to see new critical slots assignments after drag'n'drop
- Unifies the [reset] of critical slots for all units under a single UnitUtil method



Fixes: #1751
