### PR TITLE
Don't include game state in run mp display

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/MovementView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/MovementView.java
@@ -274,7 +274,7 @@ public class MovementView extends BuildView implements ActionListener, ChangeLis
         txtWalkFinal.setText(String.valueOf(en.getWalkMP()));
 
         txtRunBase.setText(String.valueOf((int) Math.ceil(((Number) spnWalk.getValue()).intValue() * 1.5)));
-        txtRunFinal.setText(en.getRunMPasString());
+        txtRunFinal.setText(en.getRunMPasString(false));
 
         int labelIndex = LABEL_INDEX_MEK;
         boolean showJump = true;


### PR DESCRIPTION
Currently, we include the state of speed enhancers in the Run MP box, which looks bad: 
![image](https://github.com/user-attachments/assets/3a79f25c-491b-4ac1-b961-36d7f9fc4cd0)

Cut this out to go back to the old way of just showing 9(15) or whatever. 

Requires MegaMek/megamek#6993.