### PR TITLE
Fixes display of dissipation

### DIFF
--- a/megameklab/src/megameklab/printing/InventoryEntry.java
+++ b/megameklab/src/megameklab/printing/InventoryEntry.java
@@ -19,11 +19,9 @@
 package megameklab.printing;
 
 import megamek.common.EquipmentType;
-import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.WeaponType;
-import megamek.common.weapons.lrms.LRMWeapon;
-import megamek.common.weapons.srms.SRMWeapon;
+import megamek.common.util.AeroAVModCalculator;
 
 /**
  * Interface for classes that process entries in the weapons and inventory table
@@ -137,27 +135,6 @@ public interface InventoryEntry {
      * @return         The AV modification, if any
      */
     default int aeroAVMod(WeaponType weapon, EquipmentType linkedBy, boolean bay) {
-        if (linkedBy.hasFlag(MiscType.F_ARTEMIS)
-                || linkedBy.hasFlag(MiscType.F_ARTEMIS_V)) {
-            // The 9 and 10 rows of the cluster hits table is only different in the 3 column
-            if (weapon.getAtClass() == WeaponType.CLASS_MML) {
-                if (weapon.getRackSize() >= 7) {
-                    return 2;
-                } else if ((weapon.getRackSize() >= 5) || linkedBy.hasFlag(MiscType.F_ARTEMIS_V)) {
-                    return 1;
-                }
-            } else if (weapon instanceof LRMWeapon) {
-                return weapon.getRackSize() / 5;
-            } else if (weapon instanceof SRMWeapon) {
-                return 2;
-            }
-        } else if (linkedBy.hasFlag(MiscType.F_ARTEMIS_PROTO) && weapon.getRackSize() == 2) {
-            // The +1 cluster hit bonus only adds a missile hit for SRM2
-            return 2;
-        } else if (bay && linkedBy.hasFlag(MiscType.F_PPC_CAPACITOR)) {
-            // PPC capacitors in weapon bays are treated as if always charged
-            return 5;
-        }
-        return 0;
+        return AeroAVModCalculator.calculateBonus(weapon, linkedBy, bay);
     }
 }

--- a/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
@@ -30,6 +30,7 @@ import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.WeaponType;
 import megamek.common.equipment.AmmoMounted;
+import megamek.common.util.AeroAVModCalculator;
 import megamek.common.weapons.CLIATMWeapon;
 import megamek.common.weapons.missiles.ATMWeapon;
 import megamek.common.weapons.missiles.MMLWeapon;
@@ -91,7 +92,7 @@ public class WeaponBayInventoryEntry implements InventoryEntry {
                 if (bay.augmentations.containsKey(weaponType)) {
                     bonus = bay.augmentations.get(
                             weaponType).entrySet().stream()
-                        .mapToInt(e -> aeroAVMod(weaponType, e.getKey(), true) * e.getValue()).sum();
+                        .mapToInt(e -> AeroAVModCalculator.calculateBonus(weaponType, e.getKey(), true) * e.getValue()).sum();
                 }
                 if (weaponType.getShortAV() > 0) {
                     double av = weaponType.getShortAV() * numWeapons + bonus;

--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -280,7 +280,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         spnPrototypeCount.addChangeListener(this);
         lblCritFreeCount.setText(String.valueOf(UnitUtil.getCriticalFreeHeatSinks(mek, isCompact)));
         lblWeightFreeCount.setText(String.valueOf(mek.getEngine().getWeightFreeEngineHeatSinks()));
-        lblTotalDissipationCount.setText(String.valueOf(simplifyHeat(mek.formatHeat())));
+        lblTotalDissipationCount.setText(String.valueOf(mek.getHeatCapacity(true, false)));
         lblMaxHeatCount.setText(String.valueOf(UnitUtil.getTotalHeatGeneration(mek)));
 
         showRiscKit(techManager.isLegal(Mek.getRiscHeatSinkOverrideKitAdvancement()));
@@ -315,7 +315,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         baseCountModel.setValue(Math.max(0, aero.getHeatSinks() - aero.getPodHeatSinks()));
         spnBaseCount.addChangeListener(this);
         lblWeightFreeCount.setText(String.valueOf(TestAero.weightFreeHeatSinks(aero)));
-        lblTotalDissipationCount.setText(String.valueOf(simplifyHeat(aero.formatHeat())));
+        lblTotalDissipationCount.setText(String.valueOf(aero.getHeatCapacity(false)));
         lblMaxHeatCount.setText(String.valueOf(UnitUtil.getTotalHeatGeneration(aero)));
         lblBaseCount.setVisible(aero.isOmni());
         spnBaseCount.setVisible(aero.isOmni());
@@ -325,13 +325,6 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         lblCritFreeCount.setVisible(false);
 
         showRiscKit(false);
-    }
-
-    private String simplifyHeat(String heat) {
-        if (heat.contains(",")) {
-            return heat.split(",")[0];
-        }
-        return heat;
     }
 
     public void refresh() {

--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -328,7 +328,10 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     }
 
     private String simplifyHeat(String heat) {
-        return heat.split(",")[0];
+        if (heat.contains(",")) {
+            return heat.split(",")[0];
+        }
+        return heat;
     }
 
     public void refresh() {

--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -280,7 +280,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         spnPrototypeCount.addChangeListener(this);
         lblCritFreeCount.setText(String.valueOf(UnitUtil.getCriticalFreeHeatSinks(mek, isCompact)));
         lblWeightFreeCount.setText(String.valueOf(mek.getEngine().getWeightFreeEngineHeatSinks()));
-        lblTotalDissipationCount.setText(String.valueOf(mek.formatHeat()));
+        lblTotalDissipationCount.setText(String.valueOf(simplifyHeat(mek.formatHeat())));
         lblMaxHeatCount.setText(String.valueOf(UnitUtil.getTotalHeatGeneration(mek)));
 
         showRiscKit(techManager.isLegal(Mek.getRiscHeatSinkOverrideKitAdvancement()));
@@ -315,7 +315,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         baseCountModel.setValue(Math.max(0, aero.getHeatSinks() - aero.getPodHeatSinks()));
         spnBaseCount.addChangeListener(this);
         lblWeightFreeCount.setText(String.valueOf(TestAero.weightFreeHeatSinks(aero)));
-        lblTotalDissipationCount.setText(String.valueOf(aero.formatHeat()));
+        lblTotalDissipationCount.setText(String.valueOf(simplifyHeat(aero.formatHeat())));
         lblMaxHeatCount.setText(String.valueOf(UnitUtil.getTotalHeatGeneration(aero)));
         lblBaseCount.setVisible(aero.isOmni());
         spnBaseCount.setVisible(aero.isOmni());
@@ -325,6 +325,10 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         lblCritFreeCount.setVisible(false);
 
         showRiscKit(false);
+    }
+
+    private String simplifyHeat(String heat) {
+        return heat.split(",")[0];
     }
 
     public void refresh() {


### PR DESCRIPTION
Fixes the display of the dissipation capacity of a mech in the Heatsink group (Structure Tab).
Now will show only the dissipation (heatsink capacity)


extra: moved aero mod calculation to MM.