### PR TITLE
Include full-head ejection system in record sheets.

### DIFF
--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -292,11 +292,22 @@ public class InventoryWriter {
                 same.incrementQty();
             }
         }
+
+        // Special entries for mek features which aren't represented by a MiscType.
         if (sheet.getEntity() instanceof Mek mek && mek.hasRiscHeatSinkOverrideKit()) {
             var mounted = new MiscMounted(sheet.getEntity(), new MiscType() {{
                 name = "RISC Heat Sink Override Kit";
                 shortName = "RISC HS Override Kit";
                 internalName = "RISC Heat Sink Override Kit";
+            }});
+            mounted.setLocation(Mek.LOC_NONE);
+            equipment.add(new StandardInventoryEntry(mounted));
+        }
+        if (sheet.getEntity() instanceof Mek mek && mek.hasFullHeadEject()) {
+            var mounted = new MiscMounted(sheet.getEntity(), new MiscType() {{
+                name = "Full Head Ejection System";
+                shortName = "Full Head Eject System";
+                internalName = "Full Head Ejection System";
             }});
             mounted.setLocation(Mek.LOC_NONE);
             equipment.add(new StandardInventoryEntry(mounted));


### PR DESCRIPTION
Fixes #1874.

Uses the same approach as the RISC Override Kit.

![image](https://github.com/user-attachments/assets/7e8b10a9-ba59-4b1c-8e89-6265dbcb28a8)
