### PR TITLE
Fixed large inventory text fitting + dynamic name selector

### DIFF
--- a/megameklab/src/megameklab/printing/AR10InventoryEntry.java
+++ b/megameklab/src/megameklab/printing/AR10InventoryEntry.java
@@ -38,7 +38,7 @@ public class AR10InventoryEntry implements InventoryEntry {
     }
 
     @Override
-    public String getNameField(int row) {
+    public String getNameField(int row, PrintRecordSheet sheet, double width, float fontSize) {
         return names[row];
     }
 

--- a/megameklab/src/megameklab/printing/InventoryEntry.java
+++ b/megameklab/src/megameklab/printing/InventoryEntry.java
@@ -47,7 +47,15 @@ public interface InventoryEntry {
      * @param row The row index within the entry. Should be &lt; nRows()
      * @return    The name of the equipment
      */
-    String getNameField(int row);
+    default String getNameField(int row) {
+        return getNameField(row, null, 0, 0);
+    }
+
+    /**
+     * @param row The row index within the entry. Should be &lt; nRows()
+     * @return    The name of the equipment
+     */
+    String getNameField(int row, PrintRecordSheet sheet, double width, float fontSize);
 
     /**
      * @param row The row index within the entry. Should be &lt; nRows()

--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -808,13 +808,13 @@ public class InventoryWriter {
                             if (row == 0) {
                                 lines = sheet.addMultilineTextElement(canvas, colX[i],
                                         yPosition, width, lineHeight,
-                                        line.getNameField(row), fontSize, SVGConstants.SVG_START_VALUE,
+                                        line.getNameField(row, sheet, width, fontSize), fontSize, SVGConstants.SVG_START_VALUE,
                                         SVGConstants.SVG_NORMAL_VALUE);
                             } else {
                                 lines = sheet.addMultilineTextElement(canvas, line.indentMultiline() ?
                                         colX[i] + indent : colX[i],
                                         yPosition, width, lineHeight,
-                                        line.getNameField(row), fontSize, SVGConstants.SVG_START_VALUE,
+                                        line.getNameField(row, sheet, width, fontSize), fontSize, SVGConstants.SVG_START_VALUE,
                                         SVGConstants.SVG_NORMAL_VALUE);
                             }
                             break;

--- a/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/WeaponBayInventoryEntry.java
@@ -221,7 +221,7 @@ public class WeaponBayInventoryEntry implements InventoryEntry {
     }
 
     @Override
-    public String getNameField(int row) {
+    public String getNameField(int row, PrintRecordSheet sheet, double width, float fontSize) {
         if (row == 0 && bay.rear && !ship.isSpheroid()) {
             return quantities.get(row) + " " + weaponNames.get(row) + " (R)";
         } else if (row < weaponNames.size()) {


### PR DESCRIPTION
This is https://github.com/MegaMek/megameklab/pull/1883 with in addition the equipment name dynamically chosen between short and normal based on the fitting space.

Examples: "C3 Computer (Slave)" instead of "C3 Slave" because it fits after the font-scaling
![image](https://github.com/user-attachments/assets/f9de7676-bcb7-420d-b4d9-bf2c54d92b8b)
