### PR TITLE
Allow TAG on HHWs

### DIFF
--- a/megameklab/src/megameklab/ui/handheldWeapon/HHWEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/handheldWeapon/HHWEquipmentDatabaseView.java
@@ -76,8 +76,12 @@ public class HHWEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
             // AMS has type PB so it's allowed
             // Except APDS has type P*D*, whatever that means.
             if (UnitUtil.isAMS(wt) && !(wt instanceof ISAPDS)) {
-                valid = true;
-            } else if (!MekUtil.isMekWeapon(wt, new BipedMek())) {
+                return super.shouldShow(eq);
+            }
+
+            // isMekWeapon/isMekEquipment consider some WeaponTypes to be Equipment rather than a Weapon, and the
+            // functions are mutually exclusive, so we check both to determine if the type is valid for a mech.
+            if (!MekUtil.isMekWeapon(wt, new BipedMek()) && !MekUtil.isMekEquipment(wt, new BipedMek())) {
                 return false;
             }
 

--- a/megameklab/src/megameklab/util/MekUtil.java
+++ b/megameklab/src/megameklab/util/MekUtil.java
@@ -48,6 +48,7 @@ import megamek.common.weapons.other.ISAMS;
 import megamek.common.weapons.other.ISAPDS;
 import megamek.common.weapons.other.ISLaserAMS;
 import megamek.common.weapons.ppc.CLPlasmaCannon;
+import megamek.common.weapons.prototypes.ISPrototypeTAG;
 import megamek.common.weapons.tag.CLLightTAG;
 import megamek.common.weapons.tag.CLTAG;
 import megamek.common.weapons.tag.ISTAG;
@@ -1317,7 +1318,7 @@ public final class MekUtil {
         }
 
         if ((eq instanceof CLTAG) || (eq instanceof ISC3MBS)
-                || (eq instanceof ISC3M) || (eq instanceof ISTAG)
+                || (eq instanceof ISC3M) || (eq instanceof ISTAG) || (eq instanceof ISPrototypeTAG)
                 || (eq instanceof AmmoType && ((AmmoType) eq).getAmmoType() == AmmoType.T_COOLANT_POD)
                 || (eq instanceof CLLightTAG) || (eq instanceof ISAMS)
                 || (eq instanceof CLAMS) || (eq instanceof ISLaserAMS)


### PR DESCRIPTION
Because despite being a WeaponType MML considers TAG to be Equipment and not a Weapon.