### PR TITLE
fix: checks if OS is mac and dont load the html for the recent files in the menu bar

### DIFF
--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -49,6 +49,7 @@ import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
 import megameklab.ui.dialog.PrintQueueDialog;
 import megameklab.ui.dialog.UiLoader;
 import megameklab.ui.dialog.settings.SettingsDialog;
+import megameklab.ui.util.OSUtil;
 import megameklab.util.CConfig;
 import megameklab.util.UnitPrintManager;
 import megameklab.util.UnitUtil;
@@ -760,10 +761,18 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
                 path = path.substring(0, 40) + "...";
             }
         }
-        String html = "<HTML><HEAD><STYLE>%s</STYLE></HEAD><BODY>%s</BODY></HTML>";
-        String style = ".small { font-size:smaller; color:gray; }";
-        String content = "<NOBR>%d. %s<BR>".formatted(fileNumber, recent.getName()) + UIUtil.spanCSS("small", path);
-        final JMenuItem miCConfig = new JMenuItem(html.formatted(style, content));
+
+        String content;
+        if (OSUtil.isMac()) {
+             content = "%d. %s ".formatted(fileNumber, recent.getName()) + "(" + path + ")";
+        } else {
+            String html = "<HTML><HEAD><STYLE>%s</STYLE></HEAD><BODY>%s</BODY></HTML>";
+            String style = ".small { font-size:smaller; color:gray; }";
+            content = html.formatted(style, "<NOBR>%d. %s<BR>".formatted(fileNumber,
+                  recent.getName()) + UIUtil.spanCSS("small", path));
+        }
+
+        final JMenuItem miCConfig = new JMenuItem(content);
         miCConfig.setName("miCConfig");
         miCConfig.addActionListener(evt -> loadUnitFromFile(fileNumber));
         miCConfig.setMnemonic(48 + fileNumber); // the number itself, i.e. 1, 2, 3 etc.

--- a/megameklab/src/megameklab/ui/util/OSUtil.java
+++ b/megameklab/src/megameklab/ui/util/OSUtil.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.ui.util;
+
+/**
+ * Utility class to determine the operating system.
+ * @author Luana Coppio
+ */
+public class OSUtil {
+    public enum OS {
+        WINDOWS,
+        MAC,
+        LINUX,
+        OTHER
+    }
+
+    private static OS os = null;
+
+    /**
+     * Returns the current operating system.
+     * @return {@link OS}
+     */
+    public static OS getOS() {
+        if (os == null) {
+            String osName = System.getProperty("os.name").toLowerCase();
+            if (osName.contains("win")) {
+                os = OS.WINDOWS;
+            } else if (osName.contains("mac") || osName.contains("darwin")) {
+                os = OS.MAC;
+            } else if (osName.contains("nix") || osName.contains("nux")) {
+                os = OS.LINUX;
+            } else {
+                os = OS.OTHER;
+            }
+        }
+        return os;
+    }
+
+    /**
+     * @return true if the current operating system is Mac
+     */
+    public static boolean isMac() {
+        return OS.MAC.equals(getOS());
+    }
+
+    /**
+     * @return true if the current operating system is Windows
+     */
+    public static boolean isWindows() {
+        return OS.WINDOWS.equals(getOS());
+    }
+
+    /**
+     * @return true if the current operating system is Linux
+     */
+    public static boolean isLinux() {
+        return OS.LINUX.equals(getOS());
+    }
+
+}


### PR DESCRIPTION
# What it does?

On MegaMekLab the "Recent files" in the menu bar appear with a bunch of html tags written in raw text. Apparently when adapting the look and feel of the OS it also gains some of its quirks, mac in particular is not able or not willing to render HTML on the menu bar in the way we setup it right now.

This PR checks if the OS is mac or not, and if it is mac it won't load the html tags 

Before:
![image](https://github.com/user-attachments/assets/90837223-4476-4d26-964d-398af4d942ff)

After:
<img width="702" alt="Screenshot 2025-05-17 at 23 32 40" src="https://github.com/user-attachments/assets/ff270d1b-cb95-42c3-8e15-80966fef4c0d" />

