### PR TITLE
Don't read the config if the setting is empty

### DIFF
--- a/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
+++ b/megameklab/src/megameklab/ui/MegaMekLabTabbedUI.java
@@ -635,6 +635,9 @@ public class MegaMekLabTabbedUI extends JFrame implements MenuBarOwner, ChangeLi
         DisplayMode currentMonitor = getGraphicsConfiguration().getDevice().getDisplayMode();
         int scaledMonitorW = UIUtil.getScaledScreenWidth(currentMonitor);
         int scaledMonitorH = UIUtil.getScaledScreenHeight(currentMonitor);
+        if (scaledMonitorH <= 0 || scaledMonitorW <= 0) {
+            return; // Invalid monitor size, do not resize
+        }
         int w = Math.min(getSize().width, scaledMonitorW);
         int h = Math.min(getSize().height, scaledMonitorH);
         setSize(new Dimension(w, h));

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -539,7 +539,11 @@ public final class CConfig {
 
     private static Optional<Dimension> getWindowSize(String cconfigSetting) {
         try {
-            String[] fileChooserSettings = getParam(cconfigSetting).split(";");
+            String param = getParam(cconfigSetting);
+            if (param.isBlank()) {
+                return Optional.empty();
+            }
+            String[] fileChooserSettings = param.split(";");
             int sizeX = Integer.parseInt(fileChooserSettings[2]);
             int sizeY = Integer.parseInt(fileChooserSettings[3]);
             Dimension screen = Toolkit.getDefaultToolkit().getScreenSize();
@@ -553,7 +557,11 @@ public final class CConfig {
 
     private static Optional<Point> getWindowPosition(String cconfigSetting) {
         try {
-            String[] fileChooserSettings = getParam(cconfigSetting).split(";");
+            String param = getParam(cconfigSetting);
+            if (param.isBlank()) {
+                return Optional.empty();
+            }
+            String[] fileChooserSettings = param.split(";");
             int posX = Integer.parseInt(fileChooserSettings[0]);
             int posY = Integer.parseInt(fileChooserSettings[1]);
             Dimension screen = Toolkit.getDefaultToolkit().getScreenSize();

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -543,9 +543,9 @@ public final class CConfig {
             if (param.isBlank()) {
                 return Optional.empty();
             }
-            String[] fileChooserSettings = param.split(";");
-            int sizeX = Integer.parseInt(fileChooserSettings[2]);
-            int sizeY = Integer.parseInt(fileChooserSettings[3]);
+            String[] values = param.split(";");
+            int sizeX = Integer.parseInt(values[2]);
+            int sizeY = Integer.parseInt(values[3]);
             Dimension screen = Toolkit.getDefaultToolkit().getScreenSize();
             int clampedWidth  = Math.max(50, Math.min(sizeX, screen.width)); // 50 minimum width
             int clampedHeight = Math.max(50, Math.min(sizeY, screen.height)); // 50 minimum height
@@ -561,9 +561,9 @@ public final class CConfig {
             if (param.isBlank()) {
                 return Optional.empty();
             }
-            String[] fileChooserSettings = param.split(";");
-            int posX = Integer.parseInt(fileChooserSettings[0]);
-            int posY = Integer.parseInt(fileChooserSettings[1]);
+            String[] values = param.split(";");
+            int posX = Integer.parseInt(values[0]);
+            int posY = Integer.parseInt(values[1]);
             Dimension screen = Toolkit.getDefaultToolkit().getScreenSize();
             int clampedX = Math.max(0, Math.min(posX, screen.width-100)); // -100 to avoid the right edge
             int clampedY = Math.max(0, Math.min(posY, screen.height-100)); // -100 to avoid the taskbar

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -532,6 +532,7 @@ public final class CConfig {
         setParam(GUI_DS_MAINUI_WINDOW, "");
         setParam(GUI_WS_MAINUI_WINDOW, "");
         setParam(GUI_HHW_MAINUI_WINDOW, "");
+        setParam(GUI_TABBED_WINDOW, "");
         saveConfig();
     }
 


### PR DESCRIPTION
This PR adds a simple check to prevent read the content of a setting if is empty.