### PR TITLE
Fix: Fixed Start Year of the Mercenary's Guild

### DIFF
--- a/megameklab/data/universe/factions/MG.yml
+++ b/megameklab/data/universe/factions/MG.yml
@@ -1,0 +1,13 @@
+key: MG
+name: Mercenary Guild
+capital: Solaris
+yearsActive:
+  - start: 0
+  - end: 2789
+tags:
+  - IS
+  - MERC
+  - SPECIAL
+  - CORPORATION
+fallBackFactions:
+  - MERC


### PR DESCRIPTION
`3000` -> `0`