### PR TITLE
Enforce correct maximum number of CI squads

### DIFF
--- a/megameklab/src/megameklab/ui/infantry/CIPlatoonTypeView.java
+++ b/megameklab/src/megameklab/ui/infantry/CIPlatoonTypeView.java
@@ -43,7 +43,6 @@ import megameklab.ui.listeners.InfantryBuildListener;
  * @author Neoancient
  */
 public class CIPlatoonTypeView extends BuildView implements ActionListener, ChangeListener {
-    private static final int MAX_NUM_SQUADS = 5;
     List<InfantryBuildListener> listeners = new CopyOnWriteArrayList<>();
     public void addListener(InfantryBuildListener l) {
         listeners.add(l);
@@ -233,7 +232,9 @@ public class CIPlatoonTypeView extends BuildView implements ActionListener, Chan
         int maxSquad = TestInfantry.maxSquadSize(getMovementMode(), isAltMode(), mount);
         spnNumSquads.removeChangeListener(this);
         spnSquadSize.removeChangeListener(this);
-        spnNumSquadsModel.setMaximum(Math.min(MAX_NUM_SQUADS, (maxSize / spnSquadSizeModel.getNumber().intValue())));
+        spnNumSquadsModel.setMaximum(Math.min(TestInfantry.maxSquadCount(getMovementMode(), isAltMode(),
+                    specialization, mount),
+              (maxSize / spnSquadSizeModel.getNumber().intValue())));
         spnSquadSizeModel.setMaximum(maxSquad);
         spnNumSquads.addChangeListener(this);
         spnSquadSize.addChangeListener(this);


### PR DESCRIPTION
Depends on MegaMek/megamek#7298, merge it first.
Fixes #1919.

Sets the maximum number of squads for an infantry platoon correctly based on its movement type and specializations, rather than always using 5.
