### PR TITLE
Treat capacitors as explosive when giving clan case

### DIFF
--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -1186,7 +1186,7 @@ public class UnitUtil {
 
     public static boolean hasAmmo(Entity unit, int location) {
         for (Mounted<?> mount : unit.getEquipment()) {
-            if (mount.getType().isExplosive(mount) &&
+            if (mount.getType().isExplosive(mount, true) &&
                       ((mount.getLocation() == location) || (mount.getSecondLocation() == location))) {
                 return true;
             }


### PR DESCRIPTION
Fixes #1965.

`isExplosive` can be told to ignore charge state. Capacitors are off during some staged of record sheet rendering, but locations with PPC capacitors should be drawn with clan CASE.