### PR TITLE
Fix test

### DIFF
--- a/megameklab/unittests/megameklab/printing/PrintSmallUnitSheetTest.java
+++ b/megameklab/unittests/megameklab/printing/PrintSmallUnitSheetTest.java
@@ -118,6 +118,7 @@ class PrintSmallUnitSheetTest {
         Dropship testDS = new Dropship();
         testDS.setChassis("Test Dropship");
         testDS.setModel("TDS-999");
+        testDS.setEngine(null);
 
         // Create print object
         PrintAero pa = new PrintDropship(testDS, 1, rso);


### PR DESCRIPTION
Due to changes in MM, DropShips now no longer have a null engine unless it it explicitly set to null. 
It's now extremely unlikely that you end up in a state where a DropShip has a null engine, but since we already have the test we may as well keep it around. 