### PR TITLE
Include ammo count in HHW ammo display

### DIFF
--- a/megameklab/data/images/recordsheets/templates_iso/handheld_weapon_large.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/handheld_weapon_large.svg
@@ -9,7 +9,7 @@
    version="1.0"
    id="svg77"
    sodipodi:docname="handheld_weapon_large.svg"
-   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -83,15 +83,15 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showguides="true"
-     inkscape:zoom="2.2623728"
-     inkscape:cx="174.15344"
-     inkscape:cy="141.22341"
-     inkscape:window-width="3840"
-     inkscape:window-height="2054"
-     inkscape:window-x="-11"
-     inkscape:window-y="-11"
+     inkscape:zoom="4.5247456"
+     inkscape:cx="449.97005"
+     inkscape:cy="82.546077"
+     inkscape:window-width="2560"
+     inkscape:window-height="1369"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="ammoPips">
+     inkscape:current-layer="rs_template">
     <inkscape:page
        x="0"
        y="0"
@@ -247,24 +247,24 @@
     </g>
     <path
        id="path81-7"
-       d="m -12.273491,-79.643625 -3.321645,-4.982471 H -195.5762 l -5.6838,8.524195 V 38.267 l 5.67,8.504 29.763,-0.004 6.049,-9.343 h 141.37951 l 6.125,-7.665 z"
+       d="m -12.273491,-79.643625 -3.321645,-4.982471 H -195.5762 l -5.6838,8.524195 V 38.267 l 5.67,8.504 45,0 6.049,-9.343 h 126.5 l 6.125,-7.665 z"
        style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(1.0317376,0,0,-1.0317376,437.44736,62.114671)"
        clip-path="url(#clipPath82-4)"
        sodipodi:nodetypes="ccccccccccc" />
     <path
        id="path83-1"
-       d="M -9.6923861e-7,-79.643625 -3.3216467,-84.626096 H -110.9987 l -5.7033,8.553441 V 38.267 l 5.67,8.504 29.958571,-0.004 6.049,-9.343 H -6.125 L 0,29.759 Z"
+       d="M -9.6923861e-7,-79.643625 -3.3216467,-84.626096 H -110.9987 l -5.7033,8.553441 V 38.267 l 5.67,8.504 45,0 6.049,-9.343 H -6.125 L 0,29.759 Z"
        style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(1.0317376,0,0,-1.0317376,550.62711,62.114671)"
        clip-path="url(#clipPath84-5)"
        sodipodi:nodetypes="ccccccccccc" />
     <text
        id="ammoLabel"
-       x="451.93652"
+       x="458"
        y="21.208117"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.2px;font-family:Eurostile;-inkscape-font-specification:'Eurostile, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;stroke-width:1.03271"
-       xml:space="preserve">Ammo:</text>
+       xml:space="preserve">Ammo (200):</text>
     <g
        style="display:inline"
        fill="none"

--- a/megameklab/data/images/recordsheets/templates_iso/handheld_weapon_standard.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/handheld_weapon_standard.svg
@@ -9,7 +9,7 @@
    version="1.0"
    id="svg77"
    sodipodi:docname="handheld_weapon_standard.svg"
-   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -59,15 +59,15 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showguides="true"
-     inkscape:zoom="9.0494911"
-     inkscape:cx="514.94608"
-     inkscape:cy="68.401636"
-     inkscape:window-width="2897"
-     inkscape:window-height="1317"
-     inkscape:window-x="699"
-     inkscape:window-y="361"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="ammoPips"
+     inkscape:zoom="3.1994783"
+     inkscape:cx="465.07583"
+     inkscape:cy="92.671359"
+     inkscape:window-width="2560"
+     inkscape:window-height="1369"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="rs_template"
      showgrid="false">
     <inkscape:page
        x="0"
@@ -134,14 +134,14 @@
        text-anchor="start">0</text>
     <path
        id="path81"
-       d="m -12.812001,-4.0430062 -3.321646,-4.9824713 H -195.5762 l -5.6838,8.52419444 V 38.267 l 5.67,8.504 29.763,-0.004 6.049,-9.343 h 140.841 l 6.125,-7.665 z"
+       d="m -12.812001,-4.0430062 -3.321646,-4.9824713 H -195.5762 l -5.6838,8.52419444 V 38.267 l 5.67,8.504 45,0 6.049,-9.343 h 125.5 l 6.125,-7.665 z"
        style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(1.0317376,0,0,-1.0317376,437.44736,62.114671)"
        clip-path="url(#clipPath82)"
        sodipodi:nodetypes="ccccccccccc" />
     <path
        id="path83"
-       d="M -9.6923873e-7,-4.0430062 -3.3216467,-9.0254775 H -110.9987 l -5.7033,8.55344084 V 38.267 l 5.67,8.504 29.958571,-0.004 6.049,-9.343 H -6.125 L 0,29.759 Z"
+       d="M -9.6923873e-7,-4.0430062 -3.3216467,-9.0254775 H -110.9987 l -5.7033,8.55344084 V 38.267 l 5.67,8.504 45,0 6.049,-9.343 H -6.125 L 0,29.759 Z"
        style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(1.0317376,0,0,-1.0317376,550.62711,62.114671)"
        clip-path="url(#clipPath84)"
@@ -180,10 +180,10 @@
          y="21.208117">Armor:</tspan></text>
     <text
        id="ammoLabel"
-       x="451.93652"
+       x="458"
        y="21.208117"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.2px;font-family:Eurostile;-inkscape-font-specification:'Eurostile, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;stroke-width:1.03271"
-       xml:space="preserve">Ammo:</text>
+       xml:space="preserve">Ammo (200):</text>
     <text
        id="ammoEntryLabel"
        x="434.16928"

--- a/megameklab/data/images/recordsheets/templates_us/handheld_weapon_large.svg
+++ b/megameklab/data/images/recordsheets/templates_us/handheld_weapon_large.svg
@@ -9,7 +9,7 @@
    version="1.0"
    id="svg77"
    sodipodi:docname="handheld_weapon_large.svg"
-   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -75,15 +75,15 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showguides="true"
-     inkscape:zoom="2.2623728"
-     inkscape:cx="152.49476"
-     inkscape:cy="237.58242"
-     inkscape:window-width="3840"
-     inkscape:window-height="2054"
-     inkscape:window-x="-11"
-     inkscape:window-y="-11"
+     inkscape:zoom="4.5247456"
+     inkscape:cx="491.29834"
+     inkscape:cy="60.887401"
+     inkscape:window-width="2560"
+     inkscape:window-height="1369"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="ammoPips">
+     inkscape:current-layer="rs_template">
     <inkscape:page
        x="0"
        y="0"
@@ -126,7 +126,7 @@
        y="31.443361"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.66667px;font-family:Eurostile;-inkscape-font-specification:'Eurostile, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;fill:#000000;stroke-width:1.03271"
        xml:space="preserve"
-       visibility="hidden">Ammo:</text>
+       visibility="hidden">Ammo :</text>
     <text
        fill="#000000"
        x="545.83575"
@@ -232,23 +232,23 @@
     </g>
     <path
        id="path81-7"
-       d="M -9.6923867e-7,-71.889715 -3.3216467,-76.872186 H -195.5762 l -5.6838,8.524195 V 38.267 l 5.67,8.504 29.763,-0.004 6.049,-9.343 H -6.125 L 0,29.759 Z"
+       d="M -9.6923867e-7,-71.889715 -3.3216467,-76.872186 H -195.5762 l -5.6838,8.524195 V 38.267 l 5.67,8.504 45,0 6.049,-9.343 H -6.125 L 0,29.759 Z"
        style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(1.0317376,0,0,-1.0317376,437.44736,62.114671)"
        clip-path="url(#clipPath82-4)"
        sodipodi:nodetypes="ccccccccccc" />
     <path
        id="path83-1"
-       d="M -9.6923861e-7,-71.889715 -3.3216467,-76.872186 H -110.9987 l -5.7033,8.553441 V 38.267 l 5.67,8.504 29.958571,-0.004 6.049,-9.343 H -6.125 L 0,29.759 Z"
+       d="M -9.6923861e-7,-71.889715 -3.3216467,-76.872186 H -110.9987 l -5.7033,8.553441 V 38.267 l 5.67,8.504 45,0 6.049,-9.343 H -8.125 L 0,29.759 Z"
        style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(1.0317376,0,0,-1.0317376,566.62711,62.114671)"
        clip-path="url(#clipPath84-5)"
        sodipodi:nodetypes="ccccccccccc" />
     <text
        id="ammoLabel"
-       x="467.93652"
-       y="21.208117"
+       x="474"
+       y="21"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.2px;font-family:Eurostile;-inkscape-font-specification:'Eurostile, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;stroke-width:1.03271"
-       xml:space="preserve">Ammo:</text>
+       xml:space="preserve">Ammo (200):</text>
   </g>
 </svg>

--- a/megameklab/data/images/recordsheets/templates_us/handheld_weapon_standard.svg
+++ b/megameklab/data/images/recordsheets/templates_us/handheld_weapon_standard.svg
@@ -9,7 +9,7 @@
    version="1.0"
    id="svg77"
    sodipodi:docname="handheld_weapon_standard.svg"
-   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -59,15 +59,15 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showguides="true"
-     inkscape:zoom="6.3989565"
-     inkscape:cx="331.85098"
-     inkscape:cy="52.274148"
-     inkscape:window-width="3840"
-     inkscape:window-height="2054"
-     inkscape:window-x="-11"
-     inkscape:window-y="-11"
+     inkscape:zoom="3.1994783"
+     inkscape:cx="227.84965"
+     inkscape:cy="43.288308"
+     inkscape:window-width="2560"
+     inkscape:window-height="1369"
+     inkscape:window-x="3832"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="ammoPips"
+     inkscape:current-layer="rs_template"
      showgrid="false">
     <inkscape:page
        x="0"
@@ -114,14 +114,14 @@
        text-anchor="start">0</text>
     <path
        id="path81"
-       d="M -9.6923861e-7,-0.16605143 -3.3216467,-5.1485227 H -195.5762 L -201.26,3.3756717 V 38.267 l 5.67,8.504 29.763,-0.004 6.049,-9.343 H -6.125 L 0,29.759 Z"
+       d="M -9.6923861e-7,-0.16605143 -3.3216467,-5.1485227 H -195.5762 L -201.26,3.3756717 V 38.267 l 5.67,8.504 45,0 6.049,-9.343 H -6.125 L 0,29.759 Z"
        style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(1.0317376,0,0,-1.0317376,437.44736,62.114671)"
        clip-path="url(#clipPath82)"
        sodipodi:nodetypes="ccccccccccc" />
     <path
        id="path83"
-       d="M -9.6923873e-7,-0.16605143 -3.3216467,-5.1485227 H -110.9987 l -5.7033,8.5534408 0,34.8620819 5.67,8.504 29.958571,-0.004 6.049,-9.343 H -6.125 L 0,29.759 Z"
+       d="M -9.6923873e-7,-0.16605143 -3.3216467,-5.1485227 H -110.9987 l -5.7033,8.5534408 0,34.8620819 5.67,8.504 45,0 6.049,-9.343 H -6.125 L 0,29.759 Z"
        style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        transform="matrix(1.0317376,0,0,-1.0317376,566.62711,62.114671)"
        clip-path="url(#clipPath84)"
@@ -160,17 +160,17 @@
          y="21.208117">Armor:</tspan></text>
     <text
        id="ammoLabel"
-       x="467.93652"
+       x="475"
        y="21.208117"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.2px;font-family:Eurostile;-inkscape-font-specification:'Eurostile, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;stroke-width:1.03271"
-       xml:space="preserve">Ammo:</text>
+       xml:space="preserve">Ammo (200):</text>
     <text
        id="ammoEntryLabel"
        x="450.16928"
        y="31.443361"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:6.66667px;font-family:Eurostile;-inkscape-font-specification:'Eurostile, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;text-anchor:start;fill:#000000;stroke-width:1.03271"
        xml:space="preserve"
-       visibility="hidden">Ammo:</text>
+       visibility="hidden">Ammo (%d):</text>
     <text
        id="text91-0-4"
        xml:space="preserve"

--- a/megameklab/src/megameklab/printing/PrintHandheldWeapon.java
+++ b/megameklab/src/megameklab/printing/PrintHandheldWeapon.java
@@ -330,7 +330,10 @@ public class PrintHandheldWeapon extends PrintEntity {
         final boolean needsLabels = pipsList.size() > 1;
         double actualLabelHeight = 0;
         SVGTextElement labelTemplate = null;
+        Element headerLabel = getSVGDocument().getElementById("ammoLabel");
         if (needsLabels) {
+            headerLabel.setTextContent("Ammo:");
+
             bbox = new Rectangle2D.Double(
                 bbox.getX(),
                 bbox.getY()+OFFSET_FIRST_LABEL,
@@ -354,6 +357,8 @@ public class PrintHandheldWeapon extends PrintEntity {
                 // Could not find label template 'ammoEntryLabel'. Using default text settings and size
                 actualLabelHeight = LABEL_DEFAULT_FONT_SIZE;
             }
+        } else {
+            headerLabel.setTextContent("Ammo (%d):".formatted(pipsList.get(0).getValue()));
         }
 
         // Find Optimal Pip Radius
@@ -476,8 +481,8 @@ public class PrintHandheldWeapon extends PrintEntity {
         double totalMinVerticalHeight = 0;
         int expandableGaps = 0;
         boolean firstBlockDrawnVertCalc = false;
-        for (int i = 0; i < pipsList.size(); i++) {
-            int pipsCount = pipsList.get(i).getValue();
+        for (Map.Entry<String, Integer> stringIntegerEntry : pipsList) {
+            int pipsCount = stringIntegerEntry.getValue();
             if (pipsCount <= 0) {
                 rowsPerAmmo.add(0);
                 continue;
@@ -553,7 +558,8 @@ public class PrintHandheldWeapon extends PrintEntity {
                 double labelBaselineY = blockContentStartY + actualLabelHeight * 0.8;
                 double labelStartX = firstPipCenterX_Base - optimalRadius - (pipStroke / 2);
                 labelStartX = Math.max(bbox.getX(), labelStartX);
-                Element label = createLabel(labelTemplate, ammoName + ":", labelStartX, labelBaselineY);
+                Element label = createLabel(labelTemplate, "%s (%d):".formatted(ammoName, pipsCount), labelStartX,
+                      labelBaselineY);
                 target.appendChild(label);
 
                 // Advance currentY past the label and its bottom margin


### PR DESCRIPTION
Instead of needing to count pips to see how much ammo you have, also include a number. 
Single bin:
<img width="2448" height="3168" alt="image" src="https://github.com/user-attachments/assets/5c83946a-b7d7-42df-a268-518432eb4abb" />
Multiple bins:
<img width="2448" height="3168" alt="image" src="https://github.com/user-attachments/assets/7cde34f7-8558-4cc8-ab75-9241f2ceb8d7" />
