### PR TITLE
Improve HHW RS handling of OS weapons

### DIFF
--- a/megameklab/data/images/recordsheets/templates_iso/handheld_weapon_large.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/handheld_weapon_large.svg
@@ -84,7 +84,7 @@
      inkscape:deskcolor="#d1d1d1"
      showguides="true"
      inkscape:zoom="4.5247456"
-     inkscape:cx="449.97005"
+     inkscape:cx="450.19106"
      inkscape:cy="82.546077"
      inkscape:window-width="2560"
      inkscape:window-height="1369"
@@ -264,7 +264,7 @@
        x="458"
        y="21.208117"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.2px;font-family:Eurostile;-inkscape-font-specification:'Eurostile, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;stroke-width:1.03271"
-       xml:space="preserve">Ammo (200):</text>
+       xml:space="preserve">Ammo:</text>
     <g
        style="display:inline"
        fill="none"

--- a/megameklab/data/images/recordsheets/templates_iso/handheld_weapon_standard.svg
+++ b/megameklab/data/images/recordsheets/templates_iso/handheld_weapon_standard.svg
@@ -60,8 +60,8 @@
      inkscape:deskcolor="#d1d1d1"
      showguides="true"
      inkscape:zoom="3.1994783"
-     inkscape:cx="465.07583"
-     inkscape:cy="92.671359"
+     inkscape:cx="465.38837"
+     inkscape:cy="92.671358"
      inkscape:window-width="2560"
      inkscape:window-height="1369"
      inkscape:window-x="3832"
@@ -183,7 +183,7 @@
        x="458"
        y="21.208117"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.2px;font-family:Eurostile;-inkscape-font-specification:'Eurostile, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;stroke-width:1.03271"
-       xml:space="preserve">Ammo (200):</text>
+       xml:space="preserve">Ammo:</text>
     <text
        id="ammoEntryLabel"
        x="434.16928"

--- a/megameklab/data/images/recordsheets/templates_us/handheld_weapon_large.svg
+++ b/megameklab/data/images/recordsheets/templates_us/handheld_weapon_large.svg
@@ -76,7 +76,7 @@
      inkscape:deskcolor="#d1d1d1"
      showguides="true"
      inkscape:zoom="4.5247456"
-     inkscape:cx="491.29834"
+     inkscape:cx="491.51935"
      inkscape:cy="60.887401"
      inkscape:window-width="2560"
      inkscape:window-height="1369"
@@ -249,6 +249,6 @@
        x="474"
        y="21"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.2px;font-family:Eurostile;-inkscape-font-specification:'Eurostile, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;stroke-width:1.03271"
-       xml:space="preserve">Ammo (200):</text>
+       xml:space="preserve">Ammo:</text>
   </g>
 </svg>

--- a/megameklab/data/images/recordsheets/templates_us/handheld_weapon_standard.svg
+++ b/megameklab/data/images/recordsheets/templates_us/handheld_weapon_standard.svg
@@ -60,8 +60,8 @@
      inkscape:deskcolor="#d1d1d1"
      showguides="true"
      inkscape:zoom="3.1994783"
-     inkscape:cx="227.84965"
-     inkscape:cy="43.288308"
+     inkscape:cx="228.1622"
+     inkscape:cy="43.288307"
      inkscape:window-width="2560"
      inkscape:window-height="1369"
      inkscape:window-x="3832"
@@ -163,7 +163,7 @@
        x="475"
        y="21.208117"
        style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8.2px;font-family:Eurostile;-inkscape-font-specification:'Eurostile, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:center;text-anchor:middle;fill:#000000;stroke-width:1.03271"
-       xml:space="preserve">Ammo (200):</text>
+       xml:space="preserve">Ammo:</text>
     <text
        id="ammoEntryLabel"
        x="450.16928"

--- a/megameklab/src/megameklab/printing/PrintHandheldWeapon.java
+++ b/megameklab/src/megameklab/printing/PrintHandheldWeapon.java
@@ -16,6 +16,8 @@ package megameklab.printing;
 import java.awt.geom.Rectangle2D;
 import java.util.AbstractMap;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -25,6 +27,7 @@ import megamek.common.Entity;
 import megamek.common.EquipmentType;
 import megamek.common.HandheldWeapon;
 import megamek.common.WeaponType;
+import megamek.common.equipment.WeaponMounted;
 import megameklab.util.CConfig;
 import org.apache.batik.util.SVGConstants;
 import org.w3c.dom.Element;
@@ -203,6 +206,23 @@ public class PrintHandheldWeapon extends PrintEntity {
                         pipsList.add(new AbstractMap.SimpleEntry<>(ammoName, shotsLeft));
                     }
                 });
+
+        var oneShotWeapons = new HashMap<String,Integer>();
+        for (Iterator<WeaponMounted> it = getEntity().getWeapons(); it.hasNext(); ) {
+            WeaponType weapon = it.next().getType();
+            var name = weapon.getName();
+            if (weapon.hasFlag(WeaponType.F_ONESHOT)) {
+                if (oneShotWeapons.containsKey(name)) {
+                    oneShotWeapons.put(name, oneShotWeapons.get(name) + 1);
+                } else {
+                    oneShotWeapons.put(name, 1);
+                }
+            }
+
+        }
+
+        pipsList.addAll(oneShotWeapons.entrySet());
+
         return pipsList;
     }
 

--- a/megameklab/src/megameklab/ui/dialog/MegaMekLabUnitSelectorDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/MegaMekLabUnitSelectorDialog.java
@@ -43,6 +43,7 @@ import megamek.common.icons.Camouflage;
 import megameklab.ui.generalUnit.RecordSheetPreviewPanel;
 import megameklab.util.CConfig;
 import megameklab.util.UnitPrintManager;
+import megameklab.util.UnitUtil;
 
 public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
     // region Variable Declarations
@@ -300,7 +301,8 @@ public class MegaMekLabUnitSelectorDialog extends AbstractUnitSelectorDialog {
         }
 
         ArrayList<Entity> selectedEntities = getSelectedEntities();
-        if (selectedEntities.size() > 0) {
+        selectedEntities.forEach(UnitUtil::updateLoadedUnit);
+        if (!selectedEntities.isEmpty()) {
             recordSheetPanel.setEntities(selectedEntities);
             printRecordSheetButton.setEnabled(true);
             exportToPDFRecordSheetButton.setEnabled(true);


### PR DESCRIPTION
Previously HHW record sheets would sometimes, but not always, include "ammo" for oneshot weapons.
This PR makes it so that pips are included for all one-shot weapons so that players can mark off how many have been fired.

Example:

<img width="926" height="336" alt="image" src="https://github.com/user-attachments/assets/1df1c26a-c433-4587-a58e-98f962aa639c" />
