### PR TITLE
Add button to sort record sheets in print queue

### DIFF
--- a/megameklab/src/megameklab/printing/PrintEntity.java
+++ b/megameklab/src/megameklab/printing/PrintEntity.java
@@ -905,8 +905,7 @@ public abstract class PrintEntity extends PrintRecordSheet {
     }
 
     private String entityName() {
-        return CConfig.getMekNameArrangement().printChassis(getEntity())
-              + (StringUtility.isNullOrBlank(getEntity().getModel()) ? "" : " " + getEntity().getModel());
+        return UnitUtil.getPrintName(getEntity());
     }
 
     protected boolean useAlternateArmorGrouping() {

--- a/megameklab/src/megameklab/printing/PrintHandheldWeapon.java
+++ b/megameklab/src/megameklab/printing/PrintHandheldWeapon.java
@@ -48,6 +48,7 @@ import megamek.common.equipment.WeaponMounted;
 import megamek.common.equipment.WeaponType;
 import megamek.common.units.Entity;
 import megameklab.util.CConfig;
+import megameklab.util.UnitUtil;
 import org.apache.batik.util.SVGConstants;
 import org.w3c.dom.Element;
 import org.w3c.dom.Text;
@@ -290,8 +291,7 @@ public class PrintHandheldWeapon extends PrintEntity {
     @Override
     protected void writeTextFields() {
         super.writeTextFields();
-        final String entityName = CConfig.getMekNameArrangement().printChassis(getEntity())
-              + (StringUtility.isNullOrBlank(getEntity().getModel()) ? "" : " " + getEntity().getModel());
+        final String entityName = UnitUtil.getPrintName(getEntity());
         setTextField(TYPE, entityName + " (" + formatWeight(getEntity().getWeight()) + ")");
 
     }

--- a/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/RecordSheetPreviewPanel.java
@@ -83,8 +83,7 @@ import org.apache.batik.ext.awt.image.GraphicsUtil;
 import org.apache.batik.gvt.GraphicsNode;
 
 /**
- * @author pavelbraginskiy
- * @author drake Simply fills itself with the record sheet for the given unit. Uses background rendering for
+ * Simply fills itself with the record sheet for the given unit. Uses background rendering for
  *       performance, rendering each page independently.
  */
 public class RecordSheetPreviewPanel extends JPanel {
@@ -198,7 +197,7 @@ public class RecordSheetPreviewPanel extends JPanel {
     }
 
     // Zoom and pan state
-    public static final int MAX_PREVIEW_ENTITIES = 10;
+    public static final int MAX_PREVIEW_ENTITIES = 30;
     private final double DEFAULT_MIN_ZOOM = 0.1;
     private final double MAX_ZOOM = 4.0;
     private final double ZOOM_STEP = 0.2;

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -49,6 +49,7 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 
 import megamek.client.Client;
+import megamek.codeUtilities.StringUtility;
 import megamek.common.CriticalSlot;
 import megamek.common.Player;
 import megamek.common.SimpleTechLevel;
@@ -2302,5 +2303,10 @@ public class UnitUtil {
             }
         }
         return false;
+    }
+
+    public static String getPrintName(Entity e) {
+        return CConfig.getMekNameArrangement().printChassis(e)
+              + (StringUtility.isNullOrBlank(e.getModel()) ? "" : " " + e.getModel());
     }
 }


### PR DESCRIPTION
Closes #2015.

I considered adding support for configuration, but that adds a lot of ui work for something I don't think anybody will care about. Sorting first by unit type is the main thing I imagine anyone will want.

Alphabetical sort uses your configured unit print name, so the same name controlled by the *Inner Sphere (Clan)*/*Clan (Inner Sphere)* setting.

Page breaks are added to ensure units come out in the expected order.

The only thing that's a little wonky is that clantech variants of IS chassis will sort with the other clan units, so e.g. you won't get the Charger C together with the other Chargers. You'll have to put it in the right spot manually, but this isn't too hard and I don't think it's avoidable.