### PR TITLE
Show omnivees are omni in RS

### DIFF
--- a/megameklab/src/megameklab/printing/PrintTank.java
+++ b/megameklab/src/megameklab/printing/PrintTank.java
@@ -151,6 +151,9 @@ public class PrintTank extends PrintEntity {
         if (tank.isSupportVehicle()) {
             sb.append("Support ");
         }
+        if (tank.isOmni()) {
+            sb.append("Omni");
+        }
         if (tank instanceof VTOL) {
             sb.append("VTOL");
         } else {


### PR DESCRIPTION
Currently sheets don't say if a vee is omni or not, but now we get:

**HOVER OMNIVEHICLE RECORD SHEET**

<img width="2448" height="3168" alt="image" src="https://github.com/user-attachments/assets/bf8a8455-a4f4-4a11-81f9-f22f6778caae" />
