### PR TITLE
Sourcebooks Data

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -37,12 +37,15 @@ BasicInfoView.txtModel.tooltip=The name of this variant
 BasicInfoView.txtMulId.text=MUL ID:
 BasicInfoView.txtMulId.tooltip=The Master Unit List ID corresponding to this unit. Should be set to -1 except for units from official sources.
 BasicInfoView.browseMul.tooltip=Opens this unit in the online Master Unit List. Note: will try to open the standard browser on your computer.
+BasicInfoView.browseSourcebook.tooltip=Opens this sourcebook in the online Master Unit List. Note: will try to open \
+  the standard browser on your computer.
 BasicInfoView.txtYear.text=Year:
 BasicInfoView.txtYear.tooltip=The year the unit was first built; this will determine what equipment is available
 BasicInfoView.cbFaction.text=Faction:
 BasicInfoView.cbFaction.tooltip=<html>New equipment may only be available to a limited number of factions until it becomes common.<br/>"Any" ignores faction restrictions.</html>
 BasicInfoView.txtSource.text=Source/Era:
 BasicInfoView.txtSource.tooltip=The published source of the unit and the game era.
+BasicInfoView.configSource.tooltip=Choose the sourcebook
 BasicInfoView.cbTechBase.text=Tech Base:
 BasicInfoView.cbTechBase.tooltip=Determines what equipment and construction options are available. Mixed tech allows use of equipment from the other tech base.
 BasicInfoView.cbTechLevel.text=Tech Level:


### PR DESCRIPTION
Requires MegaMek#7455

- Changes sourcebook entry to use sourcebook data 
- manual entry is still possible
- provides a link to the sourcebook MUL page
- the unit MUL link is changed to use the MUL link icon

<img width="460" height="195" alt="image" src="https://github.com/user-attachments/assets/120f9e17-b1ce-4560-8bd1-c63578bff0c5" />

<img width="614" height="609" alt="image" src="https://github.com/user-attachments/assets/15dca7b6-bf57-4862-b8c4-5c3870dffc08" />

