### PR TITLE
Fix: Added Missing 's' to /logs in Build Directory Construction

### DIFF
--- a/megameklab/build.gradle
+++ b/megameklab/build.gradle
@@ -205,7 +205,7 @@ tasks.register('stageFiles', Copy) {
     into fileStagingDir
 
     doLast {
-        mkdir "${fileStagingDir}/log"
+        mkdir "${fileStagingDir}/logs"
     }
 }
 


### PR DESCRIPTION
Fix https://github.com/MegaMek/mekhq/issues/7637

We were adding a log directory when building the project, when we should have been added logs. This resulted in players ending up with both a /log and logs directory.

Insofar as I can tell this bug is benign, but if we don't fix it I can guarantee we will see people asking about it throughout 07's lifecycle. :D