### PR TITLE
Fix MML part of MML 2002: BAR 4 not allowed for Tech Rating B without Armoured Chassis

### DIFF
--- a/megameklab/build.gradle
+++ b/megameklab/build.gradle
@@ -36,7 +36,7 @@ sourceSets {
 }
 
 ext {
-    mmlJvmOptions = ['-Xmx1024m']
+    mmlJvmOptions = ['-Xmx1024m', '-Dsun.awt.disablegrab=true']
     fileStagingDir = "${layout.buildDirectory.get()}/files"
 
     mmDir = "${rootDir}/../megamek"

--- a/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
@@ -278,7 +278,7 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
             // Check whether SV armor exists at this tech rating or it requires the armored chassis mod.
             if (armor.hasFlag(MiscType.F_SUPPORT_VEE_BAR_ARMOR)
                   && ((armor.getSVWeightPerPoint(getTechRating()) == 0.0)
-                  || (svLimitedArmor && armor.getSVWeightPerPoint(getTechRating()) >= 0.050))) {
+                  || (svLimitedArmor && armor.getSVWeightPerPoint(getTechRating()) > 0.050))) {
                 continue;
             }
             cbArmorType.addItem(armor);


### PR DESCRIPTION
Add jvm flag to allow step-through debugging of the UI, and make the GUI allow BAR 4 for TR B by default.

Testing:
- Ran all 3 projects' unit tests
- Confirmed BAR 4 is now available for SVs without Armoured Chassis enabled.

Close: #2002 

Note: does not depend on the MM PR.