### PR TITLE
  Bug: Interface Cockpits incorrectly allowed cockpit component armor…

### DIFF
--- a/megameklab/src/megameklab/ui/util/BAASBMDropTargetCriticalList.java
+++ b/megameklab/src/megameklab/ui/util/BAASBMDropTargetCriticalList.java
@@ -426,11 +426,7 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
                         info.setActionCommand(Integer.toString(location));
                         info.addActionListener(evt -> changeArmoring());
                         popup.add(info);
-                    } else if (!((getUnit() instanceof Mek)
-                          && (getUnit().isSuperHeavy()
-                          || (((Mek) getUnit()).getCockpitType() == Mek.COCKPIT_INTERFACE
-                          && cs.getType() == CriticalSlot.TYPE_SYSTEM
-                          && cs.getIndex() == Mek.SYSTEM_COCKPIT)))) {
+                    } else if (canAddArmoringToCriticalSlot(cs)) {
                         JMenuItem info = new JMenuItem("Add Armoring");
                         info.setActionCommand(Integer.toString(location));
                         info.addActionListener(evt -> changeArmoring());
@@ -657,6 +653,33 @@ public class BAASBMDropTargetCriticalList<E> extends JList<E> implements MouseLi
         if (refresh != null) {
             refresh.scheduleRefresh();
         }
+    }
+
+    /**
+     * Determines if armoring can be added to a critical slot.
+     * Armoring is not allowed for Superheavy meks or Interface Cockpit slots.
+     *
+     * @param cs The critical slot to check
+     * @return true if armoring is allowed, false otherwise
+     */
+    private boolean canAddArmoringToCriticalSlot(CriticalSlot cs) {
+        if (!(getUnit() instanceof Mek mek)) {
+            return false;
+        }
+
+        // Superheavy meks cannot have any armored components
+        if (mek.isSuperHeavy()) {
+            return false;
+        }
+
+        // Interface Cockpit slots cannot be armored
+        if (mek.getCockpitType() == Mek.COCKPIT_INTERFACE
+              && cs.getType() == CriticalSlot.TYPE_SYSTEM
+              && cs.getIndex() == Mek.SYSTEM_COCKPIT) {
+            return false;
+        }
+
+        return true;
     }
 
     private void changeArmoring() {


### PR DESCRIPTION
PR Notes: Fix Interface Cockpit Component Armoring

  ---
  Issue

  Bug: Interface Cockpits incorrectly allowed cockpit component armoring in MegaMekLab

  Rule: IO:AE p.110 states "The interface cockpit cannot be protected with component armor"

  Reported: https://github.com/MegaMek/megameklab/issues/2041

  ---
  Changes Made

  MegaMek - TestMek.java (Lines 1089-1102)

  Added validation to flag Interface Cockpit with armored cockpit slots as illegal:

  if (mek.getCockpitType() == Mek.COCKPIT_INTERFACE) {
      // Check if any cockpit slots are armored
      for (int location = 0; location < mek.locations(); location++) {
          for (int slot = 0; slot < mek.getNumberOfCriticalSlots(location); slot++) {
              CriticalSlot cs = mek.getCritical(location, slot);
              if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_SYSTEM)
                    && (cs.getIndex() == Mek.SYSTEM_COCKPIT) && cs.isArmored()) {
                  buff.append("Interface Cockpit cannot be protected with component armor\n");
                  illegal = true;
                  break;
              }
          }
      }
  }

  MegaMekLab - BAASBMDropTargetCriticalList.java (Lines 429-433)

  Disabled "Add Armoring" menu option for cockpit slots on Interface Cockpit meks:

  } else if (!((getUnit() instanceof Mek)
        && (getUnit().isSuperHeavy()
        || (((Mek) getUnit()).getCockpitType() == Mek.COCKPIT_INTERFACE
        && cs.getType() == CriticalSlot.TYPE_SYSTEM
        && cs.getIndex() == Mek.SYSTEM_COCKPIT)))) {

  ---
  Behavior

  Before:
  - Interface Cockpit allowed cockpit armoring
  - No validation error

  After:
  - Interface Cockpit blocks "Add Armoring" menu for cockpit slots only
  - Validation error if cockpit slots are armored
  - Other components (engine, gyro, etc.) can still be armored

  ---
  Testing

  1. Create mek with Interface Cockpit in MegaMekLab
  2. Right-click on cockpit slot → "Add Armoring" should NOT appear
  3. Right-click on engine/gyro/actuator slots → "Add Armoring" SHOULD appear
  4. Load existing unit with armored Interface Cockpit → validation should fail with error message

  ---
  Notes

  - Only restricts armoring the cockpit slots themselves, not all components
  - Follows same pattern as other cockpit restrictions in the codebase
  - "Remove Armoring" still available to fix legacy invalid units