### PR TITLE
Clear button for MML's sourcebook entry

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -46,6 +46,7 @@ BasicInfoView.cbFaction.tooltip=<html>New equipment may only be available to a l
 BasicInfoView.txtSource.text=Source/Era:
 BasicInfoView.txtSource.tooltip=The published source of the unit and the game era.
 BasicInfoView.configSource.tooltip=Choose the sourcebook
+BasicInfoView.deleteSource.tooltip=Clear Sourcebook entry
 BasicInfoView.cbTechBase.text=Tech Base:
 BasicInfoView.cbTechBase.tooltip=Determines what equipment and construction options are available. Mixed tech allows use of equipment from the other tech base.
 BasicInfoView.cbTechLevel.text=Tech Level:

--- a/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/BasicInfoView.java
@@ -212,7 +212,7 @@ public class BasicInfoView extends BuildView implements ITechManager, ActionList
         var sourcePanel = Box.createHorizontalBox();
         sourcePanel.add(txtSource);
         var clearSourceButton = new JButton(new DeleteIcon());
-        clearSourceButton.setToolTipText("Clear Sourcebook");
+        clearSourceButton.setToolTipText(resourceMap.getString("BasicInfoView.deleteSource.tooltip"));
         clearSourceButton.addActionListener(e -> setSource(""));
         sourcePanel.add(clearSourceButton);
         var editSourceButton = new JButton(new BooksIcon());


### PR DESCRIPTION
Adds a clear/delete button for the sourcebook so it can be cleared without opening the dialog. Would like to have it as a decoration in the text field itself but that's for a later time. 

Requires MM #7484

<img width="530" height="79" alt="image" src="https://github.com/user-attachments/assets/0ed1de10-cabc-4314-9531-6b0293e374e5" />
