### PR TITLE
Stealth armor isn't FMU

### DIFF
--- a/megameklab/src/megameklab/util/MekUtil.java
+++ b/megameklab/src/megameklab/util/MekUtil.java
@@ -983,6 +983,7 @@ public final class MekUtil {
               && equipment.getType().getNumCriticalSlots(equipment.getEntity()) > 0
               && !equipment.getType().isHittable()
               && (equipment.getType() instanceof MiscType)
+              && !UnitUtil.isFixedLocationSpreadEquipment(equipment.getType())
               && !equipment.getType().hasFlag(MiscType.F_CASE)
               && !equipment.getType().hasFlag(MiscType.F_CASEP)
               && !equipment.getType().hasFlag(MiscType.F_CASEII);


### PR DESCRIPTION
Currently, stealth armor slots are considered Freely-Movable Unhittable even though they're Fixed-Location Spread. No FLS equipment can possibly be FMU, so implemented it as an FLS check even though I think this only affects stealth armor just in case there's something else like that out there.

Stealth armor being FMU causes lots of problems, mainly if you try to add equipment to a location that's full but contains stealth armor, the code tries to move the stealth armor slots out of the way, which breaks them. See screenshots before and after adding Arrow IV to the right arm:

<img width="1977" height="1877" alt="image" src="https://github.com/user-attachments/assets/2476444b-217e-4c5a-9b1f-fa9df5b3f9ad" />

<img width="1977" height="1877" alt="image" src="https://github.com/user-attachments/assets/bc0c50b6-a0bc-48c9-84c6-3e1d92377b7a" />

