### PR TITLE
Properly calculate flank BV for quadvee with supercharger

### DIFF
--- a/megameklab/src/megameklab/printing/PrintMek.java
+++ b/megameklab/src/megameklab/printing/PrintMek.java
@@ -928,11 +928,11 @@ public class PrintMek extends PrintEntity {
     }
 
     private String formatQuadVeeFlank() {
-        double baseFlank = ((QuadVee) mek).getCruiseMP(MPCalculationSetting.STANDARD);
-        baseFlank *= 1.5;
+        double baseCruise = ((QuadVee) mek).getCruiseMP(MPCalculationSetting.STANDARD);
+        double baseFlank = baseCruise * 1.5;
         double fullFlank;
         if (mek.getSuperCharger() != null) {
-            fullFlank = baseFlank * 2;
+            fullFlank = baseCruise * 2;
         } else {
             fullFlank = baseFlank;
         }


### PR DESCRIPTION
A 6/9 Quadvee with a supercharger should have a flank mp of 9 [12], not 9 [18]. See Notos Prime.