### PR TITLE
Enforce WiGE has at least 5 cruise mp

### DIFF
--- a/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
@@ -643,6 +643,11 @@ public class CVStructureTab extends ITab implements CVBuildListener, ArmorAlloca
             getTank().setTrailer(false);
             getTank().setHasNoControlSystems(false);
         }
+
+        if (motive == EntityMovementMode.WIGE && getTank().getOriginalWalkMP() < 5) {
+            getTank().setOriginalWalkMP(5);
+        }
+
         panChassis.removeListener(this);
         panChassis.setFromEntity(getTank());
         panChassis.addListener(this);

--- a/megameklab/src/megameklab/ui/generalUnit/MovementView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/MovementView.java
@@ -247,7 +247,11 @@ public class MovementView extends BuildView implements ActionListener, ChangeLis
         if (en.hasETypeFlag(Entity.ETYPE_TANK) && !en.isSupportVehicle() && !en.isTrailer()) {
             int minRating = 10 + Tank.getSuspensionFactor(en.getMovementMode(), en.getWeight());
             minWalk = Math.max(1, (int) (minRating / en.getWeight()));
-        } else if (en.hasETypeFlag(Entity.ETYPE_LAND_AIR_MEK)) {
+        }
+        if (en instanceof Tank && en.getMovementMode() == EntityMovementMode.WIGE && minWalk < 5) {
+            minWalk = 5;
+        }
+        if (en.hasETypeFlag(Entity.ETYPE_LAND_AIR_MEK)) {
             minJump = minWalk = 3;
             // If the unit has improved JJs the walk can be 2 and still meet the minimum jump MP requirement of 3.
             int jumpType = en.getJumpType();


### PR DESCRIPTION
A WiGE with fewer than 5 cruise mp is invalid, this PR makes it so you can't set a number below 5 from the GUI.