### PR TITLE
Revert "PR: Refactor `Transporter.getType()` and `InfantryTransporter.getType()` to prevent conflicts in classes that implement both `IBuilding` and `Transporter`"

### DIFF
--- a/megameklab/src/megameklab/printing/PrintAero.java
+++ b/megameklab/src/megameklab/printing/PrintAero.java
@@ -221,12 +221,12 @@ public class PrintAero extends PrintEntity {
             if (transporter instanceof InfantryCompartment) {
                 transport.merge("Infantry Compartment", transporter.getUnused(), Double::sum);
             } else if (transporter instanceof StandardSeatCargoBay) {
-                seating.merge(transporter.getTransporterType(), (int) ((Bay) transporter).getCapacity(), Integer::sum);
+                seating.merge(transporter.getType(), (int) ((Bay) transporter).getCapacity(), Integer::sum);
                 // include cargo bays for fighters and fixed wing, but small craft get a block for transport bays
             } else if (transporter instanceof Bay
                   && !((Bay) transporter).isQuarters()
                   && !(aero instanceof SmallCraft)) {
-                transport.merge(transporter.getTransporterType(), ((Bay) transporter).getCapacity(), Double::sum);
+                transport.merge(transporter.getType(), ((Bay) transporter).getCapacity(), Double::sum);
             }
         }
         for (Map.Entry<String, Integer> e : seating.entrySet()) {

--- a/megameklab/src/megameklab/printing/PrintTank.java
+++ b/megameklab/src/megameklab/printing/PrintTank.java
@@ -221,10 +221,10 @@ public class PrintTank extends PrintEntity {
             if (transporter instanceof InfantryCompartment) {
                 transport.merge("Infantry Compartment", transporter.getUnused(), Double::sum);
             } else if (transporter instanceof StandardSeatCargoBay) {
-                seating.merge(transporter.getTransporterType(), (int) ((Bay) transporter).getCapacity(), Integer::sum);
+                seating.merge(transporter.getType(), (int) ((Bay) transporter).getCapacity(), Integer::sum);
                 // SVs have separate Bay handling similar to Small Craft, with doors. CVs just have bulk cargo space.
             } else if (transporter instanceof Bay && !(tank instanceof SupportTank)) {
-                transport.merge(transporter.getTransporterType(), ((Bay) transporter).getCapacity(), Double::sum);
+                transport.merge(transporter.getType(), ((Bay) transporter).getCapacity(), Double::sum);
             }
         }
         for (Map.Entry<String, Integer> e : seating.entrySet()) {

--- a/megameklab/src/megameklab/ui/ForceBuildUI.java
+++ b/megameklab/src/megameklab/ui/ForceBuildUI.java
@@ -233,6 +233,7 @@ public class ForceBuildUI extends JFrame implements ListSelectionListener, Actio
 
     /**
      * Gets the size of the force list.
+     *
      */
     public static synchronized int getForceSize() {
         if (instance == null) {
@@ -463,6 +464,7 @@ public class ForceBuildUI extends JFrame implements ListSelectionListener, Actio
 
     /**
      * Gets the list of all entities in the force.
+     *
      */
     public ArrayList<Entity> getAllEntities() {
         return forceList;


### PR DESCRIPTION
Reverts MegaMek/megameklab#2076

Hammers needs to learn to read. 