### PR TITLE
No BA JB on RS

### DIFF
--- a/megameklab/src/megameklab/printing/PrintUtil.java
+++ b/megameklab/src/megameklab/printing/PrintUtil.java
@@ -153,7 +153,8 @@ public final class PrintUtil {
               F_HARJEL,
               F_MASS,
               F_DETACHABLE_WEAPON_PACK,
-              F_MODULAR_WEAPON_MOUNT
+              F_MODULAR_WEAPON_MOUNT,
+              F_JUMP_BOOSTER
         ))) {
             return false;
         }


### PR DESCRIPTION
The BA Jump Booster (not to be confused with the BA Mechanical Jump Booster) does nothing but add 1 jump mp, there's no reason to include it in record sheets.