### PR TITLE
Properly link weapon enhancements on HHWs

### DIFF
--- a/megameklab/src/megameklab/ui/handheldWeapon/HHWEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/handheldWeapon/HHWEquipmentDatabaseView.java
@@ -86,6 +86,8 @@ public class HHWEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
 
         try {
             getEntity().addEquipment(mount, HandheldWeapon.LOC_GUN, false);
+            // Link weapons with weapon enhancements (artemis etc)
+            UnitUtil.changeMountStatus(getEntity(), mount, HandheldWeapon.LOC_GUN, HandheldWeapon.LOC_NONE, false);
             UnitUtil.removeHiddenAmmo(mount);
         } catch (LocationFullException e) {
             // Shouldn't happen, panic if it does.


### PR DESCRIPTION
Fixes #2097 
Currently, to link weapons to weapon enhancements (artemis, insulator, etc), you have to save and reload the HHW. 