### PR TITLE
Add Augmentation View Validation and UX Improvements

### DIFF
--- a/megameklab/src/megameklab/ui/infantry/CIAugmentationView.java
+++ b/megameklab/src/megameklab/ui/infantry/CIAugmentationView.java
@@ -247,10 +247,6 @@ public class CIAugmentationView extends IView implements ActionListener {
 
         int year = getInfantry().getYear();
         boolean isClan = getInfantry().isClan();
-
-        // Check wing validity constraints (IO p.85)
-        boolean hasGliderWings = getInfantry().hasAbility(OptionsConstants.MD_PL_GLIDER);
-        boolean hasPoweredFlight = getInfantry().hasAbility(OptionsConstants.MD_PL_FLIGHT);
         boolean canUseWings = isFootInfantry();
 
         for (IOption opt : options.keySet()) {
@@ -264,13 +260,13 @@ public class CIAugmentationView extends IView implements ActionListener {
                 boolean isAvailable = augType.isAvailableIn(year, isClan);
 
                 // Apply wing-specific restrictions (IO p.85)
+                // Note: Mutual exclusion between wing types is handled in actionPerformed
+                // to allow single-click switching between glider and powered flight
                 String optName = opt.getName();
-                if (optName.equals(OptionsConstants.MD_PL_GLIDER)) {
-                    // Glider wings: only foot infantry, mutually exclusive with powered flight
-                    isAvailable = isAvailable && canUseWings && !hasPoweredFlight;
-                } else if (optName.equals(OptionsConstants.MD_PL_FLIGHT)) {
-                    // Powered flight: only foot infantry, mutually exclusive with glider wings
-                    isAvailable = isAvailable && canUseWings && !hasGliderWings;
+                if (optName.equals(OptionsConstants.MD_PL_GLIDER)
+                      || optName.equals(OptionsConstants.MD_PL_FLIGHT)) {
+                    // Wings: only foot infantry can use them
+                    isAvailable = isAvailable && canUseWings;
                 }
 
                 checkBox.setEnabled(isAvailable);


### PR DESCRIPTION
 ## Summary

  Adds year-based tech filtering and IO p.85 validation rules to the Conventional Infantry Augmentation tab, plus UX improvements for enhancement configuration persistence.

  ## Changes

  ### Year-Based Tech Filtering
  - Augmentation checkboxes enabled/disabled based on unit's year and tech availability
  - Uses `MDAugmentationType.isAvailableIn(year, isClan)` for tech progression checks
  - Unavailable augmentations are grayed out

  ### Wing Validation Rules (IO p.85)
  - **Mutual Exclusion**: Glider Wings and Powered Flight Wings are mutually exclusive
  - **Foot Infantry Only**: Wings only available for foot infantry (not mechanized, motorized, or beast-mounted)
  - **Extraneous Limb Limit**: When wings installed, only 1 pair of extraneous limbs allowed

  ### UX Improvements
  - **Enhancement Preservation**: Prosthetic enhancement configs preserved when temporarily unchecking options
  - **Status Bar Update**: Dry Cost updates immediately when augmentations change

  ## Test Plan
  - [x] Load Tau Zombie (year 3065) - post-3065 augmentations grayed out
  - [x] Wing mutual exclusion works
  - [x] Wings disabled for non-foot infantry
  - [x] Extraneous limb pair 2 hidden when wings selected
  - [x] Enhancement configuration preserved on toggle
  - [x] Dry Cost updates on augmentation change

  ## Dependencies

  Requires https://github.com/MegaMek/megamek/pull/7864 corresponding MegaMek PR with `isAvailableIn()` fix.