### PR TITLE
Include stealth armor heat in heat profile

### DIFF
--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -1298,7 +1298,7 @@ public class UnitUtil {
             return heat;
         }).sum();
 
-        if (entity.getArmorType(1) == EquipmentType.T_ARMOR_STEALTH && !entity.hasPatchworkArmor()) {
+        if (entity.getArmorType(0) == EquipmentType.T_ARMOR_STEALTH && !entity.hasPatchworkArmor()) {
             total += 10;
         }
 


### PR DESCRIPTION
When summing up the equipment heat of a mek in the equipment inventory, include the 10 heat from stealth armor. This is consistent with the heat produced by other stealth sources, such as Chameleon LPS.