### PR TITLE
Print ammo kind loaded into OS/I-OS launchers

### DIFF
--- a/megameklab/src/megameklab/printing/StandardInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/StandardInventoryEntry.java
@@ -337,7 +337,7 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
         }
 
         if (mount.isOneShot()) {
-            if (mount.getLinked().getType() instanceof AmmoType at) {
+            if ((mount.getLinked() != null) && (mount.getLinked().getType() instanceof AmmoType at)) {
                 if (at.getBaseAmmo() != null) {
                     name.append(" [")
                           .append(at.getMutatorName().replace("(Clan) ", ""))


### PR DESCRIPTION
Requires MegaMek/megamek#7893 to be merged first.

When a special kind of ammo is loaded into a oneshot launcher, show that in the inventory:

<img width="2448" height="3168" alt="image" src="https://github.com/user-attachments/assets/b381db2e-e181-46b3-8e18-565ded4220ae" />
