### PR TITLE
Issue #2112 GUI maintenance

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -241,7 +241,7 @@ HeatSinkView.lblTotalDissipation.text=Total Dissipation:
 HeatSinkView.lblTotalDissipation.tooltip=<html>This is the total amount of heat the unit can dissipate in a single turn.</html>
 HeatSinkView.lblMaxHeat.text=Total Equipment Heat:
 HeatSinkView.lblMaxHeat.tooltip=<html>This is the total amount of heat this unit can potentially generate</html>
-HeatSinkView.lblRiscHeatSinkKit.text=RISC Heat Sink Override Kit:
+HeatSinkView.lblRiscHeatSinkKit.text=RISC Heat Sink Override Kit
 HeatSinkView.lblRiscHeatSinkKit.tooltip=<html>Reduces chance of heat-induced shutdown. IO:AE p86.<br/>\
   Construction only, not implemented for gameplay in MegaMek.</html>
 ArmorView.cbArmorType.text=Armor Type:

--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -1,4 +1,4 @@
-# Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+# Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
 #
 # This file is part of MegaMekLab.
 #

--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -225,25 +225,23 @@ BAChassisView.chkHarjel.tooltip=Clan exoskeletons may be constructed with a ligh
 HeatSinkView.mekNames.values=Single,IS Double,Clan Double,Compact,Laser,Double (Prototype),Double (Freezer)
 HeatSinkView.aeroNames.values=Single,Double,Double (Prototype)
 HeatSinkView.cbHSType.text=Type:
-HeatSinkView.cbHSType.tooltip=Type determines weight, space, and heat dissipation abilities. All heat sinks on the unit must be of the same type.
-HeatSinkView.spnCount.text=Number:
-HeatSinkView.spnCount.tooltip=The total number of heat sinks on the unit. Some heat sinks are integral to fusion (10), fission (5), and fuel cell engines (1) at no additional weight.
+HeatSinkView.spnCount.text=Count:
 HeatSinkView.spnBaseCount.text=Base (Omni):
 HeatSinkView.spnBaseCount.tooltip=The number of heat sinks that are part of the base chassis configuration.
-HeatSinkView.spnPrototypeCount.text=Double:
-HeatSinkView.spnPrototypeCount.tooltip=<html>Prototype double heat sinks can be mixed with single heat sinks on the same unit.<br/>\
-  The engine's slot-free capacity may only be applied to the single heat sinks.
+HeatSinkView.spnPrototypeCount.text=DHS-P / DHS-F:
+HeatSinkView.spnPrototypeCount.tooltip=IO:AE p.65 (DHS-P) / p.96 (Freezers)\nThe number of prototype double heat sinks \
+  on the unit. \nIf the "Number" field is higher, the difference is the number \nof additional single heat sinks on the unit
+HeatSinkView.spnPrototypeCount.info=\   {0,choice,0#no single heat sinks|1#1 single heat sink|1<{0} single \
+  heat sinks}
 HeatSinkView.lblCritFree.text=Engine Free:
-HeatSinkView.lblCritFree.tooltip=<html>These heat sinks are an integral part of the engine and do not have to be assigned critical space.<br/>Omni units must assign critical space to any pod-mounted heat sinks even if they would be part of the engine in standard Meks.</html>
+HeatSinkView.lblCritFree.tooltip=The number of heat sinks that are an integral part of the engine and do not have to \
+  be assigned critical space.
 HeatSinkView.lblWeightFree.text=Weight Free:
-HeatSinkView.lblWeightFree.tooltip=<html>These heat sinks are included in the weight of the engine.</html>
-HeatSinkView.lblTotalDissipation.text=Total Dissipation:
-HeatSinkView.lblTotalDissipation.tooltip=<html>This is the total amount of heat the unit can dissipate in a single turn.</html>
-HeatSinkView.lblMaxHeat.text=Total Equipment Heat:
-HeatSinkView.lblMaxHeat.tooltip=<html>This is the total amount of heat this unit can potentially generate</html>
+HeatSinkView.lblWeightFree.tooltip=The number of heat sinks that are included in the weight of the engine
+HeatSinkView.lblTotalDissipation.text=Dissipation:
+HeatSinkView.lblMaxHeat.text=Equipment Heat:
 HeatSinkView.lblRiscHeatSinkKit.text=RISC Heat Sink Override Kit
-HeatSinkView.lblRiscHeatSinkKit.tooltip=<html>Reduces chance of heat-induced shutdown. IO:AE p86.<br/>\
-  Construction only, not implemented for gameplay in MegaMek.</html>
+HeatSinkView.lblRiscHeatSinkKit.tooltip=IO:AE p.86\nConstruction only, not implemented for gameplay in MegaMek.
 ArmorView.cbArmorType.text=Armor Type:
 ArmorView.cbArmorType.tooltip=The type of armor determines the amount of protection per ton and the amount of space required. Some armors provide additional special abilities.
 ArmorView.spnTonnage.text=Armor Tonnage:
@@ -411,36 +409,27 @@ DropshipCriticalView.lblSlotCount.tooltip=The number of slots in this arc occupi
 DropshipCriticalView.lblExtraWeight.text=Extra tonnage:
 DropshipCriticalView.lblExtraWeight.tooltip=The additional weight required for exceeding the base number of weapon in this arc.
 AerospaceCrewView.spnOfficers.text=Officers:
-AerospaceCrewView.spnOfficers.tooltip=<html>At least one in five crew members (six for advanced aerospace vessels; not including marines and bay personnel) is typically considered an officer (rounded up).<br/>The officers are counted among the total crew rather than additional personnel.
 AerospaceCrewView.spnBaseCrew.text=Base Crew:
-AerospaceCrewView.spnBaseCrew.tooltip=The number of crew required to run the vessel. Does not include gunners, marines, bay personnel, or passengers.
 AerospaceCrewView.spnGunners.text=Gunners:
-AerospaceCrewView.spnGunners.tooltip=Minimum of one per each capital weapon or each six standard-scale weapons.
 AerospaceCrewView.lblTotalCrew.text=Total Crew:
-AerospaceCrewView.lblTotalCrew.tooltip=The standard crew size for vessel operations. Does not include bay personnel, passengers, or marines.
-AerospaceCrewView.lblBayPersonnel.text=Bay Personnel:
-AerospaceCrewView.lblBayPersonnel.tooltip=The additional crew capacity provided by transport bays.
+AerospaceCrewView.lblTotalCrew.tooltip=Base Crew + Gunners
+AerospaceCrewView.lblBayPersonnel.text=Bay Pers.:
 AerospaceCrewView.spnPassengers.text=Passengers:
-AerospaceCrewView.spnPassengers.tooltip=Passenger capacity. Not counted among crew, but must be allocated quarters.
 AerospaceCrewView.spnMarines.text=Marines:
-AerospaceCrewView.spnMarines.tooltip=Defends vessel against boarding actions. Do not count toward officer requirements, but must be allocated quarters.
 AerospaceCrewView.spnBAMarines.text=BA Marines:
-AerospaceCrewView.spnBAMarines.tooltip=BattleArmored marines.
 AerospaceCrewView.btnAssignQuarters.text=Auto-Assign Quarters
-AerospaceCrewView.btnAssignQuarters.tooltip=<html>Assigns officer quarters for officers, standard crew quarters for remaining crew, and second-class quarters for passengers.<br/>If there were previously more officer/first class quarters assigned than the number of officers, these will be treated as first class passenger cabins.<br/>Any steerage quarters already assigned will be used first for marines not already assigned standard quarters, then passengers, then enlisted crew.</html>
+AerospaceCrewView.btnAssignQuarters.tooltip=Assigns officer quarters for officers, standard crew quarters for \
+  remaining crew, and second-class quarters for passengers.\nIf there were previously more officer/first class \
+  quarters assigned than the number of officers, these will be treated as first class passenger cabins.\nAny steerage \
+  quarters already assigned will be used first for marines not already assigned standard quarters, then passengers, \
+  then enlisted crew.
 AerospaceCrewView.lblQuarters.text=Quarters
-AerospaceCrewView.spnQuartersFirstClass.text=First Class/Officer:
-AerospaceCrewView.spnQuartersFirstClass.tooltip=Quarters for officers or luxury suite for first class passengers. 10 tons each.
+AerospaceCrewView.spnQuartersFirstClass.text=1st/Ofc.:
 AerospaceCrewView.spnQuartersStandard.text=Standard:
-AerospaceCrewView.spnQuartersStandard.tooltip=Standard crew quarters. 7 tons each.
-AerospaceCrewView.spnQuartersSecondClass.text=Second Class:
-AerospaceCrewView.spnQuartersSecondClass.tooltip=Standard suite for second class passengers. 7 tons each.
+AerospaceCrewView.spnQuartersSecondClass.text=2nd Class:
 AerospaceCrewView.spnQuartersSteerage.text=Steerage:
-AerospaceCrewView.spnQuartersSteerage.tooltip=Basic room for crew or passenger. 5 tons each.
 AerospaceCrewView.spnLifeBoats.text=Life Boats:
-AerospaceCrewView.spnLifeBoats.tooltip=Designed to keep six passengers alive for up to a month in space.
 AerospaceCrewView.spnEscapePods.text=Escape Pods:
-AerospaceCrewView.spnEscapePods.tooltip=Designed to transport six passengers to a planetary surface in an emergency.
 SVType.AIRSHIP=Airship
 SVType.FIXED_WING=Fixed Wing
 SVType.HOVERCRAFT=Hovercraft

--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -123,8 +123,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
           I18N.getString("HeatSinkView.lblCritFree.tooltip"));
     private final DisplayTextField lblCritFreeCount = new DisplayTextField();
 
-    private final DisplayTextField lblWeightFreeCount = new DisplayTextField("",
-          I18N.getString("HeatSinkView.lblWeightFree.tooltip"));
+    private final DisplayTextField lblWeightFreeCount = new DisplayTextField();
     private final DisplayTextField lblTotalDissipationCount = new DisplayTextField();
     private final DisplayTextField lblMaxHeatCount = new DisplayTextField();
     private final JCheckBox chkRiscHeatSinkKit = new JCheckBox(I18N.getString("HeatSinkView.lblRiscHeatSinkKit.text")){
@@ -159,6 +158,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         spnBaseCount.setModel(baseCountModel);
         spnPrototypeCount.setModel(prototypeCountModel);
         lblWeightFreeCount.setHorizontalAlignment(JTextField.RIGHT);
+        lblWeightFreeCount.setToolTipText(I18N.getString("HeatSinkView.lblWeightFree.tooltip"));
         lblTotalDissipationCount.setHorizontalAlignment(JTextField.RIGHT);
         lblMaxHeatCount.setHorizontalAlignment(JTextField.RIGHT);
         chkRiscHeatSinkKit.setVisible(false);

--- a/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/HeatSinkView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -46,9 +46,11 @@ import javax.swing.JLabel;
 import javax.swing.JSpinner;
 import javax.swing.JTextField;
 import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import megamek.client.ui.util.DisplayTextField;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.equipment.MiscType;
@@ -78,6 +80,8 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         listeners.remove(l);
     }
 
+    public static final ResourceBundle I18N = ResourceBundle.getBundle("megameklab.resources.Views");
+
     public static final int TYPE_SINGLE = 0;
     public static final int TYPE_DOUBLE_IS = 1;
     public static final int TYPE_DOUBLE_CLAN = 2;
@@ -101,23 +105,27 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
 
     private final CustomComboBox<Integer> cbHSType = new CustomComboBox<>(this::getDisplayName);
     private final JSpinner spnCount = new JSpinner();
-    private final JLabel lblBaseCount = new JLabel();
+    private final JLabel lblBaseCount = new JLabel(I18N.getString("HeatSinkView.spnBaseCount.text"),
+          SwingConstants.RIGHT);
     private final JSpinner spnBaseCount = new JSpinner();
-    private final JLabel lblPrototypeCount = new JLabel();
+    private final JLabel lblPrototypeCount = new JLabel(I18N.getString("HeatSinkView.spnPrototypeCount.text"),
+          SwingConstants.RIGHT);
     private final JSpinner spnPrototypeCount = new JSpinner();
-    private final JLabel lblCritFreeText = new JLabel();
-    private final JTextField lblCritFreeCount = new JTextField();
-    private final JLabel lblWeightFreeText = new JLabel();
-    private final JTextField lblWeightFreeCount = new JTextField();
-    private final JLabel lblTotalDissipationText = new JLabel();
-    private final JTextField lblTotalDissipationCount = new JTextField();
-    private final JLabel lblMaxHeatText = new JLabel();
-    private final JTextField lblMaxHeatCount = new JTextField();
-    private final JLabel lblRiscHeatSinkKit = new JLabel();
-    private final JCheckBox chkRiscHeatSinkKit = new JCheckBox();
+    private final JLabel lblCritFreeText = new JLabel(I18N.getString("HeatSinkView.lblCritFree.text"),
+          SwingConstants.RIGHT);
+    private final DisplayTextField lblCritFreeCount = new DisplayTextField();
+    private final JLabel lblWeightFreeText = new JLabel(I18N.getString("HeatSinkView.lblWeightFree.text"),
+          SwingConstants.RIGHT);
+    private final DisplayTextField lblWeightFreeCount = new DisplayTextField();
+    private final JLabel lblTotalDissipationText = new JLabel(I18N.getString("HeatSinkView.lblTotalDissipation.text"),
+          SwingConstants.RIGHT);
+    private final DisplayTextField lblTotalDissipationCount = new DisplayTextField();
+    private final JLabel lblMaxHeatText = new JLabel(I18N.getString("HeatSinkView.lblMaxHeat.text"),
+          SwingConstants.RIGHT);
+    private final DisplayTextField lblMaxHeatCount = new DisplayTextField();
+    private final JCheckBox chkRiscHeatSinkKit = new JCheckBox(I18N.getString("HeatSinkView.lblRiscHeatSinkKit.text"));
 
-
-    private final SpinnerNumberModel countModel = new SpinnerNumberModel(0, 0, null, 1);
+    private final SpinnerNumberModel countModel = new SpinnerNumberModel(0, 0, 100000, 1);
     private final SpinnerNumberModel baseCountModel = new SpinnerNumberModel(0, 0, null, 1);
     private final SpinnerNumberModel prototypeCountModel = new SpinnerNumberModel(0, 0, null, 1);
 
@@ -136,108 +144,79 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     }
 
     private void initUI() {
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
-        MekDisplayNames = resourceMap.getString("HeatSinkView.mekNames.values").split(",");
-        aeroDisplayNames = resourceMap.getString("HeatSinkView.aeroNames.values").split(",");
+        MekDisplayNames = I18N.getString("HeatSinkView.mekNames.values").split(",");
+        aeroDisplayNames = I18N.getString("HeatSinkView.aeroNames.values").split(",");
+
+        spnCount.setToolTipText(I18N.getString("HeatSinkView.spnCount.tooltip"));
+        spnCount.setModel(countModel);
+        cbHSType.setToolTipText(I18N.getString("HeatSinkView.cbHSType.tooltip"));
+        lblCritFreeCount.setToolTipText(I18N.getString("HeatSinkView.lblCritFree.tooltip"));
+        lblCritFreeCount.setEditable(false);
+        lblCritFreeCount.setHorizontalAlignment(JTextField.RIGHT);
+        spnBaseCount.setModel(baseCountModel);
+        spnBaseCount.setToolTipText(I18N.getString("HeatSinkView.spnBaseCount.tooltip"));
+        spnPrototypeCount.setModel(prototypeCountModel);
+        spnPrototypeCount.setToolTipText(I18N.getString("HeatSinkView.spnPrototypeCount.tooltip"));
+        lblWeightFreeCount.setToolTipText(I18N.getString("HeatSinkView.lblWeightFree.tooltip"));
+        lblWeightFreeCount.setEditable(false);
+        lblWeightFreeCount.setHorizontalAlignment(JTextField.RIGHT);
+        lblTotalDissipationCount.setToolTipText(I18N.getString("HeatSinkView.lblTotalDissipation.tooltip"));
+        lblTotalDissipationCount.setEditable(false);
+        lblTotalDissipationCount.setHorizontalAlignment(JTextField.RIGHT);
+        lblMaxHeatCount.setToolTipText(I18N.getString("HeatSinkView.lblMaxHeat.tooltip"));
+        lblMaxHeatCount.setEditable(false);
+        lblMaxHeatCount.setHorizontalAlignment(JTextField.RIGHT);
+        chkRiscHeatSinkKit.setToolTipText(I18N.getString("HeatSinkView.lblRiscHeatSinkKit.tooltip"));
+        chkRiscHeatSinkKit.setVisible(false);
+        chkRiscHeatSinkKit.addActionListener(this);
 
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
+        gbc.fill = GridBagConstraints.HORIZONTAL;
 
-        gbc.gridx = 0;
         gbc.gridy = 0;
-        add(createLabel(resourceMap, "lblHSType", "HeatSinkView.cbHSType.text",
+        add(createLabel(I18N, "lblHSType", "HeatSinkView.cbHSType.text",
               "HeatSinkView.cbHSType.tooltip"), gbc);
-        gbc.gridx = 1;
-        gbc.gridwidth = 4;
-        cbHSType.setToolTipText(resourceMap.getString("HeatSinkView.cbHSType.tooltip"));
         add(cbHSType, gbc);
-        cbHSType.addActionListener(this);
 
-        spnCount.setModel(countModel);
-        gbc.gridx = 0;
         gbc.gridy++;
-        gbc.gridwidth = 1;
-        add(createLabel(resourceMap, "lblCount", "HeatSinkView.spnCount.text",
+        add(createLabel(I18N, "lblCount", "HeatSinkView.spnCount.text",
               "HeatSinkView.spnCount.tooltip"), gbc);
-        gbc.gridx = 1;
-        spnCount.setToolTipText(resourceMap.getString("HeatSinkView.spnCount.tooltip"));
         add(spnCount, gbc);
-        spnCount.addChangeListener(this);
 
-        gbc.gridx = 2;
-        add(new JLabel("<html>&nbsp;</html>"), gbc);
-        gbc.gridx = 3;
-        lblCritFreeText.setText(resourceMap.getString("HeatSinkView.lblCritFree.text"));
+        gbc.gridy++;
         add(lblCritFreeText, gbc);
-        gbc.gridx = 4;
-        lblCritFreeCount.setToolTipText(resourceMap.getString("HeatSinkView.lblCritFree.tooltip"));
-        lblCritFreeCount.setEditable(false);
-        lblCritFreeCount.setHorizontalAlignment(JTextField.RIGHT);
         add(lblCritFreeCount, gbc);
 
-        spnBaseCount.setModel(baseCountModel);
-        gbc.gridx = 0;
         gbc.gridy++;
-        lblBaseCount.setText(resourceMap.getString("HeatSinkView.spnBaseCount.text"));
         add(lblBaseCount, gbc);
-        gbc.gridx = 1;
-        spnBaseCount.setToolTipText(resourceMap.getString("HeatSinkView.spnBaseCount.tooltip"));
         add(spnBaseCount, gbc);
-        spnBaseCount.addChangeListener(this);
 
-        spnPrototypeCount.setModel(prototypeCountModel);
-        gbc.gridx = 0;
         gbc.gridy++;
-        lblPrototypeCount.setText(resourceMap.getString("HeatSinkView.spnPrototypeCount.text"));
         add(lblPrototypeCount, gbc);
-        gbc.gridx = 1;
-        spnPrototypeCount.setToolTipText(resourceMap.getString("HeatSinkView.spnPrototypeCount.tooltip"));
         add(spnPrototypeCount, gbc);
-        spnPrototypeCount.addChangeListener(this);
 
-        gbc.gridx = 0;
         gbc.gridy++;
-        lblWeightFreeText.setText(resourceMap.getString("HeatSinkView.lblWeightFree.text"));
         add(lblWeightFreeText, gbc);
-        gbc.gridx = 1;
-        lblWeightFreeCount.setToolTipText(resourceMap.getString("HeatSinkView.lblWeightFree.tooltip"));
-        lblWeightFreeCount.setEditable(false);
-        lblWeightFreeCount.setHorizontalAlignment(JTextField.RIGHT);
         add(lblWeightFreeCount, gbc);
 
-        gbc.gridx = 0;
         gbc.gridy++;
-        lblTotalDissipationText.setText(resourceMap.getString("HeatSinkView.lblTotalDissipation.text"));
         add(lblTotalDissipationText, gbc);
-        gbc.gridx = 1;
-        lblTotalDissipationCount.setToolTipText(resourceMap.getString("HeatSinkView.lblTotalDissipation.tooltip"));
-        lblTotalDissipationCount.setEditable(false);
-        lblTotalDissipationCount.setHorizontalAlignment(JTextField.RIGHT);
         add(lblTotalDissipationCount, gbc);
 
-        gbc.gridx = 0;
         gbc.gridy++;
-        lblMaxHeatText.setText(resourceMap.getString("HeatSinkView.lblMaxHeat.text"));
         add(lblMaxHeatText, gbc);
-        gbc.gridx = 1;
-        lblMaxHeatCount.setToolTipText(resourceMap.getString("HeatSinkView.lblMaxHeat.tooltip"));
-        lblMaxHeatCount.setEditable(false);
-        lblMaxHeatCount.setHorizontalAlignment(JTextField.RIGHT);
         add(lblMaxHeatCount, gbc);
 
-
-        lblRiscHeatSinkKit.setText(resourceMap.getString("HeatSinkView.lblRiscHeatSinkKit.text"));
-        lblRiscHeatSinkKit.setToolTipText(resourceMap.getString("HeatSinkView.lblRiscHeatSinkKit.tooltip"));
-        chkRiscHeatSinkKit.setToolTipText(resourceMap.getString("HeatSinkView.lblRiscHeatSinkKit.tooltip"));
-        lblRiscHeatSinkKit.setVisible(false);
-        chkRiscHeatSinkKit.setVisible(false);
-        gbc.gridx = 0;
         gbc.gridy++;
-        add(lblRiscHeatSinkKit, gbc);
-        gbc.gridx = GridBagConstraints.RELATIVE;
+        gbc.gridwidth = GridBagConstraints.REMAINDER;
+        gbc.fill = GridBagConstraints.NONE;
         add(chkRiscHeatSinkKit, gbc);
-        chkRiscHeatSinkKit.addActionListener(this);
 
+        spnCount.addChangeListener(this);
+        cbHSType.addActionListener(this);
+        spnBaseCount.addChangeListener(this);
+        spnPrototypeCount.addChangeListener(this);
     }
 
     private String getDisplayName(int index) {
@@ -246,7 +225,6 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
 
     private void showRiscKit(boolean show) {
         chkRiscHeatSinkKit.setVisible(show);
-        lblRiscHeatSinkKit.setVisible(show);
         if (!show) {
             chkRiscHeatSinkKit.setSelected(false);
         }
@@ -257,13 +235,11 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
         isPrimitive = mek.isPrimitive();
         hasPrototypeDoubles = mek.hasWorkingMisc(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE);
         refresh();
-        // If there are prototype doubles, we want to skip any singles and select that
-        // as the base type.
+        // If there are prototype doubles, we want to skip any singles and select that as the base type.
         Optional<MiscType> hs = mek.getMisc().stream().map(Mounted::getType)
               .filter(et -> et.hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)).findAny();
         if (hs.isEmpty()) {
-            hs = mek.getMisc().stream().map(Mounted::getType)
-                  .filter(UnitUtil::isHeatSink).findAny();
+            hs = mek.getMisc().stream().map(Mounted::getType).filter(UnitUtil::isHeatSink).findAny();
         }
         if (hs.isPresent()) {
             if (hs.get().is(EquipmentTypeLookup.COMPACT_HS_2)) {
@@ -376,10 +352,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
     }
 
     public int getHeatSinkIndex() {
-        if (cbHSType.getSelectedItem() != null) {
-            return (Integer) cbHSType.getSelectedItem();
-        }
-        return 0;
+        return (cbHSType.getSelectedItem() instanceof Integer index) ? index : 0;
     }
 
     public void setHeatSinkIndex(int index) {
@@ -407,11 +380,7 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
      * @return The number of heat sinks out of the total that are prototype double heat sinks.
      */
     public int getPrototypeCount() {
-        if (hasPrototypeDoubles) {
-            return prototypeCountModel.getNumber().intValue();
-        } else {
-            return 0;
-        }
+        return hasPrototypeDoubles ? prototypeCountModel.getNumber().intValue() : 0;
     }
 
     @Override
@@ -442,5 +411,4 @@ public class HeatSinkView extends BuildView implements ActionListener, ChangeLis
             listeners.forEach(l -> l.heatSinksChanged(getHeatSinkType(), getCount()));
         }
     }
-
 }

--- a/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
@@ -135,7 +135,6 @@ public class DSStructureTab extends ITab implements DropshipBuildListener, Armor
         leftPanel.add(panInfo);
         leftPanel.add(iconView);
         leftPanel.add(panChassis);
-        leftPanel.add(panCrew);
 
         midPanel.add(panHeat);
         midPanel.add(panMovement);
@@ -145,6 +144,7 @@ public class DSStructureTab extends ITab implements DropshipBuildListener, Armor
 
         rightPanel.add(panArmor);
         rightPanel.add(panArmorAllocation);
+        rightPanel.add(panCrew);
 
         gbc = new GridBagConstraints();
         gbc.gridx = 0;

--- a/megameklab/src/megameklab/ui/largeAero/LACrewView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LACrewView.java
@@ -50,7 +50,6 @@ import javax.swing.SpinnerNumberModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
-import com.formdev.flatlaf.FlatClientProperties;
 import megamek.client.ui.util.DisplayTextField;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.interfaces.ITechManager;

--- a/megameklab/src/megameklab/ui/largeAero/LACrewView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LACrewView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/ui/largeAero/LACrewView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LACrewView.java
@@ -32,8 +32,10 @@
  */
 package megameklab.ui.largeAero;
 
+import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
+import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.List;
@@ -42,11 +44,14 @@ import java.util.ResourceBundle;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.JButton;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import com.formdev.flatlaf.FlatClientProperties;
+import megamek.client.ui.util.DisplayTextField;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.interfaces.ITechManager;
 import megamek.common.units.Aero;
@@ -63,6 +68,8 @@ import megameklab.ui.listeners.AeroVesselBuildListener;
 public class LACrewView extends BuildView implements ActionListener, ChangeListener {
     private final List<AeroVesselBuildListener> listeners = new CopyOnWriteArrayList<>();
 
+    private static final ResourceBundle I18N = ResourceBundle.getBundle("megameklab.resources.Views");
+
     public void addListener(AeroVesselBuildListener l) {
         listeners.add(l);
     }
@@ -72,15 +79,16 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
     }
 
     private final JSpinner spnOfficers = new JSpinner(new SpinnerNumberModel(0, 0, null, 1));
-    private final JSpinner spnBaseCrew = new JSpinner(new SpinnerNumberModel(1, 1, null, 1));
+    // A maximum of 9999 is used to give the spinners enough width
+    private final JSpinner spnBaseCrew = new JSpinner(new SpinnerNumberModel(1, 1, 9999, 1));
     private final JSpinner spnGunners = new JSpinner(new SpinnerNumberModel(1, 1, null, 1));
-    private final JLabel lblBayPersonnel = new JLabel();
+    private final DisplayTextField lblBayPersonnel = new DisplayTextField();
     private final JSpinner spnMarines = new JSpinner(new SpinnerNumberModel(0, 0, null, 1));
     private final JSpinner spnBAMarines = new JSpinner(new SpinnerNumberModel(0, 0, null, 1));
-    private final JLabel lblTotalCrew = new JLabel();
+    private final DisplayTextField lblTotalCrew = new DisplayTextField();
     private final JSpinner spnPassengers = new JSpinner(new SpinnerNumberModel(0, 0, null, 1));
     private final JSpinner spnQuartersStandard = new JSpinner(new SpinnerNumberModel(0, 0, null, 1));
-    private final JSpinner spnQuartersFirstClass = new JSpinner(new SpinnerNumberModel(0, 0, null, 1));
+    private final JSpinner spnQuartersFirstClass = new JSpinner(new SpinnerNumberModel(0, 0, 9999, 1));
     private final JSpinner spnQuartersSecondClass = new JSpinner(new SpinnerNumberModel(0, 0, null, 1));
     private final JSpinner spnQuartersSteerage = new JSpinner(new SpinnerNumberModel(0, 0, null, 1));
     private final JSpinner spnLifeBoats = new JSpinner(new SpinnerNumberModel(0, 0, null, 1));
@@ -97,150 +105,118 @@ public class LACrewView extends BuildView implements ActionListener, ChangeListe
     }
 
     public void initUI() {
-        setLayout(new GridBagLayout());
-        ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
+        JPanel leftPanel = new JPanel(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.insets = STANDARD_INSETS;
 
-        gbc.gridx = 0;
         gbc.gridy = 0;
-        add(createLabel(resourceMap, "lblBaseCrew", "AerospaceCrewView.spnBaseCrew.text",
-              "AerospaceCrewView.spnBaseCrew.tooltip"), gbc);
-        gbc.gridx = 1;
-        add(spnBaseCrew, gbc);
-        spnBaseCrew.setToolTipText(resourceMap.getString("AerospaceCrewView.spnBaseCrew.tooltip"));
+        leftPanel.add(createLabel(I18N, "lblBaseCrew", "AerospaceCrewView.spnBaseCrew.text"), gbc);
+        leftPanel.add(spnBaseCrew, gbc);
         spnBaseCrew.addChangeListener(this);
 
-        gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap, "lblGunners", "AerospaceCrewView.spnGunners.text",
-              "AerospaceCrewView.spnGunners.tooltip"), gbc);
-        gbc.gridx = 1;
-        add(spnGunners, gbc);
-        spnGunners.setToolTipText(resourceMap.getString("AerospaceCrewView.spnGunners.tooltip"));
+        leftPanel.add(createLabel(I18N, "lblGunners", "AerospaceCrewView.spnGunners.text"), gbc);
+        leftPanel.add(spnGunners, gbc);
         spnGunners.addChangeListener(this);
 
-        gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap, "lblTotalCrew", "AerospaceCrewView.lblTotalCrew.text",
+        leftPanel.add(createLabel(I18N,
+              "lblTotalCrew",
+              "AerospaceCrewView.lblTotalCrew.text",
               "AerospaceCrewView.lblTotalCrew.tooltip"), gbc);
-        gbc.gridx = 1;
-        add(lblTotalCrew, gbc);
-        lblTotalCrew.setToolTipText(resourceMap.getString("AerospaceCrewView.lblTotalCrew.tooltip"));
+        lblTotalCrew.setToolTipText(I18N.getString("AerospaceCrewView.lblTotalCrew.tooltip"));
+        leftPanel.add(lblTotalCrew, gbc);
         lblTotalCrew.setHorizontalAlignment(JLabel.RIGHT);
 
-        gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap, "lblOfficers", "AerospaceCrewView.spnOfficers.text",
-              "AerospaceCrewView.spnOfficers.tooltip"), gbc);
-        gbc.gridx = 1;
-        spnOfficers.setToolTipText(resourceMap.getString("AerospaceCrewView.spnOfficers.tooltip"));
-        add(spnOfficers, gbc);
+        leftPanel.add(createLabel(I18N, "lblOfficers", "AerospaceCrewView.spnOfficers.text"), gbc);
+        leftPanel.add(spnOfficers, gbc);
         spnOfficers.addChangeListener(this);
 
-        gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap, "lblBayPersonnel", "AerospaceCrewView.lblBayPersonnel.text",
-              "AerospaceCrewView.lblBayPersonnel.tooltip"), gbc);
-        gbc.gridx = 1;
-        add(lblBayPersonnel, gbc);
-        lblBayPersonnel.setToolTipText(resourceMap.getString("AerospaceCrewView.lblBayPersonnel.tooltip"));
+        leftPanel.add(createLabel(I18N, "lblBayPersonnel", "AerospaceCrewView.lblBayPersonnel.text"), gbc);
+        leftPanel.add(lblBayPersonnel, gbc);
         lblBayPersonnel.setHorizontalAlignment(JLabel.RIGHT);
 
-        gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap, "lblPassengers", "AerospaceCrewView.spnPassengers.text",
-              "AerospaceCrewView.spnPassengers.tooltip"), gbc);
-        gbc.gridx = 1;
-        spnPassengers.setToolTipText(resourceMap.getString("AerospaceCrewView.spnPassengers.tooltip"));
-        add(spnPassengers, gbc);
+        leftPanel.add(createLabel(I18N, "lblPassengers", "AerospaceCrewView.spnPassengers.text"), gbc);
+        leftPanel.add(spnPassengers, gbc);
         spnPassengers.addChangeListener(this);
 
-        gbc.gridx = 0;
         gbc.gridy++;
-        add(createLabel(resourceMap, "lblMarines", "AerospaceCrewView.spnMarines.text",
-              "AerospaceCrewView.spnMarines.tooltip"), gbc);
-        gbc.gridx = 1;
-        spnMarines.setToolTipText(resourceMap.getString("AerospaceCrewView.spnMarines.tooltip"));
-        add(spnMarines, gbc);
+        leftPanel.add(createLabel(I18N, "lblMarines", "AerospaceCrewView.spnMarines.text"), gbc);
+        leftPanel.add(spnMarines, gbc);
         spnMarines.addChangeListener(this);
 
-        gbc.gridx = 0;
         gbc.gridy++;
-        lblBAMarines.setText(resourceMap.getString("AerospaceCrewView.spnBAMarines.text"));
-        add(lblBAMarines, gbc);
-        gbc.gridx = 1;
-        spnBAMarines.setToolTipText(resourceMap.getString("AerospaceCrewView.spnBAMarines.tooltip"));
-        add(spnBAMarines, gbc);
+        lblBAMarines.setText(I18N.getString("AerospaceCrewView.spnBAMarines.text"));
+        leftPanel.add(lblBAMarines, gbc);
+        leftPanel.add(spnBAMarines, gbc);
         spnBAMarines.addChangeListener(this);
 
-        gbc.gridx = 2;
+        JPanel rightPanel = new JPanel(new GridBagLayout());
+        gbc = new GridBagConstraints();
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.insets = STANDARD_INSETS;
         gbc.gridy = 0;
         gbc.gridwidth = 2;
-        add(new JLabel(resourceMap.getString("AerospaceCrewView.lblQuarters.text")), gbc);
-
-        gbc.gridx = 2;
-        gbc.gridy++;
+        gbc.anchor = GridBagConstraints.CENTER;
+        gbc.fill = GridBagConstraints.NONE;
+        JLabel quartersHeader = new JLabel(I18N.getString("AerospaceCrewView.lblQuarters.text")) {
+            @Override
+            public Dimension getPreferredSize() {
+                // make the height align with the other text fields, so the whole grid aligns well
+                return new Dimension(super.getPreferredSize().width, lblBayPersonnel.getPreferredSize().height);
+            }
+        };
+        rightPanel.add(quartersHeader, gbc);
+        gbc.anchor = GridBagConstraints.EAST;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap, "lblQuartersFirstClass", "AerospaceCrewView.spnQuartersFirstClass.text",
-              "AerospaceCrewView.spnQuartersFirstClass.tooltip"), gbc);
-        gbc.gridx = 3;
-        spnQuartersFirstClass.setToolTipText(resourceMap.getString("AerospaceCrewView.spnQuartersFirstClass.tooltip"));
-        add(spnQuartersFirstClass, gbc);
+
+        gbc.gridy++;
+        rightPanel.add(createLabel(I18N, "lblQuartersFirstClass", "AerospaceCrewView.spnQuartersFirstClass.text"), gbc);
+        rightPanel.add(spnQuartersFirstClass, gbc);
         spnQuartersFirstClass.addChangeListener(this);
 
-        gbc.gridx = 2;
         gbc.gridy++;
-        add(createLabel(resourceMap, "lblQuartersStandard", "AerospaceCrewView.spnQuartersStandard.text",
-              "AerospaceCrewView.spnQuartersStandard.tooltip"), gbc);
-        gbc.gridx = 3;
-        spnQuartersStandard.setToolTipText(resourceMap.getString("AerospaceCrewView.spnQuartersStandard.tooltip"));
-        add(spnQuartersStandard, gbc);
+        rightPanel.add(createLabel(I18N, "lblQuartersStandard", "AerospaceCrewView.spnQuartersStandard.text"), gbc);
+        rightPanel.add(spnQuartersStandard, gbc);
         spnQuartersStandard.addChangeListener(this);
 
-        gbc.gridx = 2;
         gbc.gridy++;
-        add(createLabel(resourceMap, "lblQuartersSecondClass", "AerospaceCrewView.spnQuartersSecondClass.text",
-              "AerospaceCrewView.spnQuartersSecondClass.tooltip"), gbc);
-        gbc.gridx = 3;
-        spnQuartersSecondClass.setToolTipText(resourceMap.getString("AerospaceCrewView.spnQuartersSecondClass.tooltip"));
-        add(spnQuartersSecondClass, gbc);
+        rightPanel.add(createLabel(I18N, "lblQuartersSecondClass", "AerospaceCrewView.spnQuartersSecondClass.text"),
+              gbc);
+        rightPanel.add(spnQuartersSecondClass, gbc);
         spnQuartersSecondClass.addChangeListener(this);
 
-        gbc.gridx = 2;
         gbc.gridy++;
-        add(createLabel(resourceMap, "lblQuartersSteerage", "AerospaceCrewView.spnQuartersSteerage.text",
-              "AerospaceCrewView.spnQuartersSteerage.tooltip"), gbc);
-        gbc.gridx = 3;
-        spnQuartersSteerage.setToolTipText(resourceMap.getString("AerospaceCrewView.spnQuartersSteerage.tooltip"));
-        add(spnQuartersSteerage, gbc);
+        rightPanel.add(createLabel(I18N, "lblQuartersSteerage", "AerospaceCrewView.spnQuartersSteerage.text"), gbc);
+        rightPanel.add(spnQuartersSteerage, gbc);
         spnQuartersSteerage.addChangeListener(this);
 
-        gbc.gridx = 2;
         gbc.gridy++;
         gbc.gridwidth = 2;
-        btnAssignQuarters.setText(resourceMap.getString("AerospaceCrewView.btnAssignQuarters.text"));
-        btnAssignQuarters.setToolTipText(resourceMap.getString("AerospaceCrewView.btnAssignQuarters.tooltip"));
-        add(btnAssignQuarters, gbc);
+        btnAssignQuarters.setText(I18N.getString("AerospaceCrewView.btnAssignQuarters.text"));
+        btnAssignQuarters.setToolTipText(I18N.getString("AerospaceCrewView.btnAssignQuarters.tooltip"));
+        rightPanel.add(btnAssignQuarters, gbc);
         btnAssignQuarters.addActionListener(this);
 
-        gbc.gridx = 2;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        add(createLabel(resourceMap, "lblLifeBoats", "AerospaceCrewView.spnLifeBoats.text",
-              "AerospaceCrewView.spnLifeBoats.tooltip"), gbc);
-        gbc.gridx = 3;
-        spnLifeBoats.setToolTipText(resourceMap.getString("AerospaceCrewView.spnLifeBoats.tooltip"));
-        add(spnLifeBoats, gbc);
+        rightPanel.add(createLabel(I18N, "lblLifeBoats", "AerospaceCrewView.spnLifeBoats.text"), gbc);
+        rightPanel.add(spnLifeBoats, gbc);
         spnLifeBoats.addChangeListener(this);
 
-        gbc.gridx = 2;
         gbc.gridy++;
-        add(createLabel(resourceMap, "lblEscapePods", "AerospaceCrewView.spnEscapePods.text",
-              "AerospaceCrewView.spnEscapePods.tooltip"), gbc);
-        gbc.gridx = 3;
-        spnEscapePods.setToolTipText(resourceMap.getString("AerospaceCrewView.spnEscapePods.tooltip"));
-        add(spnEscapePods, gbc);
+        rightPanel.add(createLabel(I18N, "lblEscapePods", "AerospaceCrewView.spnEscapePods.text"), gbc);
+        rightPanel.add(spnEscapePods, gbc);
         spnEscapePods.addChangeListener(this);
+
+        setLayout(new GridLayout(1, 2, 10, 0));
+        add(leftPanel);
+        add(rightPanel);
     }
 
     public void setFromEntity(Aero aero) {

--- a/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
@@ -146,7 +146,6 @@ public class WSStructureTab extends ITab implements AdvancedAeroBuildListener, A
         leftPanel.add(iconView);
         leftPanel.add(panChassis);
         leftPanel.add(panHeat);
-        leftPanel.add(panCrew);
 
         midPanel.add(panMovement);
         panMovement.setVisible(getJumpship().hasETypeFlag(Entity.ETYPE_WARSHIP));
@@ -157,6 +156,7 @@ public class WSStructureTab extends ITab implements AdvancedAeroBuildListener, A
 
         rightPanel.add(panArmor);
         rightPanel.add(panArmorAllocation);
+        rightPanel.add(panCrew);
 
         gbc = new GridBagConstraints();
         gbc.gridx = 0;

--- a/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -1152,6 +1152,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         refresh.refreshSummary();
         refresh.refreshBuild();
         refresh.refreshPreview();
+        panHeat.setFromMek(getMek());
     }
 
     @Override


### PR DESCRIPTION
Fixes #2112 

For the heat sink view and large craft crew view, gives a minimum width to some fields (using Swing-appropriate methods) that should be (far) more than enough. Also some general UI maintenance; removed some tooltips that did not seem to contain anything noteworthy or just recited rules text. Also moves the crew view to the right where there is a little more space.

No intentional logic changes.