### PR TITLE
Issue #2105 Primitive aerospace armor (yet again)

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -1,4 +1,4 @@
-# Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+# Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
 #
 # This file is part of MegaMekLab.
 #

--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -167,6 +167,7 @@ FighterChassisView.btnResetChassis.text=Reset Chassis
 FighterChassisView.btnResetChassis.tooltip=Remove all pod-mounted equipment and troop space to strip unit down to base omni chassis.
 FighterChassisView.chkDNICockpitMod.text=DNI Cockpit Modification
 FighterChassisView.chkDNICockpitMod.tooltip=<html>Direct Neural Interface cockpit modification (IO:AE p.62).<br/>Required for pilots with DNI implant. IS only.</html>
+AdvAeroChassisView.primitiveInfo.text=\   Primitive JS are constructed as WS
 DropshipChassisView.spnTonnage.text=Tonnage:
 DropshipChassisView.spnTonnage.tooltip=<html>Small Craft range 100-200 tons in 5 ton increments.<br/>Aerodyne Dropships range 200-35,000 tons in 100-ton increments.<br/>Spheroid Dropships range 200-100,000 tons in 100-ton increments.</html>
 DropshipChassisView.chkFunction.text=Military
@@ -182,7 +183,11 @@ DropshipChassisView.cbChassisType.values=Aerodyne,Spheroid
 DropshipChassisView.spnSI.text=Structural Integrity:
 DropshipChassisView.spnSI.tooltip=The structural integrity determines the maximum armor that can be mounted.
 AdvAeroChassisView.spnTonnage.text=Tonnage:
-AdvAeroChassisView.spnTonnage.tooltip=<html>Jumpships range 50,000-500,000 tons in 1,000-ton increments.<br/>Warships range 100,000-2,500,000 tons in 10,000-ton increments.<br/>Space Stations range 2,000-2,500,000 tons in 500 ton increments.<br/>Subcompact Warships range 5,000-25,000 tons in 100 ton increments.</html>
+AdvAeroChassisView.spnTonnage.tooltip=<html>Jumpships range 50,000-500,000 tons in 1,000-ton increments.<br/>Warships\
+  \ range 100,000-2,500,000 tons in 10,000-ton increments.<br/>Space Stations range 2,000-2,500,000 tons in 500 ton \
+  increments.<br/>Subcompact Warships range 5,000-25,000 tons in 100 ton increments.<BR>Primitive \
+  JumpShips/WarShips have various tonnage limits depending on faction and introduction year.</html>
+AdvAeroChassisView.tonnageRange=\   Range: {0} - {1} tons
 AdvAeroChassisView.chkLFBattery.text=Lithium-Fusion Battery
 AdvAeroChassisView.chkLFBattery.tooltip=A lithium-fusion battery allows a ships to make a second jump before having to recharge.
 AdvAeroChassisView.chkSail.text=Sail

--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -167,7 +167,7 @@ FighterChassisView.btnResetChassis.text=Reset Chassis
 FighterChassisView.btnResetChassis.tooltip=Remove all pod-mounted equipment and troop space to strip unit down to base omni chassis.
 FighterChassisView.chkDNICockpitMod.text=DNI Cockpit Modification
 FighterChassisView.chkDNICockpitMod.tooltip=<html>Direct Neural Interface cockpit modification (IO:AE p.62).<br/>Required for pilots with DNI implant. IS only.</html>
-AdvAeroChassisView.primitiveInfo.text=\   Primitive JS are constructed as WS
+AdvAeroChassisView.primitiveInfo.text=Primitive JS are constructed as WS
 DropshipChassisView.spnTonnage.text=Tonnage:
 DropshipChassisView.spnTonnage.tooltip=<html>Small Craft range 100-200 tons in 5 ton increments.<br/>Aerodyne Dropships range 200-35,000 tons in 100-ton increments.<br/>Spheroid Dropships range 200-100,000 tons in 100-ton increments.</html>
 DropshipChassisView.chkFunction.text=Military
@@ -187,7 +187,7 @@ AdvAeroChassisView.spnTonnage.tooltip=<html>Jumpships range 50,000-500,000 tons 
   \ range 100,000-2,500,000 tons in 10,000-ton increments.<br/>Space Stations range 2,000-2,500,000 tons in 500 ton \
   increments.<br/>Subcompact Warships range 5,000-25,000 tons in 100 ton increments.<BR>Primitive \
   JumpShips/WarShips have various tonnage limits depending on faction and introduction year.</html>
-AdvAeroChassisView.tonnageRange=\   Range: {0} - {1} tons
+AdvAeroChassisView.tonnageRange=Range: {0} - {1} tons
 AdvAeroChassisView.chkLFBattery.text=Lithium-Fusion Battery
 AdvAeroChassisView.chkLFBattery.tooltip=A lithium-fusion battery allows a ships to make a second jump before having to recharge.
 AdvAeroChassisView.chkSail.text=Sail
@@ -201,6 +201,7 @@ AdvAeroChassisView.chkMilitary.tooltip=A military space station can make more fr
 AdvAeroChassisView.cbBaseType.text=Vessel Type:
 AdvAeroChassisView.cbBaseType.tooltip=The type of unit being constructed.
 AdvAeroChassisView.cbBaseType.values=Jumpship,Warship,Space Station,Subcompact Warship
+AdvAeroChassisView.primitiveInfo.tooltip=IO:AE p.122
 AdvAeroChassisView.spnRange.text=Range (light years):
 AdvAeroChassisView.spnRange.tooltip=For each light year of jump range the mass of the drive core increase by 3% of the vessel tonnage.
 AdvAeroChassisView.spnSI.text=Structural Integrity:

--- a/megameklab/src/megameklab/ui/generalUnit/ArmorAllocationView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/ArmorAllocationView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -50,15 +50,7 @@ import javax.swing.UIManager;
 
 import megamek.common.equipment.ArmorType;
 import megamek.common.interfaces.ITechManager;
-import megamek.common.units.Aero;
-import megamek.common.units.Entity;
-import megamek.common.units.EntityWeightClass;
-import megamek.common.units.Jumpship;
-import megamek.common.units.Mek;
-import megamek.common.units.ProtoMek;
-import megamek.common.units.SuperHeavyTank;
-import megamek.common.units.Tank;
-import megamek.common.units.VTOL;
+import megamek.common.units.*;
 import megamek.common.verifier.TestEntity;
 import megamek.common.verifier.TestSupportVehicle;
 import megameklab.ui.generalUnit.ArmorLocationView.ArmorLocationListener;
@@ -225,8 +217,7 @@ public class ArmorAllocationView extends BuildView implements ArmorLocationListe
             final Integer maxArmor = UnitUtil.getMaxArmor(en, location);
             if (location < en.locations() && ((maxArmor == null) || (maxArmor > 0))) {
                 locView.setVisible(true);
-                locView.updateLocation(en.getLocationAbbr(location),
-                      en.hasRearArmor(location));
+                locView.updateLocation(en.getLocationAbbr(location), en.hasRearArmor(location));
                 locView.setMaxPoints(UnitUtil.getMaxArmor(en, location));
                 locView.setPoints(en.getArmor(location));
                 if (en.hasRearArmor(location)) {
@@ -234,8 +225,14 @@ public class ArmorAllocationView extends BuildView implements ArmorLocationListe
                 } else {
                     locView.setPointsRear(0);
                 }
-                if (en.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT) || en.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
-                    locView.setMinimum((int) (TestEntity.getSIBonusArmorPoints(en) / locationViews.size()));
+                if (en instanceof SmallCraft || en instanceof Jumpship) {
+                    double primitiveFactor = en.isPrimitive() ? 0.66 : 1;
+                    // As the SI bonus armor is multiplied by the primitive factor 0.66, primitive craft with little
+                    // armor tonnage may not be able to assign the bonus evenly per location, therefore the minimum
+                    // must be relaxed for those units, see IO:AE 3rd p.125 (Aquilla example calculation)
+                    locView.setMinimum((int) (TestEntity.getSIBonusArmorPoints(en)
+                          * primitiveFactor
+                          / locationViews.size()));
                 }
                 if (showPatchwork) {
                     double pointsPerTon = UnitUtil.getArmorPointsPerTon(en);
@@ -243,8 +240,7 @@ public class ArmorAllocationView extends BuildView implements ArmorLocationListe
                     if (en.hasRearArmor(location)) {
                         points += en.getArmor(location, true);
                     }
-                    locView.setToolTipText(String.format(tooltipFormat, pointsPerTon,
-                          points / pointsPerTon));
+                    locView.setToolTipText(String.format(tooltipFormat, pointsPerTon, points / pointsPerTon));
                 }
             } else {
                 locView.setVisible(false);
@@ -255,42 +251,44 @@ public class ArmorAllocationView extends BuildView implements ArmorLocationListe
         int maxArmorPoints = UnitUtil.getMaximumArmorPoints(en);
         int raw = (int) (TestEntity.getRawArmorPoints(en, en.getLabArmorTonnage())
               + TestEntity.getSIBonusArmorPoints(en));
-        int currentPoints = en.getTotalOArmor();
-        int armorPoints;
-        if (showPatchwork) {
-            armorPoints = currentPoints;
-            raw = currentPoints;
-            btnAutoAllocate.setEnabled(false);
-        } else {
-            armorPoints = Math.min(raw, maxArmorPoints);
-            btnAutoAllocate.setEnabled(true);
+
+        // The primitive armor factor of 0.66 is multiplied as the last part of the calculation after adding the base
+        // SI bonus and the base rounded armor, see IO:AE 3rd p.125 (Aquilla example calculation)
+        if ((en instanceof SmallCraft || en instanceof Jumpship) && en.isPrimitive()) {
+            raw = (int) (0.66 * raw);
         }
-        int wastedPoints = Math.max(0, raw - armorPoints);
-        txtUnallocated.setText(Integer.toString(armorPoints - currentPoints));
-        txtAllocated.setText(String.valueOf(currentPoints));
-        if (armorPoints != currentPoints) {
+        int allocatedPoints = en.getTotalOArmor();
+        int availableArmorPoints;
+        if (showPatchwork) {
+            availableArmorPoints = allocatedPoints;
+            raw = allocatedPoints;
+        } else {
+            availableArmorPoints = Math.min(raw, maxArmorPoints);
+        }
+        btnAutoAllocate.setEnabled(!showPatchwork);
+        int wastedPoints = Math.max(0, raw - availableArmorPoints);
+        txtUnallocated.setText(Integer.toString(availableArmorPoints - allocatedPoints));
+        txtAllocated.setText(Integer.toString(allocatedPoints));
+        if (availableArmorPoints != allocatedPoints) {
             txtUnallocated.setForeground(Color.RED);
         } else {
             txtUnallocated.setForeground(UIManager.getColor("Label.foreground"));
         }
-        txtTotal.setText(String.valueOf(armorPoints));
+        txtTotal.setText(String.valueOf(availableArmorPoints));
         txtMaxPossible.setText(String.valueOf(maxArmorPoints));
         txtWasted.setText(String.valueOf(wastedPoints));
         if (en.hasPatchworkArmor()) {
             txtPointsPerTon.setText("-");
         } else if (en.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
-            txtPointsPerTon.setText(String.format("%d",
-                  (int) (TestSupportVehicle.armorWeightPerPoint(en) * 1000)));
+            txtPointsPerTon.setText(String.format("%d", (int) (TestSupportVehicle.armorWeightPerPoint(en) * 1000)));
             lblPointsPerTon.setText(resourceMap.getString("ArmorAllocationView.txtKgPerPoint.text"));
             txtPointsPerTon.setToolTipText(resourceMap.getString("ArmorAllocationView.txtKgPerPoint.tooltip"));
         } else if (en instanceof ProtoMek) {
-            txtPointsPerTon.setText(String.format("%d",
-                  (int) (ArmorType.forEntity(en).getWeightPerPoint() * 1000)));
+            txtPointsPerTon.setText(String.format("%d", (int) (ArmorType.forEntity(en).getWeightPerPoint() * 1000)));
             lblPointsPerTon.setText(resourceMap.getString("ArmorAllocationView.txtKgPerPoint.text"));
             txtPointsPerTon.setToolTipText(resourceMap.getString("ArmorAllocationView.txtKgPerPoint.tooltip"));
         } else {
-            txtPointsPerTon.setText(String.format("%3.2f",
-                  UnitUtil.getArmorPointsPerTon(en)));
+            txtPointsPerTon.setText(String.format("%3.2f", UnitUtil.getArmorPointsPerTon(en)));
             lblPointsPerTon.setText(resourceMap.getString("ArmorAllocationView.txtPointsPerTon.text"));
             txtPointsPerTon.setToolTipText(resourceMap.getString("ArmorAllocationView.txtPointsPerTon.tooltip"));
         }

--- a/megameklab/src/megameklab/ui/generalUnit/ArmorAllocationView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/ArmorAllocationView.java
@@ -234,8 +234,7 @@ public class ArmorAllocationView extends BuildView implements ArmorLocationListe
                 } else {
                     locView.setPointsRear(0);
                 }
-                if (en.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)
-                      || en.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+                if (en.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT) || en.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
                     locView.setMinimum((int) (TestEntity.getSIBonusArmorPoints(en) / locationViews.size()));
                 }
                 if (showPatchwork) {

--- a/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
@@ -232,7 +232,7 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
             btnMaximize.setEnabled(false);
             btnUseRemaining.setEnabled(false);
         } else {
-            cbArmorType.setEnabled(true);
+            cbArmorType.setEnabled(cbArmorType.getItemCount() >= 2);
             tonnageModel.setValue(Math.min(UnitUtil.getMaximumArmorTonnage(en),
                   en.getLabArmorTonnage()));
             tonnageModel.setMaximum(UnitUtil.getMaximumArmorTonnage(en));
@@ -262,7 +262,6 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
             spnTonnage.setToolTipText(resourceMap.getString("ArmorView.spnTonnage.tooltip"));
             spnTonnage.setModel(tonnageModel);
         }
-        cbArmorType.setEnabled(cbArmorType.getItemCount() >= 2);
 
         cbArmorType.addActionListener(this);
         spnTonnage.addChangeListener(this);

--- a/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/MVFArmorView.java
@@ -262,6 +262,7 @@ public class MVFArmorView extends BuildView implements ActionListener, ChangeLis
             spnTonnage.setToolTipText(resourceMap.getString("ArmorView.spnTonnage.tooltip"));
             spnTonnage.setModel(tonnageModel);
         }
+        cbArmorType.setEnabled(cbArmorType.getItemCount() >= 2);
 
         cbArmorType.addActionListener(this);
         spnTonnage.addChangeListener(this);

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -143,7 +143,13 @@ public class DSMainUI extends MegaMekLabMainUI {
             if (loc == SmallCraft.LOC_HULL) {
                 newUnit.initializeArmor(IArmorState.ARMOR_NA, loc);
             } else {
+                // It is not absolutely clear from the rules if the bonus SI armor must be applied to each face
+                // evenly or is free for the player to assign (TM p.191, SO:AA p.140, IO:AE p.125). MML treats it as
+                // if it has to be assigned evenly, but for primitive armor the value per facing must be adapted
                 int armor = TestSmallCraft.getSIBonusArmorPoints(newUnit) / (newUnit.locations() - 1);
+                if (newUnit.isPrimitive()) {
+                    armor = (int) (armor * 0.66);
+                }
                 newUnit.initializeArmor(armor, loc);
             }
         }

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -48,6 +48,7 @@ import megamek.common.units.Dropship;
 import megamek.common.units.Entity;
 import megamek.common.units.EntityMovementMode;
 import megamek.common.units.SmallCraft;
+import megamek.common.verifier.TestSmallCraft;
 import megamek.logging.MMLogger;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
@@ -142,7 +143,8 @@ public class DSMainUI extends MegaMekLabMainUI {
             if (loc == SmallCraft.LOC_HULL) {
                 newUnit.initializeArmor(IArmorState.ARMOR_NA, loc);
             } else {
-                newUnit.initializeArmor(newUnit.getOSI(), loc);
+                int armor = TestSmallCraft.getSIBonusArmorPoints(newUnit) / (newUnit.locations() - 1);
+                newUnit.initializeArmor(armor, loc);
             }
         }
         if (null == oldUnit) {

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -146,11 +146,11 @@ public class DSMainUI extends MegaMekLabMainUI {
                 // It is not absolutely clear from the rules if the bonus SI armor must be applied to each face
                 // evenly or is free for the player to assign (TM p.191, SO:AA p.140, IO:AE p.125). MML treats it as
                 // if it has to be assigned evenly, but for primitive armor the value per facing must be adapted
-                int armor = TestSmallCraft.getSIBonusArmorPoints(newUnit) / (newUnit.locations() - 1);
+                int armor = TestSmallCraft.getSIBonusArmorPoints(newUnit);
                 if (newUnit.isPrimitive()) {
                     armor = (int) (armor * 0.66);
                 }
-                newUnit.initializeArmor(armor, loc);
+                newUnit.initializeArmor(armor / (newUnit.locations() - 1), loc);
             }
         }
         if (null == oldUnit) {

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -48,6 +48,7 @@ import megamek.common.units.Dropship;
 import megamek.common.units.Entity;
 import megamek.common.units.EntityMovementMode;
 import megamek.common.units.SmallCraft;
+import megamek.common.verifier.TestEntity;
 import megamek.common.verifier.TestSmallCraft;
 import megamek.logging.MMLogger;
 import megameklab.ui.MegaMekLabMainUI;
@@ -146,7 +147,7 @@ public class DSMainUI extends MegaMekLabMainUI {
                 // It is not absolutely clear from the rules if the bonus SI armor must be applied to each face
                 // evenly or is free for the player to assign (TM p.191, SO:AA p.140, IO:AE p.125). MML treats it as
                 // if it has to be assigned evenly, but for primitive armor the value per facing must be adapted
-                int armor = TestSmallCraft.getSIBonusArmorPoints(newUnit);
+                int armor = TestEntity.getSIBonusArmorPoints(newUnit);
                 if (newUnit.isPrimitive()) {
                     armor = (int) (armor * 0.66);
                 }

--- a/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -533,8 +533,13 @@ public class DSStructureTab extends ITab implements DropshipBuildListener, Armor
         }
 
         // divide armor (in excess of bonus from SI) among positions, with more toward the front
-        int bonusPerFacing = (int) (TestEntity.getSIBonusArmorPoints(getSmallCraft()) / armoredLocations);
-        int points = TestEntity.getArmorPoints(getSmallCraft()) - bonusPerFacing * 4;
+        int freeSiArmor = TestEntity.getSIBonusArmorPoints(getSmallCraft());
+        if (getSmallCraft().isPrimitive()) {
+            freeSiArmor = (int) (freeSiArmor * 0.66);
+        }
+        int freeSiArmorPerFacing = freeSiArmor / armoredLocations;
+        // freeSiArmorPerFacing is added to each location; due to integer division, this may be less than freeSiArmor!
+        int points = TestEntity.getArmorPoints(getSmallCraft()) - freeSiArmorPerFacing * armoredLocations;
         int nose = (int) Math.floor(points * 0.3);
         int wing = (int) Math.floor(points * 0.25);
         int aft = (int) Math.floor(points * 0.2);
@@ -553,10 +558,10 @@ public class DSStructureTab extends ITab implements DropshipBuildListener, Armor
                 wing++;
                 break;
         }
-        getSmallCraft().initializeArmor(nose + bonusPerFacing, Aero.LOC_NOSE);
-        getSmallCraft().initializeArmor(wing + bonusPerFacing, Aero.LOC_LEFT_WING);
-        getSmallCraft().initializeArmor(wing + bonusPerFacing, Aero.LOC_RIGHT_WING);
-        getSmallCraft().initializeArmor(aft + bonusPerFacing, Aero.LOC_AFT);
+        getSmallCraft().initializeArmor(nose + freeSiArmorPerFacing, Aero.LOC_NOSE);
+        getSmallCraft().initializeArmor(wing + freeSiArmorPerFacing, Aero.LOC_LEFT_WING);
+        getSmallCraft().initializeArmor(wing + freeSiArmorPerFacing, Aero.LOC_RIGHT_WING);
+        getSmallCraft().initializeArmor(aft + freeSiArmorPerFacing, Aero.LOC_AFT);
         getSmallCraft().autoSetThresh();
 
         panArmorAllocation.setFromEntity(getSmallCraft());

--- a/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSStructureTab.java
@@ -527,15 +527,14 @@ public class DSStructureTab extends ITab implements DropshipBuildListener, Armor
     @Override
     public void autoAllocateArmor() {
         // Ignore unarmored system-wide location
-        final int ARMOR_FACINGS = getSmallCraft().locations() - 1;
-        for (int loc = 0; loc < ARMOR_FACINGS; loc++) {
+        final int armoredLocations = getSmallCraft().locations() - 1;
+        for (int loc = 0; loc < armoredLocations; loc++) {
             getSmallCraft().initializeArmor(0, loc);
         }
 
         // divide armor (in excess of bonus from SI) among positions, with more toward the front
-        int bonusPerFacing = (int) TestEntity.getSIBonusArmorPoints(getSmallCraft()) / ARMOR_FACINGS;
-        int points = TestEntity.getArmorPoints(getSmallCraft())
-              - bonusPerFacing * 4;
+        int bonusPerFacing = (int) (TestEntity.getSIBonusArmorPoints(getSmallCraft()) / armoredLocations);
+        int points = TestEntity.getArmorPoints(getSmallCraft()) - bonusPerFacing * 4;
         int nose = (int) Math.floor(points * 0.3);
         int wing = (int) Math.floor(points * 0.25);
         int aft = (int) Math.floor(points * 0.2);

--- a/megameklab/src/megameklab/ui/largeAero/WSChassisView.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSChassisView.java
@@ -118,11 +118,11 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
         cbBaseType.setToolTipText(I18N.getString("AdvAeroChassisView.cbBaseType.tooltip"));
         primitiveLabel.putClientProperty(FlatClientProperties.STYLE_CLASS, "mini");
         primitiveLabel.setEnabled(false);
-        primitiveLabel.setBorder(new EmptyBorder(0, 0, 4, 0));
-        primitiveLabel.setToolTipText("IO:AE p.122");
+        primitiveLabel.setBorder(new EmptyBorder(0, 10, 4, 0));
+        primitiveLabel.setToolTipText(I18N.getString("AdvAeroChassisView.primitiveInfo.tooltip"));
         tonnageRangeLabel.putClientProperty(FlatClientProperties.STYLE_CLASS, "mini");
         tonnageRangeLabel.setEnabled(false);
-        tonnageRangeLabel.setBorder(new EmptyBorder(0, 0, 4, 0));
+        tonnageRangeLabel.setBorder(new EmptyBorder(0, 10, 4, 0));
         chkMilitary.setToolTipText(I18N.getString("AdvAeroChassisView.chkMilitary.tooltip"));
         chkLFBattery.setToolTipText(I18N.getString("AdvAeroChassisView.chkLFBattery.tooltip"));
         spnRange.setToolTipText(I18N.getString("AdvAeroChassisView.spnRange.tooltip"));

--- a/megameklab/src/megameklab/ui/largeAero/WSChassisView.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSChassisView.java
@@ -34,21 +34,24 @@ package megameklab.ui.largeAero;
 
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.ResourceBundle;
 import java.util.concurrent.CopyOnWriteArrayList;
+import javax.swing.Box;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
+import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import com.formdev.flatlaf.FlatClientProperties;
 import megamek.common.interfaces.ITechManager;
 import megamek.common.units.Aero;
 import megamek.common.units.Entity;
@@ -65,6 +68,9 @@ import megameklab.ui.listeners.AdvancedAeroBuildListener;
  * @author Neoancient
  */
 public class WSChassisView extends BuildView implements ActionListener, ChangeListener {
+
+    private static final ResourceBundle I18N = ResourceBundle.getBundle("megameklab.resources.Views");
+
     private final List<AdvancedAeroBuildListener> listeners = new CopyOnWriteArrayList<>();
 
     public void addListener(AdvancedAeroBuildListener l) {
@@ -83,16 +89,18 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
     private final SpinnerNumberModel spnTonnageModel = new SpinnerNumberModel(2000, 2000, null, 500);
     private final SpinnerNumberModel spnSIModel = new SpinnerNumberModel(1, 1, null, 1);
 
-    final private JSpinner spnTonnage = new JSpinner(spnTonnageModel);
-    final private JComboBox<String> cbBaseType = new JComboBox<>();
-    final private JLabel lblRange;
-    final private JSpinner spnRange = new JSpinner(new SpinnerNumberModel(15, 15, 30, 1));
-    final private JCheckBox chkLFBattery = new JCheckBox();
-    final private JCheckBox chkModular = new JCheckBox();
-    final private JCheckBox chkSail = new JCheckBox();
-    final private JCheckBox chkMilitary = new JCheckBox();
-    final private JSpinner spnSI = new JSpinner(spnSIModel);
-    final private ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
+    private final JSpinner spnTonnage = new JSpinner(spnTonnageModel);
+    private final JComboBox<String> cbBaseType = new JComboBox<>();
+    private final JLabel lblRange;
+    private final JSpinner spnRange = new JSpinner(new SpinnerNumberModel(15, 15, 30, 1));
+    private final JCheckBox chkLFBattery = new JCheckBox(I18N.getString("AdvAeroChassisView.chkLFBattery.text"));
+    private final JCheckBox chkModular = new JCheckBox(I18N.getString("AdvAeroChassisView.chkModular.text"));
+    private final JCheckBox chkSail = new JCheckBox(I18N.getString("AdvAeroChassisView.chkSail.text"));
+    private final JCheckBox chkMilitary = new JCheckBox(I18N.getString("AdvAeroChassisView.chkMilitary.text"));
+    private final JSpinner spnSI = new JSpinner(spnSIModel);
+
+    private final JLabel primitiveLabel = new JLabel(I18N.getString("AdvAeroChassisView.primitiveInfo.text"));
+    private final JLabel tonnageRangeLabel = new JLabel();
 
     private final ITechManager techManager;
     private int baseType;
@@ -103,104 +111,89 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
 
     public WSChassisView(ITechManager techManager) {
         this.techManager = techManager;
-        lblRange = createLabel("lblRange", "");
-        initUI();
-    }
 
-    public void initUI() {
+        lblRange = createLabel("lblRange", I18N.getString("AdvAeroChassisView.spnRange.text"));
+        spnTonnage.setToolTipText(I18N.getString("AdvAeroChassisView.spnTonnage.tooltip"));
+        chkSail.setToolTipText(I18N.getString("AdvAeroChassisView.chkSail.tooltip"));
+        cbBaseType.setToolTipText(I18N.getString("AdvAeroChassisView.cbBaseType.tooltip"));
+        primitiveLabel.putClientProperty(FlatClientProperties.STYLE_CLASS, "mini");
+        primitiveLabel.setEnabled(false);
+        primitiveLabel.setBorder(new EmptyBorder(0, 0, 4, 0));
+        primitiveLabel.setToolTipText("IO:AE p.122");
+        tonnageRangeLabel.putClientProperty(FlatClientProperties.STYLE_CLASS, "mini");
+        tonnageRangeLabel.setEnabled(false);
+        tonnageRangeLabel.setBorder(new EmptyBorder(0, 0, 4, 0));
+        chkMilitary.setToolTipText(I18N.getString("AdvAeroChassisView.chkMilitary.tooltip"));
+        chkLFBattery.setToolTipText(I18N.getString("AdvAeroChassisView.chkLFBattery.tooltip"));
+        spnRange.setToolTipText(I18N.getString("AdvAeroChassisView.spnRange.tooltip"));
+        spnSI.setToolTipText(I18N.getString("AdvAeroChassisView.spnSI.tooltip"));
+        chkModular.setToolTipText(I18N.getString("AdvAeroChassisView.chkModular.tooltip"));
+
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
-        cbBaseType.setModel(new DefaultComboBoxModel<>(resourceMap.getString("AdvAeroChassisView.cbBaseType.values")
-              .split(",")));
+        String[] typeNames = I18N.getString("AdvAeroChassisView.cbBaseType.values").split(",");
+        cbBaseType.setModel(new DefaultComboBoxModel<>(typeNames));
 
-        gbc.anchor = GridBagConstraints.NORTHWEST;
-        gbc.insets = new Insets(5, 5, 5, 5);
-
-        gbc.gridx = 0;
-        gbc.gridy = 0;
-        gbc.gridwidth = 2;
-        add(createLabel(resourceMap, "lblTonnage", "AdvAeroChassisView.spnTonnage.text",
-              "AdvAeroChassisView.spnTonnage.tooltip"), gbc);
-        gbc.gridx = 2;
-        gbc.gridy = 0;
-        gbc.gridwidth = 2;
+        gbc.anchor = GridBagConstraints.EAST;
+        gbc.insets = STANDARD_INSETS;
         gbc.fill = GridBagConstraints.HORIZONTAL;
-        spnTonnage.setToolTipText(resourceMap.getString("AdvAeroChassisView.spnTonnage.tooltip"));
-        add(spnTonnage, gbc);
-        spnTonnage.addChangeListener(this);
 
-        chkSail.setText(resourceMap.getString("AdvAeroChassisView.chkSail.text"));
-        gbc.gridx = 4;
         gbc.gridy = 0;
-        gbc.fill = GridBagConstraints.NONE;
-        gbc.gridwidth = 1;
-        chkSail.setToolTipText(resourceMap.getString("AdvAeroChassisView.chkSail.tooltip"));
-        add(chkSail, gbc);
-        chkSail.addActionListener(this);
-
-        gbc.gridx = 0;
-        gbc.gridy = 1;
-        gbc.gridwidth = 2;
-        add(createLabel(resourceMap, "lblBaseType", "AdvAeroChassisView.cbBaseType.text",
+        add(createLabel(I18N,
+              "lblBaseType",
+              "AdvAeroChassisView.cbBaseType.text",
               "AdvAeroChassisView.cbBaseType.tooltip"), gbc);
-        gbc.gridx = 2;
-        gbc.gridy = 1;
-        gbc.gridwidth = 2;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        cbBaseType.setToolTipText(resourceMap.getString("AdvAeroChassisView.cbBaseType.tooltip"));
         add(cbBaseType, gbc);
-        cbBaseType.addActionListener(this);
 
-        chkMilitary.setText(resourceMap.getString("AdvAeroChassisView.chkMilitary.text"));
-        gbc.gridx = 4;
-        gbc.gridy = 1;
-        gbc.fill = GridBagConstraints.NONE;
-        gbc.gridwidth = 1;
-        chkMilitary.setToolTipText(resourceMap.getString("AdvAeroChassisView.chkMilitary.tooltip"));
-        add(chkMilitary, gbc);
-        chkMilitary.addActionListener(this);
+        gbc.gridy++;
+        add(new JLabel(), gbc);
+        add(primitiveLabel, gbc);
 
-        chkLFBattery.setText(resourceMap.getString("AdvAeroChassisView.chkLFBattery.text"));
-        gbc.gridx = 2;
-        gbc.gridy = 2;
-        gbc.fill = GridBagConstraints.NONE;
-        gbc.gridwidth = 2;
-        chkLFBattery.setToolTipText(resourceMap.getString("AdvAeroChassisView.chkLFBattery.tooltip"));
-        add(chkLFBattery, gbc);
-        chkLFBattery.addActionListener(this);
+        gbc.gridy++;
+        add(createLabel(I18N,
+              "lblTonnage",
+              "AdvAeroChassisView.spnTonnage.text",
+              "AdvAeroChassisView.spnTonnage.tooltip"), gbc);
+        add(spnTonnage, gbc);
 
-        gbc.gridx = 0;
-        gbc.gridy = 3;
-        lblRange.setText(resourceMap.getString("AdvAeroChassisView.spnRange.text"));
-        gbc.gridwidth = 2;
-        add(lblRange, gbc);
-        gbc.gridx = 2;
-        gbc.gridy = 3;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        gbc.gridwidth = 2;
-        spnRange.setToolTipText(resourceMap.getString("AdvAeroChassisView.spnRange.tooltip"));
-        add(spnRange, gbc);
-        spnRange.addChangeListener(this);
+        gbc.gridy++;
+        add(new JLabel(), gbc);
+        add(tonnageRangeLabel, gbc);
 
-        gbc.gridx = 0;
-        gbc.gridy = 4;
-        gbc.gridwidth = 2;
-        add(createLabel(resourceMap, "lblSI", "AdvAeroChassisView.spnSI.text",
-              "AdvAeroChassisView.spnSI.tooltip"), gbc);
-        gbc.gridx = 2;
-        gbc.gridy = 4;
-        gbc.gridwidth = 2;
-        spnSI.setToolTipText(resourceMap.getString("AdvAeroChassisView.spnSI.tooltip"));
+        gbc.gridy++;
+        add(createLabel(I18N, "lblSI", "AdvAeroChassisView.spnSI.text", "AdvAeroChassisView.spnSI.tooltip"), gbc);
         add(spnSI, gbc);
-        spnSI.addChangeListener(this);
 
-        chkModular.setText(resourceMap.getString("AdvAeroChassisView.chkModular.text"));
-        gbc.gridx = 4;
-        gbc.gridy = 4;
-        gbc.fill = GridBagConstraints.NONE;
-        gbc.gridwidth = 1;
-        chkModular.setToolTipText(resourceMap.getString("AdvAeroChassisView.chkModular.tooltip"));
+        gbc.gridy++;
+        add(Box.createVerticalStrut(4), gbc);
+
+        gbc.gridy++;
+        add(new JLabel(), gbc);
+        add(chkSail, gbc);
+
+        gbc.gridy++;
+        add(new JLabel(), gbc);
+        add(chkMilitary, gbc);
+
+        gbc.gridy++;
+        add(new JLabel(), gbc);
+        add(chkLFBattery, gbc);
+
+        gbc.gridy++;
+        add(lblRange, gbc);
+        add(spnRange, gbc);
+
+        gbc.gridy++;
+        add(new JLabel(), gbc);
         add(chkModular, gbc);
+
+        spnTonnage.addChangeListener(this);
+        chkSail.addActionListener(this);
+        cbBaseType.addActionListener(this);
+        chkMilitary.addActionListener(this);
+        chkLFBattery.addActionListener(this);
+        spnRange.addChangeListener(this);
+        spnSI.addChangeListener(this);
         chkModular.addActionListener(this);
     }
 
@@ -242,11 +235,11 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
               && ((SpaceStation) craft).isModularOrKFAdapter());
         chkModular.addActionListener(this);
 
-
         cbBaseType.removeActionListener(this);
         cbBaseType.setSelectedIndex(baseType);
         cbBaseType.addActionListener(this);
         cbBaseType.setEnabled(!craft.isPrimitive());
+        primitiveLabel.setVisible(craft.isPrimitive());
 
         spnSIModel.setValue(craft.getOSI());
         if (craft.isPrimitive()) {
@@ -266,6 +259,9 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
         }
         lblRange.setVisible(craft.isPrimitive());
         spnRange.setVisible(craft.isPrimitive());
+        tonnageRangeLabel.setText(MessageFormat.format(
+              I18N.getString("AdvAeroChassisView.tonnageRange"), minTonnage, maxTonnage));
+
     }
 
     public void setAsCustomization() {
@@ -276,23 +272,22 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
     public void refresh() {
         refreshTonnage();
         refreshSI();
-        chkLFBattery.setVisible((baseType != TYPE_STATION)
-              && techManager.isLegal(Jumpship.getLFBatteryTA()));
+        chkLFBattery.setVisible((baseType != TYPE_STATION) && techManager.isLegal(Jumpship.getLFBatteryTA()));
         chkMilitary.setVisible((baseType == TYPE_STATION));
         if (baseType == TYPE_STATION) {
             if ((getTonnage() <= SpaceStation.MODULAR_MINIMUM_WEIGHT)
                   && techManager.isLegal(SpaceStation.getKFAdapterTA())) {
-                chkModular.setText(resourceMap.getString("AdvAeroChassisView.chkKFAdapter.text"));
-                chkModular.setToolTipText(resourceMap.getString("AdvAeroChassisView.chkKFAdapter.tooltip"));
+                chkModular.setText(I18N.getString("AdvAeroChassisView.chkKFAdapter.text"));
+                chkModular.setToolTipText(I18N.getString("AdvAeroChassisView.chkKFAdapter.tooltip"));
             } else if ((getTonnage() > SpaceStation.MODULAR_MINIMUM_WEIGHT)
                   && techManager.isLegal(SpaceStation.getModularTA())) {
-                chkModular.setText(resourceMap.getString("AdvAeroChassisView.chkModular.text"));
-                chkModular.setToolTipText(resourceMap.getString("AdvAeroChassisView.chkModular.tooltip"));
+                chkModular.setText(I18N.getString("AdvAeroChassisView.chkModular.text"));
+                chkModular.setToolTipText(I18N.getString("AdvAeroChassisView.chkModular.tooltip"));
             }
         }
-        chkModular.setVisible((baseType == TYPE_STATION)
-              && techManager.isLegal(getTonnage() <= 100000.0 ?
-              SpaceStation.getKFAdapterTA() : SpaceStation.getModularTA()));
+        chkModular.setVisible((baseType == TYPE_STATION) && techManager.isLegal(getTonnage() <= 100000.0
+              ? SpaceStation.getKFAdapterTA()
+              : SpaceStation.getModularTA()));
     }
 
     private void refreshTonnage() {
@@ -336,10 +331,6 @@ public class WSChassisView extends BuildView implements ActionListener, ChangeLi
 
     public boolean hasLFBattery() {
         return chkLFBattery.isSelected() && chkLFBattery.isEnabled();
-    }
-
-    public void setLFBattery(boolean battery) {
-        chkLFBattery.setSelected(battery);
     }
 
     public void setMaxThrust(int maxThrust) {

--- a/megameklab/src/megameklab/ui/largeAero/WSChassisView.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSChassisView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -572,16 +572,20 @@ public class WSStructureTab extends ITab implements AdvancedAeroBuildListener, A
     @Override
     public void autoAllocateArmor() {
         // ignore unarmored system-wide location and warship broadsides
-        final int ARMOR_FACINGS = getJumpship() instanceof Warship ?
+        final int armorFacings = getJumpship() instanceof Warship ?
               getJumpship().locations() - 3 : getJumpship().locations() - 1;
-        for (int loc = 0; loc < ARMOR_FACINGS; loc++) {
+        for (int loc = 0; loc < armorFacings; loc++) {
             getJumpship().initializeArmor(0, loc);
         }
 
         // divide armor (in excess of bonus from SI) among positions, with more toward the front
-        int bonusPerFacing = (int) Math.floor(TestEntity.getSIBonusArmorPoints(getJumpship()) / ARMOR_FACINGS);
-        int points = TestEntity.getArmorPoints(getJumpship())
-              - bonusPerFacing * 6;
+        int freeSiArmor = TestEntity.getSIBonusArmorPoints(getJumpship());
+        if (getJumpship().isPrimitive()) {
+            freeSiArmor = (int) (freeSiArmor * 0.66);
+        }
+        int freeSiArmorPerFacing = freeSiArmor / armorFacings;
+        // freeSiArmorPerFacing is added to each location; due to integer division, this may be less than freeSiArmor!
+        int points = TestEntity.getArmorPoints(getJumpship()) - freeSiArmorPerFacing * armorFacings;
         int nose = (int) Math.floor(points * 0.22);
         int foreSides = (int) Math.floor(points * 0.18);
         int aftSides = (int) Math.floor(points * 0.16);
@@ -609,12 +613,12 @@ public class WSStructureTab extends ITab implements AdvancedAeroBuildListener, A
                 foreSides++;
                 break;
         }
-        getJumpship().initializeArmor(nose + bonusPerFacing, Jumpship.LOC_NOSE);
-        getJumpship().initializeArmor(foreSides + bonusPerFacing, Jumpship.LOC_FRS);
-        getJumpship().initializeArmor(foreSides + bonusPerFacing, Jumpship.LOC_FLS);
-        getJumpship().initializeArmor(aftSides + bonusPerFacing, Jumpship.LOC_ARS);
-        getJumpship().initializeArmor(aftSides + bonusPerFacing, Jumpship.LOC_ALS);
-        getJumpship().initializeArmor(aft + bonusPerFacing, Jumpship.LOC_AFT);
+        getJumpship().initializeArmor(nose + freeSiArmorPerFacing, Jumpship.LOC_NOSE);
+        getJumpship().initializeArmor(foreSides + freeSiArmorPerFacing, Jumpship.LOC_FRS);
+        getJumpship().initializeArmor(foreSides + freeSiArmorPerFacing, Jumpship.LOC_FLS);
+        getJumpship().initializeArmor(aftSides + freeSiArmorPerFacing, Jumpship.LOC_ARS);
+        getJumpship().initializeArmor(aftSides + freeSiArmorPerFacing, Jumpship.LOC_ALS);
+        getJumpship().initializeArmor(aft + freeSiArmorPerFacing, Jumpship.LOC_AFT);
         getJumpship().autoSetThresh();
 
         panArmorAllocation.setFromEntity(getJumpship());

--- a/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
@@ -475,6 +475,7 @@ public class WSStructureTab extends ITab implements AdvancedAeroBuildListener, A
         getJumpship().setSail(sail);
         refresh.refreshPreview();
         refresh.refreshStatus();
+        panSummary.refresh();
     }
 
     @Override


### PR DESCRIPTION
Requires Megamek/megamek#8034
Fixes #2105 

From the example on IO:AE 3rd p.125 which is pretty clear, for once, I take it that the primitive aero armor calculations were (still) incorrect. Specifically, the primitive factor 0.66 cannot be rolled into points per tonnage values. Instead, the total SI bonus and the total armor using standard armor values must be added, rounded down and then multiplied by 0.66 and rounded down again. So, this PR sets out to correct things. This requires a lot of updated calculations. 
For capital craft especially there can be redundant armor, i.e. removing 0.5 t or even more of armor does not decrease the armor points. For these, loading the unit always comes up short on armor tonnage. Therefore, this PR adds the tonnage as a value saved to blk files, but only if the armor tonnage would be loaded incorrectly.
Also, for primitive JS, the armor type selector is now disabled, as the armor type is locked in anyway. From my personal experience working on this, I changed the JS/WS chassis view to be more helpful, see screenshot for primitive JS.
I am still unclear if SI bonus armor is free to be distributed or is locked in per facing. I kept it as locked in but added adaptations for primitive craft where the SI bonus gets multiplied down.
<img width="515" height="334" alt="image" src="https://github.com/user-attachments/assets/2598704b-0280-4386-95eb-3fc9d69c2745" />
