### PR TITLE
MML#1449 remove bays

### DIFF
--- a/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
@@ -78,6 +78,7 @@ import megameklab.ui.listeners.BABuildListener;
 import megameklab.ui.util.CustomComboBox;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
+import megameklab.util.BattleArmorUtil;
 import megameklab.util.UnitUtil;
 
 /**
@@ -572,7 +573,7 @@ public class BAStructureTab extends ITab
     @Override
     public void chassisTypeChanged(int chassisType) {
         getBattleArmor().setChassisType(chassisType);
-        UnitUtil.removeAllCriticalSlotsFrom(getBattleArmor(),
+        BattleArmorUtil.removeAllCriticalSlotsFrom(getBattleArmor(),
               List.of(BattleArmor.MOUNT_LOC_LEFT_ARM, BattleArmor.MOUNT_LOC_RIGHT_ARM, BattleArmor.MOUNT_LOC_TURRET));
         panBasicInfo.setFromEntity(getBattleArmor());
         panChassis.setFromEntity(getBattleArmor());

--- a/megameklab/src/megameklab/ui/fighterAero/ASBuildTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASBuildTab.java
@@ -41,9 +41,6 @@ import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 
-import megamek.common.equipment.Mounted;
-import megamek.common.units.Entity;
-import megamek.common.verifier.TestAero;
 import megameklab.ui.EntitySource;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
@@ -111,19 +108,10 @@ public class ASBuildTab extends ITab implements ActionListener {
         }
     }
 
-
     private void resetCrits() {
-        for (Mounted<?> mount : getAero().getEquipment()) {
-            if (!mount.isWeaponGroup() && TestAero.eqRequiresLocation(mount.getType(), true)
-                  && !UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
-                UnitUtil.removeCriticalSlots(getAero(), mount);
-                UnitUtil.changeMountStatus(getAero(), mount, Entity.LOC_NONE, Entity.LOC_NONE, false);
-            }
-        }
-
+        UnitUtil.removeAllCriticalSlots(getAero());
         refresh.scheduleRefresh();
     }
-
 
     public void removeAllActionListeners() {
         resetButton.removeActionListener(this);

--- a/megameklab/src/megameklab/util/AeroUtil.java
+++ b/megameklab/src/megameklab/util/AeroUtil.java
@@ -44,6 +44,7 @@ import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponType;
 import megamek.common.units.Aero;
+import megamek.common.units.AeroSpaceFighter;
 import megamek.common.units.Dropship;
 import megamek.common.units.Entity;
 import megamek.common.units.SmallCraft;
@@ -333,6 +334,21 @@ public final class AeroUtil {
         List<Mounted<?>> weaponGroups = new ArrayList<>(unit.getWeaponGroupList());
         for (Mounted<?> group : weaponGroups) {
             UnitUtil.removeMounted(unit, group);
+        }
+    }
+
+    /**
+     * Removes all critical slots for the given fighter, unallocating all equipment (i.e., placing it into
+     * Entity.LOC_NONE) with the exception of certain equipment that has a fixed location such as Ammo.
+     */
+    public static void removeAllCriticalSlotsFromFighter(AeroSpaceFighter aero) {
+        for (Mounted<?> mount : aero.getEquipment()) {
+            if (!mount.isWeaponGroup()
+                  && TestAero.eqRequiresLocation(mount.getType(), true)
+                  && !UnitUtil.isFixedLocationSpreadEquipment(mount.getType())) {
+                UnitUtil.removeCriticalSlots(aero, mount);
+                UnitUtil.changeMountStatus(aero, mount, Entity.LOC_NONE, Entity.LOC_NONE, false);
+            }
         }
     }
 

--- a/megameklab/src/megameklab/util/BattleArmorUtil.java
+++ b/megameklab/src/megameklab/util/BattleArmorUtil.java
@@ -46,6 +46,7 @@ import megamek.common.weapons.attacks.SwarmAttack;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
 import java.util.List;
+import java.util.stream.IntStream;
 
 public final class BattleArmorUtil {
 
@@ -137,6 +138,13 @@ public final class BattleArmorUtil {
         return (equip instanceof WeaponType)
               && (equip.hasFlag(WeaponType.F_TASER) || (((WeaponType) equip).getAmmoType()
               == AmmoType.AmmoTypeEnum.NARC));
+    }
+
+    /**
+     * Removes all critical slots for the given BA, unallocating all equipment (i.e., placing it into Entity.LOC_NONE).
+     */
+    public static void removeAllCriticalSlotsFrom(BattleArmor battleArmor) {
+        removeAllCriticalSlotsFrom(battleArmor, IntStream.range(0, battleArmor.locations()).boxed().toList());
     }
 
     /**

--- a/megameklab/src/megameklab/util/BattleArmorUtil.java
+++ b/megameklab/src/megameklab/util/BattleArmorUtil.java
@@ -141,7 +141,8 @@ public final class BattleArmorUtil {
     }
 
     /**
-     * Removes all critical slots for the given BA, unallocating all equipment (i.e., placing it into Entity.LOC_NONE).
+     * Removes all critical slots for the given BA, unallocating all equipment (i.e., placing it into
+     * BattleArmor.MOUNT_LOC_NONE and BattleArmor.LOC_SQUAD).
      */
     public static void removeAllCriticalSlotsFrom(BattleArmor battleArmor) {
         removeAllCriticalSlotsFrom(battleArmor, IntStream.range(0, battleArmor.locations()).boxed().toList());
@@ -149,7 +150,7 @@ public final class BattleArmorUtil {
 
     /**
      * Removes all critical slots from the given locations for the given BA, unallocating all equipment in those
-     * locations (i.e., placing it into Entity.LOC_NONE).
+     * locations (i.e., placing it into BattleArmor.MOUNT_LOC_NONE and BattleArmor.LOC_SQUAD).
      */
     public static void removeAllCriticalSlotsFrom(BattleArmor battleArmor, List<Integer> locations) {
         battleArmor.getEquipment()

--- a/megameklab/src/megameklab/util/BattleArmorUtil.java
+++ b/megameklab/src/megameklab/util/BattleArmorUtil.java
@@ -45,6 +45,8 @@ import megamek.common.weapons.attacks.StopSwarmAttack;
 import megamek.common.weapons.attacks.SwarmAttack;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
+import java.util.List;
+
 public final class BattleArmorUtil {
 
     /**
@@ -135,6 +137,22 @@ public final class BattleArmorUtil {
         return (equip instanceof WeaponType)
               && (equip.hasFlag(WeaponType.F_TASER) || (((WeaponType) equip).getAmmoType()
               == AmmoType.AmmoTypeEnum.NARC));
+    }
+
+    /**
+     * Removes all critical slots from the given locations for the given BA, unallocating all equipment in those
+     * locations (i.e., placing it into Entity.LOC_NONE).
+     */
+    public static void removeAllCriticalSlotsFrom(BattleArmor battleArmor, List<Integer> locations) {
+        battleArmor.getEquipment()
+              .stream()
+              .filter(m -> (m != null) && (m.getBaMountLoc() != BattleArmor.MOUNT_LOC_NONE))
+              .filter(m -> !UnitUtil.isFixedLocationSpreadEquipment(m.getType()))
+              .filter(m -> locations.contains(m.getBaMountLoc()))
+              .forEach(m -> {
+                  m.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
+                  UnitUtil.changeMountStatus(battleArmor, m, BattleArmor.LOC_SQUAD, BattleArmor.LOC_SQUAD, false);
+              });
     }
 
     private BattleArmorUtil() {

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -44,7 +44,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 
@@ -420,74 +419,47 @@ public class UnitUtil {
     }
 
     /**
-     * Removes all critical slots of the given unit, unallocating all equipment (i.e., placing it into Entity.LOC_NONE).
+     * Removes all critical slots of the given unit, unallocating most equipment (i.e., placing it into Entity
+     * .LOC_NONE). Generally, equipment that does not make sense when unallocated is either deleted or left in its
+     * location. Depending on unit type, ammo is left in place when its placement is not free (fighters). Unallocated
+     * Clan CASE is removed (but all other forms of CASE/CASE II/CASE-P are not). Weapon bays are deleted.
      */
     public static void removeAllCriticalSlots(Entity unit) {
-        removeAllCriticalSlotsFrom(unit, IntStream.range(0, unit.locations()).boxed().toList());
+        if (unit instanceof AeroSpaceFighter fighter) {
+            AeroUtil.removeAllCriticalSlotsFromFighter(fighter);
+        } else if (unit instanceof BattleArmor battleArmor) {
+            BattleArmorUtil.removeAllCriticalSlotsFrom(battleArmor);
+        } else {
+            // weapon bays can never be outside of their location, so delete them
+            List<Mounted<?>> weaponBays =
+                  unit.getEquipment().stream()
+                        .filter(m -> m.getType() instanceof BayWeapon)
+                        .toList();
+            // removeMounted modifies the equipment list, therefore need to create a separate weaponBay list!
+            weaponBays.forEach(mounted -> removeMounted(unit, mounted));
 
-        // cleanup of remnants if any (should not be needed, but we never know)
-        unit.getEquipment()
-              .stream()
-              .filter(m -> (m != null) &&
-                    (m.getLocation() != Entity.LOC_NONE) &&
-                    (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
-              .forEach(m -> {
-                  UnitUtil.removeCriticalSlots(unit, m);
-                  UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
-              });
-    }
-
-    /**
-     * Removes all critical slots from the given locations for the given unit, unallocating all equipment in those
-     * locations (i.e., placing it into Entity.LOC_NONE).
-     */
-    public static void removeAllCriticalSlotsFrom(Entity unit, List<Integer> locations) {
-        if (unit instanceof BattleArmor battleArmor) {
-            BattleArmorUtil.removeAllCriticalSlotsFrom(battleArmor, locations);
-            return;
-        }
-
-        // weapon bays can never be outside of their location, so delete them
-        List<Mounted<?>> weaponBays =
-              unit.getEquipment().stream()
-                    .filter(m -> m.getType() instanceof BayWeapon)
-                    .filter(m -> locations.contains(m.getLocation()))
-                    .toList();
-        // removeMounted modifies the equipment list, therefore need to create a separate weaponBay list!
-        weaponBays.forEach(mounted -> UnitUtil.removeMounted(unit, mounted));
-
-        // first we remove all criticalSlots
-        for (int loc = 0; loc < unit.locations(); loc++) {
-            if (!locations.contains(loc)) {
-                continue;
-            }
-            for (int i = 0; i < unit.getNumberOfCriticalSlots(loc); i++) {
-                CriticalSlot cs = unit.getCritical(loc, i);
-                if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
-                    Mounted<?> m1 = cs.getMount();
-                    Mounted<?> m2 = cs.getMount2();
-                    if ((m2 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m2.getType()))) {
-                        UnitUtil.removeCriticalSlots(unit, m2);
-                        UnitUtil.changeMountStatus(unit, m2, Entity.LOC_NONE, Entity.LOC_NONE, false);
-                    }
-                    if ((m1 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m1.getType()))) {
-                        UnitUtil.removeCriticalSlots(unit, m1);
-                        UnitUtil.changeMountStatus(unit, m1, Entity.LOC_NONE, Entity.LOC_NONE, false);
+            // now, remove all non-special crit slots
+            for (int loc = 0; loc < unit.locations(); loc++) {
+                for (int i = 0; i < unit.getNumberOfCriticalSlots(loc); i++) {
+                    CriticalSlot cs = unit.getCritical(loc, i);
+                    if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
+                        Mounted<?> m1 = cs.getMount();
+                        Mounted<?> m2 = cs.getMount2();
+                        if ((m2 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m2.getType()))) {
+                            UnitUtil.removeCriticalSlots(unit, m2);
+                            UnitUtil.changeMountStatus(unit, m2, Entity.LOC_NONE, Entity.LOC_NONE, false);
+                        }
+                        if ((m1 != null) && (!UnitUtil.isFixedLocationSpreadEquipment(m1.getType()))) {
+                            UnitUtil.removeCriticalSlots(unit, m1);
+                            UnitUtil.changeMountStatus(unit, m1, Entity.LOC_NONE, Entity.LOC_NONE, false);
+                        }
                     }
                 }
             }
         }
 
-        // cleanup of remnants if any (should not be needed, but we never know)
-        unit.getEquipment()
-              .stream()
-              .filter(m -> (m != null) && locations.contains(m.getLocation()))
-              .filter(m -> (m.getLocation() != Entity.LOC_NONE) &&
-                    (!UnitUtil.isFixedLocationSpreadEquipment(m.getType())))
-              .forEach(m -> {
-                  UnitUtil.removeCriticalSlots(unit, m);
-                  UnitUtil.changeMountStatus(unit, m, Entity.LOC_NONE, Entity.LOC_NONE, false);
-              });
+        // Clan CASE is automatic and should not end up unallocated
+        removeAllMounted(unit, EquipmentType.get(EquipmentTypeLookup.CLAN_CASE));
     }
 
     /**

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -420,9 +420,9 @@ public class UnitUtil {
     }
 
     /**
-     * Removes all criticalSlots of the given unit.
+     * Removes all critical slots of the given unit, unallocating all equipment (i.e., placing it into Entity.LOC_NONE).
      */
-    synchronized public static void removeAllCriticalSlots(Entity unit) {
+    public static void removeAllCriticalSlots(Entity unit) {
         removeAllCriticalSlotsFrom(unit, IntStream.range(0, unit.locations()).boxed().toList());
 
         // cleanup of remnants if any (should not be needed, but we never know)
@@ -438,21 +438,24 @@ public class UnitUtil {
     }
 
     /**
-     * Removes all criticalSlots from the given locations for the given unit.
+     * Removes all critical slots from the given locations for the given unit, unallocating all equipment in those
+     * locations (i.e., placing it into Entity.LOC_NONE).
      */
-    synchronized public static void removeAllCriticalSlotsFrom(Entity unit, List<Integer> locations) {
-        // Special handling for BattleArmor
-        if (unit instanceof BattleArmor ba) {
-            ba.getEquipment()
-                  .stream()
-                  .filter(m -> (m != null) && (m.getBaMountLoc() != BattleArmor.MOUNT_LOC_NONE))
-                  .filter(m -> locations.contains(m.getBaMountLoc()))
-                  .forEach(m -> {
-                      m.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
-                      UnitUtil.changeMountStatus(unit, m, BattleArmor.LOC_SQUAD, BattleArmor.LOC_SQUAD, false);
-                  });
+    public static void removeAllCriticalSlotsFrom(Entity unit, List<Integer> locations) {
+        if (unit instanceof BattleArmor battleArmor) {
+            BattleArmorUtil.removeAllCriticalSlotsFrom(battleArmor, locations);
             return;
         }
+
+        // weapon bays can never be outside of their location, so delete them
+        List<Mounted<?>> weaponBays =
+              unit.getEquipment().stream()
+                    .filter(m -> m.getType() instanceof BayWeapon)
+                    .filter(m -> locations.contains(m.getLocation()))
+                    .toList();
+        // removeMounted modifies the equipment list, therefore need to create a separate weaponBay list!
+        weaponBays.forEach(mounted -> UnitUtil.removeMounted(unit, mounted));
+
         // first we remove all criticalSlots
         for (int loc = 0; loc < unit.locations(); loc++) {
             if (!locations.contains(loc)) {
@@ -474,6 +477,7 @@ public class UnitUtil {
                 }
             }
         }
+
         // cleanup of remnants if any (should not be needed, but we never know)
         unit.getEquipment()
               .stream()

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -419,10 +419,10 @@ public class UnitUtil {
     }
 
     /**
-     * Removes all critical slots of the given unit, unallocating most equipment (i.e., placing it into Entity
-     * .LOC_NONE). Generally, equipment that does not make sense when unallocated is either deleted or left in its
-     * location. Depending on unit type, ammo is left in place when its placement is not free (fighters). Unallocated
-     * Clan CASE is removed (but all other forms of CASE/CASE II/CASE-P are not). Weapon bays are deleted.
+     * Removes all critical slots of the given unit, unallocating most equipment (i.e., placing it into
+     * {@code Entity.LOC_NONE}. Generally, equipment that does not make sense when unallocated is either deleted or left
+     * in its location. Depending on unit type, ammo is left in place when its placement is not free (fighters).
+     * Unallocated Clan CASE is removed (but all other forms of CASE/CASE II/CASE-P are not). Weapon bays are deleted.
      */
     public static void removeAllCriticalSlots(Entity unit) {
         if (unit instanceof AeroSpaceFighter fighter) {


### PR DESCRIPTION
Fixes #1449 
When removing all equipment crits ("Reset"), deletes weapon bays so they dont become unallocated.
Additionally, C-CASE is now deleted when unallocated.

Also some moving around of code between the Utils. I also removed some generic "cleanup" code that only serves to mask errors. 

It's easy to notice that the Reset buttons on the various unit types still have numerous issues with special equipment but I didn't want this to become another WarShip of a PR.