### PR TITLE
BA construction and manipulators

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -413,6 +413,11 @@ BAEnhancementView.chkDNICockpitMod.text=DNI Cockpit Modification
 BAEnhancementView.chkDNICockpitMod.tooltip=<html>Direct Neural Interface cockpit modification (IO:AE p.62).<br/>Required for pilots with DNI implant. IS only.</html>
 BAEnhancementView.chkEIInterface.text=Enhanced Imaging Interface
 BAEnhancementView.chkEIInterface.tooltip=<html>Enhanced Imaging (EI) Interface (IO:AE p.69).<br/>Allows use of EI implant abilities. Clan only, Experimental.</html>
+
+BAManipulatorView.leftArm=Left Arm:
+BAManipulatorView.rightArm=Right Arm:
+BAManipulatorView.cargoCapacity=Capacity:
+
 DropshipCriticalView.aerodyneArcs.values=Nose,Left Wing,Right Wing,Aft,Hull
 DropshipCriticalView.spheroidArcs.values=Nose,Forward Left,Forward Right,Aft,Hull,Aft Left,Aft Right,-,-
 DropshipCriticalView.capitalArcs.values=Nose,Forward Left,Forward Right,Aft,Aft Left,Aft Right,Hull,Left Broadside,Right Broadside

--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -417,6 +417,8 @@ BAEnhancementView.chkEIInterface.tooltip=<html>Enhanced Imaging (EI) Interface (
 BAManipulatorView.leftArm=Left Arm:
 BAManipulatorView.rightArm=Right Arm:
 BAManipulatorView.cargoCapacity=Capacity:
+BAManipulatorView.mea=Modular Equipment Adaptor
+BAManipulatorView.meaCannotAdd=Not enough room to add a Modular Equipment Adaptor!
 
 DropshipCriticalView.aerodyneArcs.values=Nose,Left Wing,Right Wing,Aft,Hull
 DropshipCriticalView.spheroidArcs.values=Nose,Forward Left,Forward Right,Aft,Hull,Aft Left,Aft Right,-,-

--- a/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
@@ -59,6 +59,7 @@ import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponType;
+import megamek.common.units.BaConstructionUtil;
 import megamek.common.verifier.TestBattleArmor;
 import megamek.common.weapons.Weapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -486,7 +487,7 @@ public class BABuildView extends IView implements ActionListener, MouseListener 
                     String locName = BattleArmor.MOUNT_LOC_NAMES[misc.getBaMountLoc()];
                     item = new JMenuItem("Mount in " + misc.getName() + " (" + locName + ")");
                     item.addActionListener(evt -> {
-                        BattleArmorUtil.mountOnApm(eq, misc);
+                        BaConstructionUtil.mountOnApm(eq, misc);
                         ((BABuildTab) getParent().getParent()).refreshAll();
                     });
                     popup.add(item);

--- a/megameklab/src/megameklab/ui/battleArmor/BAChassisView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAChassisView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/ui/battleArmor/BAChassisView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAChassisView.java
@@ -118,6 +118,7 @@ public class BAChassisView extends BuildView implements ActionListener, ChangeLi
               "BAChassisView.cbWeightClass.tooltip"), gbc);
         gbc.gridx = 1;
         cbWeightClass.setToolTipText(resourceMap.getString("BAChassisView.cbWeightClass.tooltip"));
+        cbWeightClass.setPrototypeDisplayValue(0);
         add(cbWeightClass, gbc);
         cbWeightClass.addActionListener(this);
 

--- a/megameklab/src/megameklab/ui/battleArmor/BAEnhancementView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAEnhancementView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -34,7 +34,6 @@ package megameklab.ui.battleArmor;
 
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.List;
@@ -51,7 +50,7 @@ import megameklab.ui.generalUnit.BuildView;
 import megameklab.ui.listeners.BABuildListener;
 
 /**
- * Structure tab panel for BA movement enhancements
+ * Panel for BA movement enhancements
  *
  * @author Neoancient
  */
@@ -79,10 +78,10 @@ public class BAEnhancementView extends BuildView implements ActionListener {
     private final EquipmentType jumpBooster = EquipmentType.get(EquipmentTypeLookup.BA_JUMP_BOOSTER);
     private final EquipmentType mechJumpBooster = EquipmentType.get(EquipmentTypeLookup.BA_MECHANICAL_JUMP_BOOSTER);
     private final EquipmentType myomerBooster = EquipmentType.get(EquipmentTypeLookup.BA_MYOMER_BOOSTER);
-    private final EquipmentType dniCockpitMod = EquipmentType.get("DNICockpitModification");
-    private final EquipmentType eiInterface = EquipmentType.get("EIInterface");
+    private final EquipmentType dniCockpitMod = EquipmentType.get(EquipmentTypeLookup.DNI_COCKPIT_MOD);
+    private final EquipmentType eiInterface = EquipmentType.get(EquipmentTypeLookup.EI_INTERFACE);
 
-    private ITechManager techManager;
+    private final ITechManager techManager;
 
     public BAEnhancementView(ITechManager techManager) {
         this.techManager = techManager;
@@ -91,69 +90,63 @@ public class BAEnhancementView extends BuildView implements ActionListener {
 
     private void initUI() {
         ResourceBundle resourceMap = ResourceBundle.getBundle("megameklab.resources.Views");
+        chkPartialWing.setText(resourceMap.getString("BAEnhancementView.chkPartialWing.text"));
+        chkPartialWing.setToolTipText(resourceMap.getString("BAEnhancementView.chkPartialWing.tooltip"));
+        chkJumpBooster.setText(resourceMap.getString("BAEnhancementView.chkJumpBooster.text"));
+        chkJumpBooster.setToolTipText(resourceMap.getString("BAEnhancementView.chkJumpBooster.tooltip"));
+        chkMechanicalJumpBooster.setText(resourceMap.getString("BAEnhancementView.chkMechJumpBooster.text"));
+        chkMechanicalJumpBooster.setToolTipText(resourceMap.getString("BAEnhancementView.chkMechJumpBooster.tooltip"));
+        chkMyomerBooster.setText(resourceMap.getString("BAEnhancementView.chkMyomerBooster.text"));
+        chkMyomerBooster.setToolTipText(resourceMap.getString("BAEnhancementView.chkMyomerBooster.tooltip"));
+        chkDNICockpitMod.setText(resourceMap.getString("BAEnhancementView.chkDNICockpitMod.text"));
+        chkDNICockpitMod.setToolTipText(resourceMap.getString("BAEnhancementView.chkDNICockpitMod.tooltip"));
+        chkEIInterface.setText(resourceMap.getString("BAEnhancementView.chkEIInterface.text"));
+        chkEIInterface.setToolTipText(resourceMap.getString("BAEnhancementView.chkEIInterface.tooltip"));
 
         setLayout(new GridBagLayout());
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0;
-        gbc.gridy = 0;
         gbc.anchor = GridBagConstraints.NORTHWEST;
-        gbc.insets = new Insets(5, 5, 5, 5);
-        chkPartialWing.setText(resourceMap.getString("BAEnhancementView.chkPartialWing.text"));
-        chkPartialWing.setToolTipText(resourceMap.getString("BAEnhancementView.chkPartialWing.tooltip"));
+        gbc.insets = STANDARD_INSETS;
+        // a little padding; these checkboxes are awfully tight otherwise
+        gbc.ipadx = 3;
+        gbc.ipady = 3;
+
         add(chkPartialWing, gbc);
-        chkPartialWing.addActionListener(this);
-
-        gbc.gridx++;
-        chkJumpBooster.setText(resourceMap.getString("BAEnhancementView.chkJumpBooster.text"));
-        chkJumpBooster.setToolTipText(resourceMap.getString("BAEnhancementView.chkJumpBooster.tooltip"));
         add(chkJumpBooster, gbc);
-        chkJumpBooster.addActionListener(this);
-
-        gbc.gridx = 0;
-        gbc.gridy++;
-        chkMechanicalJumpBooster.setText(resourceMap.getString("BAEnhancementView.chkMechJumpBooster.text"));
-        chkMechanicalJumpBooster.setToolTipText(resourceMap.getString("BAEnhancementView.chkMechJumpBooster.tooltip"));
         add(chkMechanicalJumpBooster, gbc);
-        chkMechanicalJumpBooster.addActionListener(this);
-
-        gbc.gridx++;
-        chkMyomerBooster.setText(resourceMap.getString("BAEnhancementView.chkMyomerBooster.text"));
-        chkMyomerBooster.setToolTipText(resourceMap.getString("BAEnhancementView.chkMyomerBooster.tooltip"));
         add(chkMyomerBooster, gbc);
-        chkMyomerBooster.addActionListener(this);
-
-        gbc.gridx = 0;
-        gbc.gridy++;
-        chkDNICockpitMod.setText(resourceMap.getString("BAEnhancementView.chkDNICockpitMod.text"));
-        chkDNICockpitMod.setToolTipText(resourceMap.getString("BAEnhancementView.chkDNICockpitMod.tooltip"));
         add(chkDNICockpitMod, gbc);
-        chkDNICockpitMod.addActionListener(this);
-
-        gbc.gridx++;
-        chkEIInterface.setText(resourceMap.getString("BAEnhancementView.chkEIInterface.text"));
-        chkEIInterface.setToolTipText(resourceMap.getString("BAEnhancementView.chkEIInterface.tooltip"));
         add(chkEIInterface, gbc);
+
+        chkPartialWing.addActionListener(this);
+        chkDNICockpitMod.addActionListener(this);
+        chkMechanicalJumpBooster.addActionListener(this);
+        chkJumpBooster.addActionListener(this);
+        chkMyomerBooster.addActionListener(this);
         chkEIInterface.addActionListener(this);
     }
 
     public void setFromEntity(BattleArmor ba) {
-        ignoreEvents = true;
-        chkPartialWing.setSelected(ba.hasWorkingMisc(MiscType.F_PARTIAL_WING));
-        chkJumpBooster.setSelected(ba.hasWorkingMisc(MiscType.F_JUMP_BOOSTER));
-        chkMechanicalJumpBooster.setSelected(ba.hasWorkingMisc(MiscType.F_MECHANICAL_JUMP_BOOSTER));
-        chkMyomerBooster.setSelected(ba.hasWorkingMisc(MiscType.F_MASC));
+        try {
+            ignoreEvents = true;
+            chkPartialWing.setSelected(ba.hasMisc(EquipmentTypeLookup.BA_PARTIAL_WING));
+            chkJumpBooster.setSelected(ba.hasMisc(EquipmentTypeLookup.BA_JUMP_BOOSTER));
+            chkMechanicalJumpBooster.setSelected(ba.hasMisc(MiscType.F_MECHANICAL_JUMP_BOOSTER));
+            chkMyomerBooster.setSelected(ba.hasMisc(MiscType.F_MASC));
 
-        // DNI Cockpit Mod - IS only
-        boolean dniLegal = (dniCockpitMod != null) && techManager.isLegal(dniCockpitMod);
-        chkDNICockpitMod.setVisible(dniLegal);
-        chkDNICockpitMod.setSelected(dniLegal && ba.hasWorkingMisc(MiscType.F_DNI_COCKPIT_MOD));
+            // DNI Cockpit Mod - IS only
+            boolean dniLegal = (dniCockpitMod != null) && techManager.isLegal(dniCockpitMod);
+            chkDNICockpitMod.setEnabled(dniLegal);
+            chkDNICockpitMod.setSelected(dniLegal && ba.hasMisc(EquipmentTypeLookup.DNI_COCKPIT_MOD));
 
-        // EI Interface - Clan only
-        boolean eiLegal = (eiInterface != null) && techManager.isLegal(eiInterface);
-        chkEIInterface.setVisible(eiLegal);
-        chkEIInterface.setSelected(eiLegal && ba.hasWorkingMisc(MiscType.F_EI_INTERFACE));
-
-        ignoreEvents = false;
+            // EI Interface - Clan only
+            boolean eiLegal = (eiInterface != null) && techManager.isLegal(eiInterface);
+            chkEIInterface.setEnabled(eiLegal);
+            chkEIInterface.setSelected(eiLegal && ba.hasMisc(EquipmentTypeLookup.EI_INTERFACE));
+        } finally {
+            ignoreEvents = false;
+        }
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/battleArmor/BAEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAEquipmentDatabaseView.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.exceptions.LocationFullException;
@@ -95,6 +96,7 @@ class BAEquipmentDatabaseView extends AbstractEquipmentDatabaseView {
               || equipment.hasFlag(MiscType.F_PARTIAL_WING)
               || equipment.hasFlag(MiscType.F_JUMP_BOOSTER)
               || equipment.hasFlag(MiscType.F_MECHANICAL_JUMP_BOOSTER)
+              || equipment.is(EquipmentTypeLookup.BA_MODULAR_EQUIPMENT_ADAPTOR)
               || UnitUtil.isJumpJet(equipment))) {
             return false;
         }

--- a/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
@@ -47,6 +47,7 @@ import megamek.common.TechConstants;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -57,6 +58,7 @@ public class BAMainUI extends MegaMekLabMainUI {
     private BAEquipmentTab equipTab;
     private FluffTab fluffTab;
     private BAStatusBar statusbar;
+    private PreviewTab previewTab;
 
     @Override
     protected FluffTab getFluffTab() {
@@ -87,6 +89,7 @@ public class BAMainUI extends MegaMekLabMainUI {
         quirksTab = new QuirksTab(this);
         statusbar = new BAStatusBar(this);
         buildTab = new BABuildTab(this);
+        previewTab = new PreviewTab(this);
         structureTab.addRefreshedListener(this);
         equipTab.addRefreshedListener(this);
         buildTab.addRefreshedListener(this);
@@ -99,6 +102,7 @@ public class BAMainUI extends MegaMekLabMainUI {
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
+        configPane.addTab("Preview", previewTab);
 
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
@@ -144,6 +148,7 @@ public class BAMainUI extends MegaMekLabMainUI {
         refreshBuild();
         refreshPreview();
         refreshHeader();
+        refreshPreview();
     }
 
     @Override
@@ -188,7 +193,7 @@ public class BAMainUI extends MegaMekLabMainUI {
     @Override
     public void refreshPreview() {
         super.refreshPreview();
-        structureTab.refreshPreview();
+        previewTab.refresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
@@ -148,7 +148,6 @@ public class BAMainUI extends MegaMekLabMainUI {
         refreshBuild();
         refreshPreview();
         refreshHeader();
-        refreshPreview();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2010-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
@@ -34,6 +34,7 @@ package megameklab.ui.battleArmor;
 
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
@@ -61,6 +62,7 @@ import java.util.Vector;
 import static megamek.common.battleArmor.BattleArmor.MOUNT_LOC_LEFT_ARM;
 import static megamek.common.battleArmor.BattleArmor.MOUNT_LOC_RIGHT_ARM;
 import static megamek.common.equipment.EquipmentTypeLookup.BA_MODULAR_EQUIPMENT_ADAPTOR;
+import static megamek.common.verifier.TestBattleArmor.BAManipulator;
 
 public class BAManipulatorView extends IView {
 
@@ -84,6 +86,7 @@ public class BAManipulatorView extends IView {
     private final ITechManager techManager;
     private RefreshListener refreshListener;
 
+    /** Set to true whenever input fields are changed programmatically. Listeners ignore events when true. */
     private boolean ignoreEvents = false;
 
     public BAManipulatorView(EntitySource eSource, ITechManager techManager) {
@@ -163,8 +166,8 @@ public class BAManipulatorView extends IView {
 
             Vector<String> validManipulators = new Vector<>();
             validManipulators.add(BattleArmor.MANIPULATOR_TYPE_STRINGS[BattleArmor.MANIPULATOR_NONE]);
-            for (TestBattleArmor.BAManipulator manipulator : TestBattleArmor.BAManipulator.values()) {
-                EquipmentType et = manipulator.getMiscMounted();
+            for (BAManipulator manipulator : BAManipulator.values()) {
+                EquipmentType et = manipulator.miscType();
                 if ((null != et) && techManager.isLegal(et)) {
                     validManipulators.add(et.getName());
                 }
@@ -173,16 +176,22 @@ public class BAManipulatorView extends IView {
             leftManipulatorSelect.setModel(new DefaultComboBoxModel<>(validManipulators));
             rightManipulatorSelect.setModel(new DefaultComboBoxModel<>(validManipulators));
 
-            TestBattleArmor.BAManipulator manipulator = TestBattleArmor.BAManipulator.getManipulator(getBattleArmor().getLeftManipulatorName());
+            BAManipulator manipulator = BAManipulator.getManipulator(getBattleArmor().getLeftManipulatorName());
             if (manipulator != null) {
                 leftManipulatorSelect.setSelectedItem(BattleArmor.MANIPULATOR_NAME_STRINGS[manipulator.type]);
             }
 
-            manipulator = TestBattleArmor.BAManipulator.getManipulator(getBattleArmor().getRightManipulatorName());
+            manipulator = BAManipulator.getManipulator(getBattleArmor().getRightManipulatorName());
             if (manipulator != null) {
                 rightManipulatorSelect.setSelectedItem(BattleArmor.MANIPULATOR_NAME_STRINGS[manipulator.type]);
                 rightManipulatorSelect.setEnabled(!manipulator.pairMounted);
-                refreshCargoLifterSize();
+                Mounted<?> leftManipulator = getBattleArmor().getLeftManipulator();
+                if (leftManipulator != null && leftManipulator.is(EquipmentTypeLookup.BA_MANIPULATOR_CARGO_LIFTER)) {
+                    cargoLifterCapacityModel.setValue(leftManipulator.getSize());
+                    cargoLifterCapacity.setVisible(true);
+                } else {
+                    cargoLifterCapacity.setVisible(false);
+                }
                 lblSize.setVisible(cargoLifterCapacity.isVisible());
             }
 
@@ -207,24 +216,34 @@ public class BAManipulatorView extends IView {
         }
     }
 
+    /**
+     * Eventhandler for selecting a manipulator in one of the two dropdowns
+     *
+     * @param event the Swing event
+     */
     public void manipulatorSelected(ActionEvent event) {
         if (ignoreEvents) {
             return;
         }
         int location = event.getSource() == leftManipulatorSelect ? MOUNT_LOC_LEFT_ARM : MOUNT_LOC_RIGHT_ARM;
         String name = (String) ((JComboBox<?>) event.getSource()).getSelectedItem();
-        TestBattleArmor.BAManipulator testManipulatorItem = TestBattleArmor.BAManipulator.getManipulator(name);
-        if (testManipulatorItem == null) {
+        BAManipulator manipulatorItem = BAManipulator.getManipulator(name);
+        if (manipulatorItem == null) {
             throw new IllegalStateException(COMBO_ERROR.formatted(name));
         }
-        var currentManipulator = getManipulator(location);
+        MiscMounted currentManipulator = getBattleArmor().getManipulator(location);
         // only react if the manipulator has actually changed
-        if (currentManipulator.isEmpty() || !currentManipulator.get().is(testManipulatorItem.internalName)) {
-            setManipulators(testManipulatorItem, location);
+        if (currentManipulator == null || !currentManipulator.is(manipulatorItem.internalName)) {
+            setManipulators(manipulatorItem, location);
             doRefresh();
         }
     }
 
+    /**
+     * Eventhandler for (de)selecting one of the two Modular Equipment Adaptors
+     *
+     * @param event the Swing event
+     */
     public void modularSelected(ActionEvent event) {
         if (ignoreEvents) {
             return;
@@ -267,25 +286,18 @@ public class BAManipulatorView extends IView {
         ignoreEvents = false;
     }
 
+    /**
+     * Eventhandler for changing the cargo lifter size value
+     *
+     * @param event the Swing event
+     */
     public void cargoSizeEdited(ChangeEvent event) {
         if (ignoreEvents) {
             return;
         }
-        setManipulatorSize(BattleArmor.MOUNT_LOC_LEFT_ARM, cargoLifterCapacityModel.getNumber().doubleValue());
-        setManipulatorSize(BattleArmor.MOUNT_LOC_RIGHT_ARM, cargoLifterCapacityModel.getNumber().doubleValue());
+        setManipulatorSize(MOUNT_LOC_LEFT_ARM, cargoLifterCapacityModel.getNumber().doubleValue());
+        setManipulatorSize(MOUNT_LOC_RIGHT_ARM, cargoLifterCapacityModel.getNumber().doubleValue());
         doRefresh();
-    }
-
-    private void refreshCargoLifterSize() {
-        Optional<MiscMounted> manipulator = getManipulator(BattleArmor.MOUNT_LOC_LEFT_ARM);
-        if (manipulator.isPresent() && manipulator.get().getType().isVariableSize()) {
-            cargoLifterCapacityModel.setValue(manipulator.get().getSize());
-            cargoLifterCapacityModel.setStepSize(manipulator.get().getType().variableStepSize());
-            cargoLifterCapacityModel.setMinimum(manipulator.get().getType().variableStepSize());
-            cargoLifterCapacity.setVisible(true);
-        } else {
-            cargoLifterCapacity.setVisible(false);
-        }
     }
 
     /**
@@ -295,11 +307,8 @@ public class BAManipulatorView extends IView {
      * @param newManipulator The new manipulator type
      * @param mountLoc       one of the two arm locations (MOUNT_LOC_x_ARM)
      */
-    private void setManipulators(TestBattleArmor.BAManipulator newManipulator, int mountLoc) {
+    private void setManipulators(BAManipulator newManipulator, int mountLoc) {
         MiscMounted currentManipulator = getBattleArmor().getManipulator(mountLoc);
-        if (currentManipulator != null) {
-            UnitUtil.removeMounted(getBattleArmor(), currentManipulator);
-        }
         setManipulator(newManipulator, mountLoc);
 
         if (newManipulator.pairMounted) {
@@ -309,7 +318,7 @@ public class BAManipulatorView extends IView {
             // when the previous manipulator was pair-mounted but the new one is not, remove the old on the other arm
             MiscMounted secondManipulator = getBattleArmor().getManipulator(otherArm(mountLoc));
             if (secondManipulator != null) {
-                UnitUtil.removeMounted(getBattleArmor(), currentManipulator);
+                UnitUtil.removeMounted(getBattleArmor(), secondManipulator);
             }
         }
     }
@@ -322,12 +331,14 @@ public class BAManipulatorView extends IView {
      * @param newManipulator The new manipulator type
      * @param mountLoc       one of the two arm locations (MOUNT_LOC_x_ARM)
      */
-    private void setManipulator(TestBattleArmor.BAManipulator newManipulator, int mountLoc) {
-        Optional<MiscMounted> currentManipulator = getManipulator(mountLoc);
-        currentManipulator.ifPresent(miscMounted -> UnitUtil.removeMounted(getBattleArmor(), miscMounted));
-        if (newManipulator != TestBattleArmor.BAManipulator.NONE) {
+    private void setManipulator(BAManipulator newManipulator, int mountLoc) {
+        MiscMounted currentManipulator = getBattleArmor().getManipulator(mountLoc);
+        if (currentManipulator != null) {
+            ConstructionUtil.removeMounted(getBattleArmor(), currentManipulator);
+        }
+        if (newManipulator != BAManipulator.NONE) {
             try {
-                Mounted<?> manipulator = getBattleArmor().addEquipment(newManipulator.getMiscMounted(),
+                Mounted<?> manipulator = getBattleArmor().addEquipment(newManipulator.miscType(),
                       BattleArmor.LOC_SQUAD);
                 manipulator.setBaMountLoc(mountLoc);
             } catch (LocationFullException ex) {
@@ -355,7 +366,7 @@ public class BAManipulatorView extends IView {
     }
 
     private boolean isPairedManipulator(EquipmentType eq) {
-        TestBattleArmor.BAManipulator manipulator = TestBattleArmor.BAManipulator.getManipulator(eq.getInternalName());
+        BAManipulator manipulator = BAManipulator.getManipulator(eq.getInternalName());
         return manipulator != null && manipulator.pairMounted;
     }
 

--- a/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
@@ -73,8 +73,8 @@ public class BAManipulatorView extends IView {
 
     private static final MiscType MODULAR_MOUNT = (MiscType) EquipmentType.get(BA_MODULAR_EQUIPMENT_ADAPTOR);
 
-    private final JCheckBox leftModularSelector = new JCheckBox("Modular Equipment Adaptor");
-    private final JCheckBox rightModularSelector = new JCheckBox("Modular Equipment Adaptor");
+    private final JCheckBox leftModularSelector = new JCheckBox(I18N.getString("BAManipulatorView.mea"));
+    private final JCheckBox rightModularSelector = new JCheckBox(I18N.getString("BAManipulatorView.mea"));
 
     private final CustomComboBox<String> leftManipulatorSelect = new CustomComboBox<>(this::manipulatorDisplayName);
     private final CustomComboBox<String> rightManipulatorSelect = new CustomComboBox<>(this::manipulatorDisplayName);
@@ -252,7 +252,7 @@ public class BAManipulatorView extends IView {
         int location = event.getSource() == leftModularSelector ? MOUNT_LOC_LEFT_ARM : MOUNT_LOC_RIGHT_ARM;
 
         if (modularCheckBox.isSelected()) {
-            if (getBattleArmor().hasMisc(BA_MODULAR_EQUIPMENT_ADAPTOR, location)) {
+            if (getBattleArmor().hasMiscInMountLocation(BA_MODULAR_EQUIPMENT_ADAPTOR, location)) {
                 // equipment is already there, no action needed
                 return;
             }
@@ -280,7 +280,7 @@ public class BAManipulatorView extends IView {
 
     private void handleNoRoomForModularMount(JCheckBox checkBox) {
         JOptionPane.showMessageDialog(SwingUtilities.windowForComponent(this),
-              "Not enough room to add a Modular Equipment Adaptor!");
+              I18N.getString("BAManipulatorView.meaCannotAdd"));
         ignoreEvents = true;
         checkBox.setSelected(false);
         ignoreEvents = false;

--- a/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.ui.battleArmor;
+
+import megamek.common.battleArmor.BattleArmor;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.MiscMounted;
+import megamek.common.equipment.MiscType;
+import megamek.common.exceptions.LocationFullException;
+import megamek.common.interfaces.ITechManager;
+import megamek.common.verifier.TestBattleArmor;
+import megamek.logging.MMLogger;
+import megameklab.ui.EntitySource;
+import megameklab.ui.generalUnit.BuildView;
+import megameklab.ui.util.CustomComboBox;
+import megameklab.ui.util.IView;
+import megameklab.ui.util.RefreshListener;
+import megameklab.util.UnitUtil;
+
+import javax.swing.*;
+import javax.swing.event.ChangeEvent;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.event.ActionEvent;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.Vector;
+
+import static megamek.common.battleArmor.BattleArmor.MOUNT_LOC_LEFT_ARM;
+import static megamek.common.battleArmor.BattleArmor.MOUNT_LOC_RIGHT_ARM;
+import static megamek.common.equipment.EquipmentTypeLookup.BA_MODULAR_EQUIPMENT_ADAPTOR;
+
+public class BAManipulatorView extends IView {
+
+    private static final MMLogger LOGGER = MMLogger.create(BAStructureTab.class);
+    private static final ResourceBundle I18N = ResourceBundle.getBundle("megameklab.resources.Views");
+    private static final String COMBO_ERROR =
+          "Manipulator Combo choice could not be parsed to TestBattleArmor.BAManipulator object: %s";
+
+    private static final MiscType MODULAR_MOUNT = (MiscType) EquipmentType.get(BA_MODULAR_EQUIPMENT_ADAPTOR);
+
+    private final JCheckBox leftModularSelector = new JCheckBox("Modular Equipment Adaptor");
+    private final JCheckBox rightModularSelector = new JCheckBox("Modular Equipment Adaptor");
+
+    private final CustomComboBox<String> leftManipulatorSelect = new CustomComboBox<>(this::manipulatorDisplayName);
+    private final CustomComboBox<String> rightManipulatorSelect = new CustomComboBox<>(this::manipulatorDisplayName);
+
+    private final SpinnerNumberModel cargoLifterCapacityModel = new SpinnerNumberModel(0.5, 0.5, 80, 0.5);
+    private final JSpinner cargoLifterCapacity = new JSpinner(cargoLifterCapacityModel);
+    private final JLabel lblSize = createLabel(I18N.getString("BAManipulatorView.cargoCapacity"));
+
+    private final ITechManager techManager;
+    private RefreshListener refreshListener;
+
+    private boolean ignoreEvents = false;
+
+    public BAManipulatorView(EntitySource eSource, ITechManager techManager) {
+        super(eSource);
+        this.techManager = techManager;
+
+        setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.gridy = 0;
+        gbc.insets = BuildView.STANDARD_INSETS;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+
+        add(createLabel(I18N.getString("BAManipulatorView.leftArm")), gbc);
+        add(leftManipulatorSelect, gbc);
+
+        gbc.gridy++;
+        add(new JLabel(), gbc);
+        add(leftModularSelector, gbc);
+
+        gbc.gridy++;
+        add(Box.createVerticalStrut(10), gbc);
+
+        gbc.gridy++;
+        add(createLabel(I18N.getString("BAManipulatorView.rightArm")), gbc);
+        add(rightManipulatorSelect, gbc);
+
+        gbc.gridy++;
+        add(new JLabel(), gbc);
+        add(rightModularSelector, gbc);
+
+        gbc.gridy++;
+        add(Box.createVerticalStrut(10), gbc);
+
+        gbc.gridy++;
+        add(lblSize, gbc);
+        add(cargoLifterCapacity, gbc);
+
+        leftManipulatorSelect.addActionListener(this::manipulatorSelected);
+        rightManipulatorSelect.addActionListener(this::manipulatorSelected);
+        cargoLifterCapacity.addChangeListener(this::cargoSizeEdited);
+        leftModularSelector.addActionListener(this::modularSelected);
+        rightModularSelector.addActionListener(this::modularSelected);
+    }
+
+    public void addRefreshedListener(RefreshListener l) {
+        refreshListener = l;
+    }
+
+    private void doRefresh() {
+        if (refreshListener != null) {
+            setFromEntity();
+            refreshListener.refreshBuild();
+            refreshListener.refreshSummary();
+            refreshListener.refreshPreview();
+            refreshListener.refreshStatus();
+        }
+    }
+
+    public JLabel createLabel(String text) {
+        return new JLabel(text, SwingConstants.RIGHT);
+    }
+
+    /**
+     * Extracts the actual name of the manipulator from the full equipment name
+     */
+    private String manipulatorDisplayName(String name) {
+        int start = name.indexOf("[");
+        if (start > 0) {
+            return name.substring(start + 1).replace("]", "");
+        }
+        return name;
+    }
+
+    void setFromEntity() {
+        try {
+            ignoreEvents = true;
+
+            Vector<String> validManipulators = new Vector<>();
+            validManipulators.add(BattleArmor.MANIPULATOR_TYPE_STRINGS[BattleArmor.MANIPULATOR_NONE]);
+            for (TestBattleArmor.BAManipulator manipulator : TestBattleArmor.BAManipulator.values()) {
+                EquipmentType et = getMisc(manipulator);
+                if ((null != et) && techManager.isLegal(et)) {
+                    validManipulators.add(et.getName());
+                }
+            }
+
+            leftManipulatorSelect.setModel(new DefaultComboBoxModel<>(validManipulators));
+            rightManipulatorSelect.setModel(new DefaultComboBoxModel<>(validManipulators));
+
+            TestBattleArmor.BAManipulator manipulator = TestBattleArmor.BAManipulator.getManipulator(getBattleArmor().getLeftManipulatorName());
+            if (manipulator != null) {
+                leftManipulatorSelect.setSelectedItem(BattleArmor.MANIPULATOR_NAME_STRINGS[manipulator.type]);
+            }
+
+            manipulator = TestBattleArmor.BAManipulator.getManipulator(getBattleArmor().getRightManipulatorName());
+            if (manipulator != null) {
+                rightManipulatorSelect.setSelectedItem(BattleArmor.MANIPULATOR_NAME_STRINGS[manipulator.type]);
+                rightManipulatorSelect.setEnabled(!manipulator.pairMounted);
+                refreshCargoLifterSize();
+                lblSize.setVisible(cargoLifterCapacity.isVisible());
+            }
+
+            leftModularSelector.setSelected(
+                  getBattleArmor().hasMiscInMountLocation(BA_MODULAR_EQUIPMENT_ADAPTOR, MOUNT_LOC_LEFT_ARM));
+            rightModularSelector.setSelected(
+                  getBattleArmor().hasMiscInMountLocation(BA_MODULAR_EQUIPMENT_ADAPTOR, MOUNT_LOC_RIGHT_ARM));
+
+            if (getBattleArmor().getChassisType() == BattleArmor.CHASSIS_TYPE_QUAD) {
+                leftModularSelector.setEnabled(false);
+                rightModularSelector.setEnabled(false);
+                leftManipulatorSelect.setEnabled(false);
+                rightManipulatorSelect.setEnabled(false);
+            } else {
+                leftModularSelector.setEnabled(true);
+                rightModularSelector.setEnabled(true);
+                leftManipulatorSelect.setEnabled(true);
+                rightManipulatorSelect.setEnabled(manipulator == null || !manipulator.pairMounted);
+            }
+        } finally {
+            ignoreEvents = false;
+        }
+    }
+
+    public void manipulatorSelected(ActionEvent event) {
+        if (ignoreEvents) {
+            return;
+        }
+        int location = event.getSource() == leftManipulatorSelect ? MOUNT_LOC_LEFT_ARM : MOUNT_LOC_RIGHT_ARM;
+        String name = (String) ((JComboBox<?>) event.getSource()).getSelectedItem();
+        TestBattleArmor.BAManipulator testManipulatorItem = TestBattleArmor.BAManipulator.getManipulator(name);
+        if (testManipulatorItem == null) {
+            throw new IllegalStateException(COMBO_ERROR.formatted(name));
+        }
+        var currentManipulator = getManipulator(location);
+        // only react if the manipulator has actually changed
+        if (currentManipulator.isEmpty() || !currentManipulator.get().is(testManipulatorItem.internalName)) {
+            setManipulators(testManipulatorItem, location);
+            doRefresh();
+        }
+    }
+
+    public void modularSelected(ActionEvent event) {
+        if (ignoreEvents) {
+            return;
+        }
+        JCheckBox modularCheckBox = (JCheckBox) event.getSource();
+        int location = event.getSource() == leftModularSelector ? MOUNT_LOC_LEFT_ARM : MOUNT_LOC_RIGHT_ARM;
+
+        if (modularCheckBox.isSelected()) {
+            if (getBattleArmor().hasMisc(BA_MODULAR_EQUIPMENT_ADAPTOR, location)) {
+                // equipment is already there, no action needed
+                return;
+            }
+            MiscMounted modularMountMisc = new MiscMounted(getBattleArmor(), MODULAR_MOUNT);
+            if (!TestBattleArmor.isMountLegal(getBattleArmor(), modularMountMisc, location)) {
+                handleNoRoomForModularMount(modularCheckBox);
+                return;
+            }
+
+            try {
+                modularMountMisc.setBaMountLoc(location);
+                getBattleArmor().addEquipment(modularMountMisc, BattleArmor.LOC_SQUAD, false);
+                doRefresh();
+            } catch (LocationFullException ignored) {
+                // currently isn't thrown on BA
+            }
+        } else {
+            var modularMount = getModularMount(location);
+            if (modularMount.isPresent()) {
+                UnitUtil.removeMounted(getBattleArmor(), modularMount.get());
+                doRefresh();
+            }
+        }
+    }
+
+    private void handleNoRoomForModularMount(JCheckBox checkBox) {
+        JOptionPane.showMessageDialog(SwingUtilities.windowForComponent(this),
+              "Not enough room to add a Modular Equipment Adaptor!");
+        ignoreEvents = true;
+        checkBox.setSelected(false);
+        ignoreEvents = false;
+    }
+
+    public void cargoSizeEdited(ChangeEvent event) {
+        if (ignoreEvents) {
+            return;
+        }
+        setManipulatorSize(BattleArmor.MOUNT_LOC_LEFT_ARM, cargoLifterCapacityModel.getNumber().doubleValue());
+        setManipulatorSize(BattleArmor.MOUNT_LOC_RIGHT_ARM, cargoLifterCapacityModel.getNumber().doubleValue());
+        doRefresh();
+    }
+
+    private void refreshCargoLifterSize() {
+        Optional<MiscMounted> manipulator = getManipulator(BattleArmor.MOUNT_LOC_LEFT_ARM);
+        if (manipulator.isPresent() && manipulator.get().getType().isVariableSize()) {
+            cargoLifterCapacityModel.setValue(manipulator.get().getSize());
+            cargoLifterCapacityModel.setStepSize(manipulator.get().getType().variableStepSize());
+            cargoLifterCapacityModel.setMinimum(manipulator.get().getType().variableStepSize());
+            cargoLifterCapacity.setVisible(true);
+        } else {
+            cargoLifterCapacity.setVisible(false);
+        }
+    }
+
+    /**
+     * Adds and removes manipulator MiscMounteds on the unit so that the manipulator on the given mountLoc arm is the
+     * one given as newManipulator (which may be none). Also updates the other arm if necessary.
+     *
+     * @param newManipulator The new manipulator type
+     * @param mountLoc       one of the two arm locations (MOUNT_LOC_x_ARM)
+     */
+    private void setManipulators(TestBattleArmor.BAManipulator newManipulator, int mountLoc) {
+        if (mountLoc != MOUNT_LOC_LEFT_ARM && mountLoc != MOUNT_LOC_RIGHT_ARM) {
+            throw new IllegalArgumentException("Invalid location (must be arm)");
+        }
+
+        Optional<MiscMounted> currentManipulator = getManipulator(mountLoc);
+        currentManipulator.ifPresent(miscMounted -> UnitUtil.removeMounted(getBattleArmor(), miscMounted));
+        setManipulator(newManipulator, mountLoc);
+
+        if (newManipulator.pairMounted) {
+            setManipulator(newManipulator, otherArm(mountLoc));
+
+        } else if (currentManipulator.isPresent() && isPairedManipulator(currentManipulator.get().getType())) {
+            // when the previous manipulator was pairmounted but the new one is not, remove the old on the other arm
+            getManipulator(otherArm(mountLoc))
+                  .ifPresent(miscMounted -> UnitUtil.removeMounted(getBattleArmor(), miscMounted));
+        }
+    }
+
+    /**
+     * Adds and removes manipulator MiscMounteds on the unit so that the manipulator on the given mountLoc arm is the
+     * one given as newManipulator (which may be none). Does not touch the other arm. Should only be called from
+     * setManipulators().
+     *
+     * @param newManipulator The new manipulator type
+     * @param mountLoc       one of the two arm locations (MOUNT_LOC_x_ARM)
+     */
+    private void setManipulator(TestBattleArmor.BAManipulator newManipulator, int mountLoc) {
+        Optional<MiscMounted> currentManipulator = getManipulator(mountLoc);
+        currentManipulator.ifPresent(miscMounted -> UnitUtil.removeMounted(getBattleArmor(), miscMounted));
+        if (newManipulator != TestBattleArmor.BAManipulator.NONE) {
+            MiscMounted newMount = new MiscMounted(getBattleArmor(), getMisc(newManipulator));
+            newMount.setBaMountLoc(mountLoc);
+            try {
+                getBattleArmor().addEquipment(newMount, BattleArmor.LOC_SQUAD, false);
+            } catch (LocationFullException ex) {
+                LOGGER.error("Could not mount {}", newManipulator, ex);
+            }
+        }
+    }
+
+    private MiscType getMisc(TestBattleArmor.BAManipulator baManipulator) {
+        return (MiscType) EquipmentType.get(baManipulator.internalName);
+    }
+
+    private int otherArm(int armLocation) {
+        return armLocation == MOUNT_LOC_LEFT_ARM ? MOUNT_LOC_RIGHT_ARM : MOUNT_LOC_LEFT_ARM;
+    }
+
+    private Optional<MiscMounted> getManipulator(int mountLoc) {
+        return getBattleArmor().getMisc().stream()
+              .filter(m -> m.getBaMountLoc() == mountLoc)
+              .filter(m -> m.getType().hasFlag(MiscType.F_BA_MANIPULATOR))
+              .findFirst();
+    }
+
+    private Optional<MiscMounted> getModularMount(int mountLoc) {
+        return getBattleArmor().getMisc().stream()
+              .filter(m -> m.getBaMountLoc() == mountLoc)
+              .filter(m -> m.is(BA_MODULAR_EQUIPMENT_ADAPTOR))
+              .findFirst();
+    }
+
+    private boolean isPairedManipulator(EquipmentType eq) {
+        TestBattleArmor.BAManipulator manipulator = TestBattleArmor.BAManipulator.getManipulator(eq.getInternalName());
+        return manipulator != null && manipulator.pairMounted;
+    }
+
+    private void setManipulatorSize(int mountLoc, double size) {
+        getManipulator(mountLoc).ifPresent(manipulator -> manipulator.setSize(size));
+    }
+}

--- a/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
@@ -62,7 +62,7 @@ import static megamek.common.equipment.EquipmentTypeLookup.BA_MODULAR_EQUIPMENT_
 
 public class BAManipulatorView extends IView {
 
-    private static final MMLogger LOGGER = MMLogger.create(BAStructureTab.class);
+    private static final MMLogger LOGGER = MMLogger.create(BAManipulatorView.class);
     private static final ResourceBundle I18N = ResourceBundle.getBundle("megameklab.resources.Views");
     private static final String COMBO_ERROR =
           "Manipulator Combo choice could not be parsed to TestBattleArmor.BAManipulator object: %s";
@@ -294,21 +294,21 @@ public class BAManipulatorView extends IView {
      * @param mountLoc       one of the two arm locations (MOUNT_LOC_x_ARM)
      */
     private void setManipulators(TestBattleArmor.BAManipulator newManipulator, int mountLoc) {
-        if (mountLoc != MOUNT_LOC_LEFT_ARM && mountLoc != MOUNT_LOC_RIGHT_ARM) {
-            throw new IllegalArgumentException("Invalid location (must be arm)");
+        MiscMounted currentManipulator = getBattleArmor().getManipulator(mountLoc);
+        if (currentManipulator != null) {
+            UnitUtil.removeMounted(getBattleArmor(), currentManipulator);
         }
-
-        Optional<MiscMounted> currentManipulator = getManipulator(mountLoc);
-        currentManipulator.ifPresent(miscMounted -> UnitUtil.removeMounted(getBattleArmor(), miscMounted));
         setManipulator(newManipulator, mountLoc);
 
         if (newManipulator.pairMounted) {
             setManipulator(newManipulator, otherArm(mountLoc));
 
-        } else if (currentManipulator.isPresent() && isPairedManipulator(currentManipulator.get().getType())) {
-            // when the previous manipulator was pairmounted but the new one is not, remove the old on the other arm
-            getManipulator(otherArm(mountLoc))
-                  .ifPresent(miscMounted -> UnitUtil.removeMounted(getBattleArmor(), miscMounted));
+        } else if (currentManipulator != null && isPairedManipulator(currentManipulator.getType())) {
+            // when the previous manipulator was pair-mounted but the new one is not, remove the old on the other arm
+            MiscMounted secondManipulator = getBattleArmor().getManipulator(otherArm(mountLoc));
+            if (secondManipulator != null) {
+                UnitUtil.removeMounted(getBattleArmor(), currentManipulator);
+            }
         }
     }
 

--- a/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
@@ -36,6 +36,7 @@ import megamek.common.battleArmor.BattleArmor;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.MiscType;
+import megamek.common.equipment.Mounted;
 import megamek.common.exceptions.LocationFullException;
 import megamek.common.interfaces.ITechManager;
 import megamek.common.verifier.TestBattleArmor;
@@ -162,7 +163,7 @@ public class BAManipulatorView extends IView {
             Vector<String> validManipulators = new Vector<>();
             validManipulators.add(BattleArmor.MANIPULATOR_TYPE_STRINGS[BattleArmor.MANIPULATOR_NONE]);
             for (TestBattleArmor.BAManipulator manipulator : TestBattleArmor.BAManipulator.values()) {
-                EquipmentType et = getMisc(manipulator);
+                EquipmentType et = manipulator.getMiscMounted();
                 if ((null != et) && techManager.isLegal(et)) {
                     validManipulators.add(et.getName());
                 }
@@ -324,18 +325,14 @@ public class BAManipulatorView extends IView {
         Optional<MiscMounted> currentManipulator = getManipulator(mountLoc);
         currentManipulator.ifPresent(miscMounted -> UnitUtil.removeMounted(getBattleArmor(), miscMounted));
         if (newManipulator != TestBattleArmor.BAManipulator.NONE) {
-            MiscMounted newMount = new MiscMounted(getBattleArmor(), getMisc(newManipulator));
-            newMount.setBaMountLoc(mountLoc);
             try {
-                getBattleArmor().addEquipment(newMount, BattleArmor.LOC_SQUAD, false);
+                Mounted<?> manipulator = getBattleArmor().addEquipment(newManipulator.getMiscMounted(),
+                      BattleArmor.LOC_SQUAD);
+                manipulator.setBaMountLoc(mountLoc);
             } catch (LocationFullException ex) {
                 LOGGER.error("Could not mount {}", newManipulator, ex);
             }
         }
-    }
-
-    private MiscType getMisc(TestBattleArmor.BAManipulator baManipulator) {
-        return (MiscType) EquipmentType.get(baManipulator.internalName);
     }
 
     private int otherArm(int armLocation) {

--- a/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAManipulatorView.java
@@ -39,6 +39,7 @@ import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.exceptions.LocationFullException;
 import megamek.common.interfaces.ITechManager;
+import megamek.common.units.ConstructionUtil;
 import megamek.common.verifier.TestBattleArmor;
 import megamek.logging.MMLogger;
 import megameklab.ui.EntitySource;
@@ -252,7 +253,7 @@ public class BAManipulatorView extends IView {
         } else {
             var modularMount = getModularMount(location);
             if (modularMount.isPresent()) {
-                UnitUtil.removeMounted(getBattleArmor(), modularMount.get());
+                ConstructionUtil.removeMounted(getBattleArmor(), modularMount.get());
                 doRefresh();
             }
         }

--- a/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
@@ -340,6 +340,7 @@ public class BAStructureTab extends ITab implements BABuildListener, ArmorAlloca
     @Override
     public void chassisTypeChanged(int chassisType) {
         getBattleArmor().setChassisType(chassisType);
+        BattleArmorUtil.removeManipulatorEquipment(getBattleArmor());
         BattleArmorUtil.removeAllCriticalSlotsFrom(getBattleArmor(),
               List.of(BattleArmor.MOUNT_LOC_LEFT_ARM, BattleArmor.MOUNT_LOC_RIGHT_ARM, BattleArmor.MOUNT_LOC_TURRET));
         panBasicInfo.setFromEntity(getBattleArmor());

--- a/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAStructureTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -32,29 +32,20 @@
  */
 package megameklab.ui.battleArmor;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.swing.*;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 
 import megamek.codeUtilities.MathUtility;
 import megamek.common.CriticalSlot;
 import megamek.common.SimpleTechLevel;
-import megamek.common.annotations.Nullable;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.enums.Faction;
 import megamek.common.equipment.ArmorType;
 import megamek.common.equipment.EquipmentType;
-import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.exceptions.LocationFullException;
@@ -64,7 +55,6 @@ import megamek.common.units.EntityWeightClass;
 import megamek.common.units.UnitRole;
 import megamek.common.verifier.Ceil;
 import megamek.common.verifier.TestBattleArmor;
-import megamek.common.verifier.TestBattleArmor.BAManipulator;
 import megamek.common.verifier.TestEntity;
 import megamek.logging.MMLogger;
 import megameklab.ui.EntitySource;
@@ -72,10 +62,8 @@ import megameklab.ui.generalUnit.BAProtoArmorView;
 import megameklab.ui.generalUnit.BasicInfoView;
 import megameklab.ui.generalUnit.IconView;
 import megameklab.ui.generalUnit.MovementView;
-import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.listeners.ArmorAllocationListener;
 import megameklab.ui.listeners.BABuildListener;
-import megameklab.ui.util.CustomComboBox;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
 import megameklab.util.BattleArmorUtil;
@@ -84,13 +72,10 @@ import megameklab.util.UnitUtil;
 /**
  * @author jtighe (torren@users.sourceforge.net)
  */
-public class BAStructureTab extends ITab
-      implements ActionListener, ChangeListener, BABuildListener, ArmorAllocationListener {
+public class BAStructureTab extends ITab implements BABuildListener, ArmorAllocationListener {
     private static final MMLogger logger = MMLogger.create(BAStructureTab.class);
 
     private RefreshListener refresh;
-
-    Dimension labelSize = new Dimension(60, 25);
 
     private BasicInfoView panBasicInfo;
     private BAChassisView panChassis;
@@ -98,20 +83,7 @@ public class BAStructureTab extends ITab
     private BAProtoArmorView panArmor;
     private BAEnhancementView panEnhancements;
     private IconView iconView;
-
-    // Manipulator Panel
-    private final CustomComboBox<String> leftManipulatorSelect = new CustomComboBox<>(this::manipulatorDisplayName);
-    private final CustomComboBox<String> rightManipulatorSelect = new CustomComboBox<>(this::manipulatorDisplayName);
-
-    private final SpinnerNumberModel spnLeftManipulatorSizeModel = new SpinnerNumberModel(0.5, 0.5, Double.MAX_VALUE,
-          0.5);
-    private final SpinnerNumberModel spnRightManipulatorSizeModel = new SpinnerNumberModel(0.5, 0.5, Double.MAX_VALUE,
-          0.5);
-    private final JSpinner spnLeftManipulatorSize = new JSpinner(spnLeftManipulatorSizeModel);
-    private final JSpinner spnRightManipulatorSize = new JSpinner(spnRightManipulatorSizeModel);
-    private final JLabel lblSize = createLabel("Size:", new Dimension(40, 25));
-
-    private PreviewTab previewTab;
+    private BAManipulatorView panManipulator;
 
     public BAStructureTab(EntitySource eSource) {
         super(eSource);
@@ -120,100 +92,52 @@ public class BAStructureTab extends ITab
     }
 
     public void setUpPanels() {
-        JPanel leftPanel = new JPanel();
-        leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.Y_AXIS));
-
-        previewTab = new PreviewTab(eSource);
         panBasicInfo = new BasicInfoView(getBattleArmor().getConstructionTechAdvancement());
         panChassis = new BAChassisView(panBasicInfo);
         panMovement = new MovementView(panBasicInfo);
         panArmor = new BAProtoArmorView(panBasicInfo);
         iconView = new IconView();
-        JPanel manipulatorPanel = new JPanel(new GridBagLayout());
         panEnhancements = new BAEnhancementView(panBasicInfo);
-        GridBagConstraints gbc = new GridBagConstraints();
-        Dimension comboSize = new Dimension(180, 25);
-        Dimension spinnerSize = new Dimension(60, 25);
-
-        gbc.gridx = 0;
-        gbc.gridy = 0;
-        gbc.anchor = GridBagConstraints.NORTHWEST;
-        gbc.fill = GridBagConstraints.NONE;
-        manipulatorPanel.add(createLabel("Left Arm:", labelSize), gbc);
-        gbc.gridy = 1;
-        manipulatorPanel.add(createLabel("Right Arm:", labelSize), gbc);
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        gbc.gridx = 1;
-        gbc.gridy = 0;
-        manipulatorPanel.add(leftManipulatorSelect, gbc);
-        gbc.gridx = 2;
-        manipulatorPanel.add(lblSize, gbc);
-        gbc.gridx = 3;
-        manipulatorPanel.add(spnLeftManipulatorSize, gbc);
-        gbc.gridx = 1;
-        gbc.gridy = 1;
-        manipulatorPanel.add(rightManipulatorSelect, gbc);
-        gbc.gridx = 3;
-        manipulatorPanel.add(spnRightManipulatorSize, gbc);
-
-        setFieldSize(leftManipulatorSelect, comboSize);
-        setFieldSize(rightManipulatorSelect, comboSize);
-        setFieldSize(spnLeftManipulatorSize, spinnerSize);
-        setFieldSize(spnRightManipulatorSize, spinnerSize);
+        panManipulator = new BAManipulatorView(eSource, panBasicInfo);
 
         panBasicInfo.setBorder(BorderFactory.createTitledBorder("Basic Information"));
         panChassis.setBorder(BorderFactory.createTitledBorder("Chassis"));
         panMovement.setBorder(BorderFactory.createTitledBorder("Movement"));
         panArmor.setBorder(BorderFactory.createTitledBorder("Armor"));
-        manipulatorPanel.setBorder(BorderFactory.createTitledBorder("Manipulators"));
+        panManipulator.setBorder(BorderFactory.createTitledBorder("Manipulators"));
         panEnhancements.setBorder(BorderFactory.createTitledBorder("Enhancements"));
+
+        setLayout(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+
+        Box leftPanel = Box.createVerticalBox();
+        Box midPanel = Box.createVerticalBox();
+        Box rightPanel = Box.createVerticalBox();
 
         leftPanel.add(panBasicInfo);
         leftPanel.add(iconView);
-        leftPanel.add(panChassis);
-        leftPanel.add(panMovement);
-        leftPanel.add(panArmor);
-        leftPanel.add(panEnhancements);
-        leftPanel.add(manipulatorPanel);
-        leftPanel.add(Box.createVerticalGlue());
 
-        // Right panel setup
-        JPanel rightPanel = new JPanel(new BorderLayout());
-        rightPanel.setPreferredSize(new Dimension(400, 1));
-        rightPanel.add(previewTab, BorderLayout.CENTER);
+        midPanel.add(panChassis);
+        midPanel.add(panArmor);
+        midPanel.add(panMovement);
 
-        setLayout(new GridBagLayout());
-        gbc = new GridBagConstraints();
-        gbc.insets = new Insets(0, 5, 0, 5);
-        gbc.gridx = 0;
+        rightPanel.add(panEnhancements);
+        rightPanel.add(panManipulator);
+
         gbc.gridy = 0;
-        gbc.anchor = GridBagConstraints.NORTHWEST;
-        gbc.fill = java.awt.GridBagConstraints.VERTICAL;
+        gbc.anchor = GridBagConstraints.NORTH;
         gbc.insets = new Insets(5, 5, 5, 5);
-        gbc.weightx = 0.0;
-        gbc.weighty = 1.0;
         add(leftPanel, gbc);
-
-        gbc.gridx = 1;
-        gbc.gridy = 0;
-        gbc.fill = GridBagConstraints.BOTH;  // Fill both horizontally and vertically
-        gbc.weightx = 1.0;                         // Expand to fill horizontal space
-        gbc.weighty = 1.0;                         // Expand to fill vertical space
-        gbc.insets = new Insets(0, 0, 0, 0);
+        add(midPanel, gbc);
         add(rightPanel, gbc);
+        // add a row that will take up vertical space to top-align the content
+        gbc.gridy++;
+        gbc.weighty = 1;
+        add(Box.createVerticalGlue(), gbc);
     }
 
-    public JLabel createLabel(String text, Dimension maxSize) {
-        JLabel label = new JLabel(text, SwingConstants.RIGHT);
-        setFieldSize(label, maxSize);
-        return label;
-    }
-
-    @Override
-    public void setFieldSize(JComponent box, Dimension maxSize) {
-        box.setPreferredSize(maxSize);
-        box.setMaximumSize(maxSize);
-        box.setMinimumSize(maxSize);
+    public JLabel createLabel(String text) {
+        return new JLabel(text, SwingConstants.RIGHT);
     }
 
     public void refresh() {
@@ -223,74 +147,18 @@ public class BAStructureTab extends ITab
         panArmor.setFromEntity(getBattleArmor());
         panEnhancements.setFromEntity(getBattleArmor());
         iconView.setFromEntity(getEntity());
+        panManipulator.setFromEntity();
 
         removeAllListeners();
-
-        // Manipulators
-        leftManipulatorSelect.removeAllItems();
-        rightManipulatorSelect.removeAllItems();
-        leftManipulatorSelect.addItem(BattleArmor.MANIPULATOR_TYPE_STRINGS[BattleArmor.MANIPULATOR_NONE]);
-        rightManipulatorSelect.addItem(BattleArmor.MANIPULATOR_TYPE_STRINGS[BattleArmor.MANIPULATOR_NONE]);
-        for (BAManipulator manipulator : BAManipulator.values()) {
-            EquipmentType et = EquipmentType.get(manipulator.internalName);
-            if ((null != et) && getTechManager().isLegal(et)) {
-                leftManipulatorSelect.addItem(et.getName());
-                rightManipulatorSelect.addItem(et.getName());
-            }
-        }
-        BAManipulator manipulator = BAManipulator.getManipulator(getBattleArmor().getLeftManipulatorName());
-
-        if (manipulator != null) {
-            leftManipulatorSelect.setSelectedItem(BattleArmor.MANIPULATOR_NAME_STRINGS[manipulator.type]);
-        }
-
-        manipulator = BAManipulator.getManipulator(getBattleArmor().getRightManipulatorName());
-
-        if (manipulator != null) {
-            rightManipulatorSelect.setSelectedItem(BattleArmor.MANIPULATOR_NAME_STRINGS[manipulator.type]);
-
-            refreshManipulatorSizes(BattleArmor.MOUNT_LOC_LEFT_ARM,
-                  spnLeftManipulatorSize,
-                  spnLeftManipulatorSizeModel);
-            // For variable-sized pair-mounted manipulators, we'll only use one spinner
-            spnRightManipulatorSize.setEnabled(!manipulator.pairMounted);
-            refreshManipulatorSizes(BattleArmor.MOUNT_LOC_RIGHT_ARM,
-                  spnRightManipulatorSize,
-                  spnRightManipulatorSizeModel);
-            lblSize.setVisible(spnLeftManipulatorSize.isVisible() || spnRightManipulatorSize.isVisible());
-        }
-
         refreshPreview();
-
         addAllListeners();
-    }
-
-    /**
-     * Sets values for the size control if the manipulator has a variable size; otherwise hides it.
-     *
-     * @param mountLoc The mount location
-     * @param spinner  The spinner to show/hide
-     * @param model    The spinner's number model
-     */
-    private void refreshManipulatorSizes(int mountLoc, JSpinner spinner, SpinnerNumberModel model) {
-        Optional<MiscMounted> mounted = getBattleArmor().getMisc().stream()
-              .filter(m -> m.getType().hasFlag(MiscType.F_BA_MANIPULATOR) && (m.getBaMountLoc() == mountLoc))
-              .findFirst();
-        if (mounted.isPresent() && mounted.get().getType().isVariableSize()) {
-            model.setValue(mounted.get().getSize());
-            model.setStepSize(mounted.get().getType().variableStepSize());
-            model.setMinimum(mounted.get().getType().variableStepSize());
-            spinner.setVisible(true);
-        } else {
-            spinner.setVisible(false);
-        }
     }
 
     public ITechManager getTechManager() {
         return panBasicInfo;
     }
 
-    /*
+    /**
      * Used by MekHQ to set the tech faction for custom refits.
      */
     public void setTechFaction(Faction techFaction) {
@@ -298,11 +166,6 @@ public class BAStructureTab extends ITab
     }
 
     public void addAllListeners() {
-        leftManipulatorSelect.addActionListener(this);
-        rightManipulatorSelect.addActionListener(this);
-        spnLeftManipulatorSize.addChangeListener(this);
-        spnRightManipulatorSize.addChangeListener(this);
-
         panBasicInfo.addListener(this);
         panChassis.addListener(this);
         panMovement.addListener(this);
@@ -311,11 +174,6 @@ public class BAStructureTab extends ITab
     }
 
     public void removeAllListeners() {
-        leftManipulatorSelect.removeActionListener(this);
-        rightManipulatorSelect.removeActionListener(this);
-        spnLeftManipulatorSize.removeChangeListener(this);
-        spnRightManipulatorSize.removeChangeListener(this);
-
         panBasicInfo.removeListener(this);
         panChassis.removeListener(this);
         panMovement.removeListener(this);
@@ -325,100 +183,7 @@ public class BAStructureTab extends ITab
 
     public void addRefreshedListener(RefreshListener l) {
         refresh = l;
-    }
-
-    @Override
-    public void actionPerformed(ActionEvent e) {
-        removeAllListeners();
-        if (e.getSource() instanceof JComboBox) {
-            if (e.getSource().equals(leftManipulatorSelect) || e.getSource().equals(rightManipulatorSelect)) {
-                String name = (String) ((JComboBox<?>) e.getSource()).getSelectedItem();
-                setManipulator(BAManipulator.getManipulator(name),
-                      e.getSource().equals(leftManipulatorSelect) ? BattleArmor.MOUNT_LOC_LEFT_ARM
-                            : BattleArmor.MOUNT_LOC_RIGHT_ARM,
-                      true);
-            }
-        }
-        refresh.refreshAll();
-    }
-
-    private void setManipulator(BAManipulator manipulator, int mountLoc, boolean checkPaired) {
-        MiscMounted current = getManipulator(mountLoc);
-        if (current != null) {
-            UnitUtil.removeMounted(getBattleArmor(), current);
-        }
-        if (manipulator != BAManipulator.NONE) {
-            MiscMounted newMount = new MiscMounted(getBattleArmor(),
-                  (MiscType) EquipmentType.get(manipulator.internalName));
-            newMount.setBaMountLoc(mountLoc);
-            try {
-                getBattleArmor().addEquipment(newMount, BattleArmor.LOC_SQUAD, false);
-            } catch (LocationFullException ex) {
-                logger.error("Could not mount {}", manipulator, ex);
-            }
-        }
-        if (checkPaired) {
-            int otherArm = mountLoc == (BattleArmor.MOUNT_LOC_LEFT_ARM) ? BattleArmor.MOUNT_LOC_RIGHT_ARM
-                  : BattleArmor.MOUNT_LOC_LEFT_ARM;
-            if (manipulator.pairMounted) {
-                setManipulator(manipulator, otherArm, false);
-            } else if ((current != null) && isPairedManipulator(current.getType())) {
-                MiscMounted toRemove = getManipulator(otherArm);
-                if (toRemove != null) {
-                    UnitUtil.removeMounted(getBattleArmor(), toRemove);
-                }
-            }
-        }
-        refresh.refreshSummary();
-        refresh.refreshPreview();
-    }
-
-    private @Nullable MiscMounted getManipulator(int mountLoc) {
-        return getBattleArmor().getMisc().stream()
-              .filter(m -> (m.getBaMountLoc() == mountLoc) && m.getType().hasFlag(MiscType.F_BA_MANIPULATOR))
-              .findFirst().orElse(null);
-    }
-
-    private boolean isPairedManipulator(EquipmentType eq) {
-        BAManipulator manipulator = BAManipulator.getManipulator(eq.getInternalName());
-        if (manipulator != null) {
-            return manipulator.pairMounted;
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public void stateChanged(ChangeEvent evt) {
-        if (evt.getSource() == spnLeftManipulatorSize) {
-            setManipulatorSize(BattleArmor.MOUNT_LOC_LEFT_ARM, spnLeftManipulatorSizeModel.getNumber().doubleValue());
-            String leftManipulatorName = getBattleArmor().getLeftManipulatorName();
-            BAManipulator manipulator = BAManipulator.getManipulator(leftManipulatorName);
-            if (manipulator != null && manipulator.pairMounted) {
-                spnRightManipulatorSizeModel.setValue(spnLeftManipulatorSizeModel.getValue());
-            }
-        } else if (evt.getSource() == spnRightManipulatorSize) {
-            setManipulatorSize(BattleArmor.MOUNT_LOC_RIGHT_ARM, spnRightManipulatorSizeModel.getNumber().doubleValue());
-        }
-        refresh.refreshAll();
-    }
-
-    private void setManipulatorSize(int mountLoc, double size) {
-        Optional<MiscMounted> mounted = getBattleArmor().getMisc().stream()
-              .filter(m -> m.getType().hasFlag(MiscType.F_BA_MANIPULATOR) && (m.getBaMountLoc() == mountLoc))
-              .findFirst();
-        mounted.ifPresent(value -> value.setSize(size));
-    }
-
-    /**
-     * Extracts the actual name of the manipulator from the full equipment name
-     */
-    private String manipulatorDisplayName(String name) {
-        int start = name.indexOf("[");
-        if (start > 0) {
-            return name.substring(start + 1).replace("]", "");
-        }
-        return name;
+        panManipulator.addRefreshedListener(l);
     }
 
     public void setAsCustomization() {
@@ -426,7 +191,9 @@ public class BAStructureTab extends ITab
     }
 
     public void refreshPreview() {
-        previewTab.refresh();
+        if (refresh != null) {
+            refresh.refreshPreview();
+        }
     }
 
     @Override
@@ -579,6 +346,7 @@ public class BAStructureTab extends ITab
         panChassis.setFromEntity(getBattleArmor());
         panMovement.setFromEntity(getBattleArmor());
         panEnhancements.setFromEntity(getBattleArmor());
+        panManipulator.setFromEntity();
         refreshPreview();
         refresh.refreshStatus();
         refresh.refreshBuild();

--- a/megameklab/src/megameklab/util/BattleArmorUtil.java
+++ b/megameklab/src/megameklab/util/BattleArmorUtil.java
@@ -41,6 +41,7 @@ import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponType;
+import megamek.common.equipment.enums.MiscTypeFlag;
 import megamek.common.units.Entity;
 import megamek.common.weapons.attacks.LegAttack;
 import megamek.common.weapons.attacks.StopSwarmAttack;
@@ -235,15 +236,15 @@ public final class BattleArmorUtil {
 
     /**
      * Unallocates (removes from arm/body etc to the unallocated equipment list) the given mounted. For special mounts
-     * for other equipment (DWP etc), that other equipment is removed from this mount first, emptying the given
-     * mounted. This method will unallocate regardless of the type of equipment, i.e., it does not check if this
-     * equipment should ever go unallocated (e.g. fixed location equipment). It is therefore up to the caller to
-     * select equipment to unallocate.
+     * for other equipment (DWP etc), that other equipment is removed from this mount first, emptying the given mounted.
+     * This method will unallocate regardless of the type of equipment, i.e., it does not check if this equipment should
+     * ever go unallocated (e.g. fixed location equipment). It is therefore up to the caller to select equipment to
+     * unallocate.
      *
      * @param mounted The equipment to unallocate
      */
     public static void unallocateMounted(BattleArmor battleArmor, Mounted<?> mounted) {
-        if (isFilledDwp(mounted) || isFilledApm(mounted)) {
+        if (isFilledDwp(mounted) || isFilledApm(mounted) || isFilledArmoredGlove(mounted)) {
             emptyDwpApm(mounted);
         }
         if ((mounted.isAPMMounted() || mounted.isDWPMounted()) && mounted.getLinkedBy() != null) {
@@ -271,6 +272,13 @@ public final class BattleArmorUtil {
     }
 
     /**
+     * @return True when the given mounted is an Armored Glove manipulator and it has an AP weapon allocated to it.
+     */
+    public static boolean isFilledArmoredGlove(Mounted<?> mounted) {
+        return mounted.getType().hasFlag(MiscTypeFlag.F_ARMORED_GLOVE) && mounted.getLinked() != null;
+    }
+
+    /**
      * Removes all critical slots for the given BA, unallocating all equipment (i.e., placing it into
      * BattleArmor.MOUNT_LOC_NONE and BattleArmor.LOC_SQUAD).
      */
@@ -280,8 +288,8 @@ public final class BattleArmorUtil {
 
     /**
      * Removes all critical slots from the given locations for the given BA, unallocating all equipment in those
-     * locations (i.e., placing it into BattleArmor.MOUNT_LOC_NONE and BattleArmor.LOC_SQUAD). Fixed location
-     * equipment is not affected (it is left in place).
+     * locations (i.e., placing it into BattleArmor.MOUNT_LOC_NONE and BattleArmor.LOC_SQUAD). Fixed location equipment
+     * is not affected (it is left in place).
      */
     public static void removeAllCriticalSlotsFrom(BattleArmor battleArmor, List<Integer> locations) {
         battleArmor.getEquipment()
@@ -295,7 +303,17 @@ public final class BattleArmorUtil {
     public static boolean isFilledWeaponMount(Mounted<?> mounted) {
         return isFilledDwp(mounted) || isFilledApm(mounted)
               || (mounted.getType().hasFlag(MiscType.F_AP_MOUNT) && mounted.getLinked() != null);
+    }
 
+    /**
+     * Removes all manipulator equipment, including Modular Equipment Adaptors, from the unit.
+     *
+     * @param battleArmor The BA
+     */
+    public static void removeManipulatorEquipment(BattleArmor battleArmor) {
+        UnitUtil.removeAllMounted(battleArmor, EquipmentType.get(EquipmentTypeLookup.BA_MODULAR_EQUIPMENT_ADAPTOR));
+        // UnitUtil calls unallocateMounted to unallocate attached AP weapons
+        UnitUtil.removeAllMiscMounted(battleArmor, MiscTypeFlag.F_BA_MANIPULATOR);
     }
 
     private BattleArmorUtil() {

--- a/megameklab/src/megameklab/util/BattleArmorUtil.java
+++ b/megameklab/src/megameklab/util/BattleArmorUtil.java
@@ -37,11 +37,11 @@ import megamek.common.battleArmor.BattleArmor;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.EquipmentTypeLookup;
-import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponType;
 import megamek.common.equipment.enums.MiscTypeFlag;
+import megamek.common.units.BaConstructionUtil;
 import megamek.common.units.Entity;
 import megamek.common.weapons.attacks.LegAttack;
 import megamek.common.weapons.attacks.StopSwarmAttack;
@@ -51,6 +51,8 @@ import megamek.logging.MMLogger;
 
 import java.util.List;
 import java.util.stream.IntStream;
+
+import static megamek.common.units.BaConstructionUtil.*;
 
 public final class BattleArmorUtil {
 
@@ -171,30 +173,6 @@ public final class BattleArmorUtil {
     }
 
     /**
-     * Mounts the given weapon on the given Anti-Personnel Weapon Mount, which may be either the misc item or an armored
-     * glove. Any previously mounted weapon is removed from it, becoming unallocated. Does nothing and logs a warning
-     * when the given apm Mounted is not a suitable AP mount or the given weapon may not be mounted on an APM.
-     *
-     * @param weapon The weapon to mount on the APM
-     * @param apm    The APM to receive the weapon
-     */
-    public static void mountOnApm(Mounted<?> weapon, Mounted<?> apm) {
-        if (!(apm instanceof MiscMounted miscMounted) || !miscMounted.getType().hasFlag(MiscType.F_AP_MOUNT)) {
-            LOGGER.warn("Trying to APM-mount on an item that is not an AP mount or armored glove!");
-            return;
-        }
-        if (!weapon.getType().hasFlag(WeaponType.F_INFANTRY)) {
-            LOGGER.warn("Trying to APM-mount invalid equipment!");
-            return;
-        }
-        emptyDwpApm(apm);
-        weapon.setLinkedBy(apm);
-        apm.setLinked(weapon);
-        weapon.setAPMMounted(true);
-        weapon.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
-    }
-
-    /**
      * Empties the given Detachable Weapon Pack, removing any weapon mounted on it. Can be safely called (does nothing)
      * when there is no weapon on the DWP or the given Mounted is not a DWP (in this case, logs a warning).
      *
@@ -221,17 +199,7 @@ public final class BattleArmorUtil {
      * @param mount The APM/DWP to empty
      */
     public static void emptyDwpApm(Mounted<?> mount) {
-        if (!mount.is(EquipmentTypeLookup.BA_DWP) && !mount.getType().hasFlag(MiscType.F_AP_MOUNT)) {
-            LOGGER.warn("Trying to unattach equipment from something that is neither APM nor DWP!");
-            return;
-        }
-        if (mount.getLinked() != null) {
-            Mounted<?> attachedEquipment = mount.getLinked();
-            attachedEquipment.setLinkedBy(null);
-            attachedEquipment.setDWPMounted(false);
-            attachedEquipment.setAPMMounted(false);
-            mount.setLinked(null);
-        }
+        BaConstructionUtil.emptyDwpApm(mount);
     }
 
     /**
@@ -244,38 +212,7 @@ public final class BattleArmorUtil {
      * @param mounted The equipment to unallocate
      */
     public static void unallocateMounted(BattleArmor battleArmor, Mounted<?> mounted) {
-        if (isFilledDwp(mounted) || isFilledApm(mounted) || isFilledArmoredGlove(mounted)) {
-            emptyDwpApm(mounted);
-        }
-        if ((mounted.isAPMMounted() || mounted.isDWPMounted()) && mounted.getLinkedBy() != null) {
-            emptyDwpApm(mounted.getLinkedBy());
-        }
-        mounted.setDWPMounted(false);
-        mounted.setAPMMounted(false);
-        mounted.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
-        UnitUtil.changeMountStatus(battleArmor, mounted, BattleArmor.LOC_SQUAD, BattleArmor.LOC_SQUAD, false);
-    }
-
-    /**
-     * @return True when the given mounted is a Detachable Weapon Pack and it has a weapon allocated to it.
-     */
-    public static boolean isFilledDwp(Mounted<?> mounted) {
-        return mounted.is(EquipmentTypeLookup.BA_DWP) && mounted.getLinked() != null;
-    }
-
-    /**
-     * @return True when the given mounted is an Anti-Personnel weapon mount (only the misc item, not an armored glove!)
-     *       and it has a weapon allocated to it.
-     */
-    public static boolean isFilledApm(Mounted<?> mounted) {
-        return mounted.is(EquipmentTypeLookup.BA_APM) && mounted.getLinked() != null;
-    }
-
-    /**
-     * @return True when the given mounted is an Armored Glove manipulator and it has an AP weapon allocated to it.
-     */
-    public static boolean isFilledArmoredGlove(Mounted<?> mounted) {
-        return mounted.getType().hasFlag(MiscTypeFlag.F_ARMORED_GLOVE) && mounted.getLinked() != null;
+        BaConstructionUtil.unallocateMounted(battleArmor, mounted);
     }
 
     /**

--- a/megameklab/src/megameklab/util/BattleArmorUtil.java
+++ b/megameklab/src/megameklab/util/BattleArmorUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/util/MekUtil.java
+++ b/megameklab/src/megameklab/util/MekUtil.java
@@ -38,7 +38,6 @@ import static megameklab.util.UnitUtil.changeMountStatus;
 import static megameklab.util.UnitUtil.getCritsUsed;
 import static megameklab.util.UnitUtil.isNonMekOrTankWeapon;
 import static megameklab.util.UnitUtil.isValidLocation;
-import static megameklab.util.UnitUtil.removeAllMounted;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -65,6 +64,7 @@ import megamek.common.units.BipedMek;
 import megamek.common.units.Entity;
 import megamek.common.units.LandAirMek;
 import megamek.common.units.Mek;
+import megamek.common.units.MekConstructionUtil;
 import megamek.common.units.QuadMek;
 import megamek.common.units.TripodMek;
 import megamek.common.weapons.c3.ISC3M;
@@ -876,27 +876,6 @@ public final class MekUtil {
     }
 
     /**
-     * Clears all links of the given equipment to other equipment and un-allocates it (assigns to LOC_NONE). Note: Does
-     * not clear the equipment's crit slots from its former location. For this, use
-     * {@link UnitUtil#removeCriticalSlots(Entity, Mounted)}
-     */
-    public static void clearMountedLocationAndLinked(Mounted<?> equipment) {
-        if ((Entity.LOC_NONE != equipment.getLocation()) && !equipment.isOneShot()) {
-            if (equipment.getLinked() != null) {
-                equipment.getLinked().setLinkedBy(null);
-                equipment.setLinked(null);
-            }
-            if (equipment.getLinkedBy() != null) {
-                equipment.getLinkedBy().setLinked(null);
-                equipment.setLinkedBy(null);
-            }
-        }
-        equipment.setLocation(Entity.LOC_NONE, false);
-        equipment.setSecondLocation(Entity.LOC_NONE, false);
-        equipment.setSplit(false);
-    }
-
-    /**
      * Moves all equipment that is freely movable and unhittable (e.g. Endo Steel and Ferro-Fibrous but not CASE)
      * ("FMU") that is currently unallocated (LOC_NONE) to free locations on the Mek as long as there are any.
      */
@@ -1270,46 +1249,7 @@ public final class MekUtil {
      * @param mek the mek to update
      */
     public static void updateClanCasePlacement(Mek mek) {
-        boolean hadClanCase = mek.isClan() || mek.hasClanCaseEquipped();
-        if (hadClanCase) {
-            removeAllMounted(mek, EquipmentType.get(EquipmentTypeLookup.CLAN_CASE));
-            addClanCaseToExplosiveLocations(mek);
-        }
-    }
-
-    /**
-     * Adds Clan CASE to all locations on the Mek that have explosive equipment and don't already have CASE or CASE II.
-     * Unlike {@link Mek#addClanCase()}, this does not check tech base or existing Clan CASE presence.
-     * Respects per-location opt-out via {@link Mek#isClanCaseOptedOut(int)}.
-     *
-     * @param mek the mek to add Clan CASE to
-     */
-    public static void addClanCaseToExplosiveLocations(Mek mek) {
-        EquipmentType clCase = EquipmentType.get(EquipmentTypeLookup.CLAN_CASE);
-        for (int i = 0; i < mek.locations(); i++) {
-            if (mek.locationHasCase(i) || mek.hasCASEII(i)) {
-                continue;
-            }
-            // Respect per-location opt-out
-            if (mek.isClanCaseOptedOut(i)) {
-                continue;
-            }
-            boolean explosiveFound = false;
-            for (Mounted<?> m : mek.getEquipment()) {
-                if (m.getType().isExplosive(m, true)
-                      && ((m.getLocation() == i) || (m.getSecondLocation() == i))) {
-                    explosiveFound = true;
-                    break;
-                }
-            }
-            if (explosiveFound) {
-                try {
-                    mek.addEquipment(Mounted.createMounted(mek, clCase), i, false);
-                } catch (Exception ignored) {
-                    // 0-crit equipment shouldn't fail
-                }
-            }
-        }
+        MekConstructionUtil.updateClanCasePlacement(mek);
     }
 
     /**

--- a/megameklab/src/megameklab/util/MekUtil.java
+++ b/megameklab/src/megameklab/util/MekUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -266,128 +266,7 @@ public class UnitUtil {
      * @param mount The equipment
      */
     public static void removeMounted(Entity unit, Mounted<?> mount) {
-        UnitUtil.removeCriticalSlots(unit, mount);
-
-        if (unit instanceof BattleArmor battleArmor) {
-            // DWP and APM require special treatment
-            BattleArmorUtil.unallocateMounted(battleArmor, mount);
-        }
-
-        // We will need to reset the equipment numbers of the bay ammo and weapons
-        Map<WeaponMounted, List<WeaponMounted>> bayWeapons = new HashMap<>();
-        Map<WeaponMounted, List<AmmoMounted>> bayAmmo = new HashMap<>();
-        for (WeaponMounted bay : unit.getWeaponBayList()) {
-            bayWeapons.put(bay, bay.getBayWeapons());
-            bayAmmo.put(bay, bay.getBayAmmo());
-        }
-
-        // Some special checks for Aeros
-        if (unit instanceof Aero) {
-            if (mount instanceof WeaponMounted) {
-                // Aeros have additional weapon lists that need to be cleared
-                unit.getTotalWeaponList().remove(mount);
-                unit.getWeaponBayList().remove(mount);
-                unit.getWeaponGroupList().remove(mount);
-            }
-        }
-
-        unit.getEquipment().remove(mount);
-
-        if (mount instanceof MiscMounted) {
-            unit.getMisc().remove(mount);
-        } else if (mount instanceof AmmoMounted) {
-            unit.getAmmo().remove(mount);
-        } else if (mount instanceof WeaponMounted) {
-            unit.getWeaponList().remove(mount);
-            unit.getTotalWeaponList().remove(mount);
-        }
-
-        if (mount instanceof WeaponMounted && bayWeapons.containsKey(mount)) {
-            bayWeapons.get(mount).forEach(w -> {
-                removeCriticalSlots(unit, w);
-                changeMountStatus(unit, w, Entity.LOC_NONE, Entity.LOC_NONE, false);
-            });
-            bayAmmo.get(mount).forEach(a -> {
-                removeCriticalSlots(unit, a);
-                Mounted<?> moveTo = UnitUtil.findUnallocatedAmmo(unit, a.getType());
-
-                if (null != moveTo) {
-                    moveTo.setShotsLeft(moveTo.getBaseShotsLeft() + a.getBaseShotsLeft());
-                    UnitUtil.removeMounted(unit, a);
-                }
-
-                changeMountStatus(unit, a, Entity.LOC_NONE, Entity.LOC_NONE, false);
-            });
-            bayWeapons.remove(mount);
-            bayAmmo.remove(mount);
-        }
-
-        for (WeaponMounted bay : bayWeapons.keySet()) {
-            bay.clearBayWeapons();
-            for (WeaponMounted w : bayWeapons.get(bay)) {
-                if (mount != w) {
-                    bay.addWeaponToBay(w);
-                }
-            }
-        }
-
-        for (WeaponMounted bay : bayAmmo.keySet()) {
-            bay.clearBayAmmo();
-            for (AmmoMounted a : bayAmmo.get(bay)) {
-                if (mount != a) {
-                    bay.addAmmoToBay(a);
-                }
-            }
-        }
-
-        // Remove ammo added for a one-shot launcher
-        if ((mount.getType() instanceof WeaponType) && mount.isOneShot()) {
-            List<AmmoMounted> osAmmo = new ArrayList<>();
-            for (AmmoMounted ammo = (AmmoMounted) mount.getLinked();
-                  ammo != null;
-                  ammo = (AmmoMounted) ammo.getLinked()) {
-                osAmmo.add(ammo);
-            }
-            osAmmo.forEach(m -> {
-                unit.getEquipment().remove(m);
-                unit.getAmmo().remove(m);
-            });
-        }
-
-        // It's possible that the equipment we are removing was linked to something else, and so the linkedBy state may
-        // be set. We should remove it. Using getLinked could be unreliable, so we'll brute force it. An example of this
-        // would be removing a linked Artemis IV FCS
-        for (Mounted<?> m : unit.getEquipment()) {
-            if (mount.equals(m.getLinkedBy())) {
-                m.setLinkedBy(null);
-            }
-        }
-
-        if ((mount.getType() instanceof MiscType) &&
-              (mount.getType().hasFlag(MiscType.F_HEAD_TURRET) ||
-                    mount.getType().hasFlag(MiscType.F_SHOULDER_TURRET) ||
-                    mount.getType().hasFlag(MiscType.F_QUAD_TURRET))) {
-            for (Mounted<?> m : unit.getEquipment()) {
-                if (m.getLocation() == mount.getLocation()) {
-                    m.setMekTurretMounted(false);
-                }
-            }
-        }
-
-        if ((mount.getType() instanceof MiscType) && mount.getType().hasFlag(MiscType.F_SPONSON_TURRET)) {
-            for (Mounted<?> m : unit.getEquipment()) {
-                m.setSponsonTurretMounted(false);
-            }
-        }
-
-        if ((mount.getType() instanceof MiscType) && mount.getType().hasFlag(MiscType.F_PINTLE_TURRET)) {
-            for (Mounted<?> m : unit.getEquipment()) {
-                if (m.getLocation() == mount.getLocation()) {
-                    m.setPintleTurretMounted(false);
-                }
-            }
-        }
-        unit.recalculateTechAdvancement();
+        ConstructionUtil.removeMounted(unit, mount);
     }
 
     /**
@@ -444,26 +323,7 @@ public class UnitUtil {
      * @param mounted The equipment to test
      */
     public static void removeCriticalSlots(Entity unit, @Nullable Mounted<?> mounted) {
-        for (int loc = 0; loc < unit.locations(); loc++) {
-            for (int slot = 0; slot < unit.getNumberOfCriticalSlots(loc); slot++) {
-                CriticalSlot criticalSlot = unit.getCritical(loc, slot);
-                if ((criticalSlot != null) && (criticalSlot.getType() == CriticalSlot.TYPE_EQUIPMENT)) {
-                    if ((criticalSlot.getMount() != null) && (criticalSlot.getMount().equals(mounted))) {
-                        // If there are two pieces of equipment in this slot, remove first one, and replace it with
-                        // the second
-                        if (criticalSlot.getMount2() != null) {
-                            criticalSlot.setMount(criticalSlot.getMount2());
-                            criticalSlot.setMount2(null);
-                        } else {
-                            // If it's the only Mounted, clear the slot
-                            unit.setCritical(loc, slot, null);
-                        }
-                    } else if ((criticalSlot.getMount2() != null) && (criticalSlot.getMount2().equals(mounted))) {
-                        criticalSlot.setMount2(null);
-                    }
-                }
-            }
-        }
+        ConstructionUtil.removeCriticalSlots(unit, mounted);
     }
 
     /**
@@ -705,30 +565,7 @@ public class UnitUtil {
      */
     public static void changeMountStatus(Entity unit, Mounted<?> eq, int location, int secondaryLocation,
           boolean rear) {
-        if ((location != eq.getLocation() && !eq.isOneShot())) {
-            if (eq.getLinked() != null) {
-                eq.getLinked().setLinkedBy(null);
-                eq.setLinked(null);
-            }
-            if (eq.getLinkedBy() != null) {
-                eq.getLinkedBy().setLinked(null);
-                eq.setLinkedBy(null);
-            }
-        }
-        eq.setLocation(location, rear);
-        eq.setSecondLocation(secondaryLocation, rear);
-        eq.setSplit(secondaryLocation > -1);
-        // If we're adding it to a location on the unit, check equipment linkages
-        if (location > Entity.LOC_NONE) {
-            try {
-                MekFileParser.postLoadInit(unit);
-            } catch (Exception ignored) {
-                // Exception thrown for not having equipment to link to yet, which is acceptable here
-            }
-        }
-        if (unit instanceof Mek mek) {
-            MekUtil.updateClanCasePlacement(mek);
-        }
+        ConstructionUtil.changeMountStatus(unit, eq, location, secondaryLocation, rear);
     }
 
     public static void resizeMount(Mounted<?> mount, double newSize) {
@@ -788,14 +625,7 @@ public class UnitUtil {
      * @return An unallocated non-one-shot ammo mount of the same type, or null if there is not one.
      */
     public static Mounted<?> findUnallocatedAmmo(Entity unit, EquipmentType at) {
-        for (Mounted<?> m : unit.getAmmo()) {
-            if ((m.getLocation() == Entity.LOC_NONE) &&
-                  at.equals(m.getType()) &&
-                  ((m.getLinkedBy() == null) || !m.getLinkedBy().getType().hasFlag(WeaponType.F_ONE_SHOT))) {
-                return m;
-            }
-        }
-        return null;
+        return ConstructionUtil.findUnallocatedAmmo(unit, at);
     }
 
     /**

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -139,6 +139,7 @@ public class UnitUtil {
     public static boolean isFixedLocationSpreadEquipment(EquipmentType equipmentType) {
         return (equipmentType instanceof MiscType miscType) && (miscType.hasFlag(MiscType.F_JUMP_BOOSTER)
               || miscType.hasFlag(MiscType.F_BA_MANIPULATOR)
+              || miscType.is(EquipmentTypeLookup.BA_MODULAR_EQUIPMENT_ADAPTOR)
               || miscType.hasFlag(MiscType.F_PARTIAL_WING)
               || miscType.hasFlag(MiscType.F_NULL_SIG)
               || miscType.hasFlag(MiscType.F_VOID_SIG)


### PR DESCRIPTION
## Requires MM [#8161](https://github.com/MegaMek/megamek/pull/8161) !!!

## BA changes:
- Moves the unit preview to its own tab and rearranges the main BA screen in accordance with other unit types, see screenshot
- moves BA manipulators to their own view class, adding MEA selectors
- accordingly, removes MEA from manual equipment selection and dnd movement
- to avoid size issues, arranges the checkboxes in the enhancement view in one column
- moves some construction code over to MM so that the same construction code can be used in MM and MML, see the MM PR
<img width="1418" height="694" alt="image" src="https://github.com/user-attachments/assets/56a055b2-3420-4e89-b637-f14315bb8c54" />
