### PR TITLE
Add licensing acknowledgment dialog on startup and update About dialog

### DIFF
--- a/megameklab/src/megameklab/MegaMekLab.java
+++ b/megameklab/src/megameklab/MegaMekLab.java
@@ -229,10 +229,6 @@ public class MegaMekLab {
 
         updateGuiScaling(); // also sets the look-and-feel
 
-        // Show licensing/welcome dialog
-        LicensingDialog.showIfNeeded(null,
-              "Welcome to MegaMekLab " + MMLConstants.VERSION);
-
         if (args.length >= 1) {
             String name = args[0];
             if (openUnitFile(name, noStartup)) {
@@ -258,6 +254,12 @@ public class MegaMekLab {
             }
             case RESTORE_TABS -> UiLoader.restoreTabbedUi();
             default -> StartupGUI.getInstance().setVisible(true);
+        }
+
+        // Show licensing/welcome dialog after startup screen is visible
+        if (!noStartup) {
+            LicensingDialog.showIfNeeded(null,
+                  "Welcome to " + MMLConstants.PROJECT_NAME + " " + MMLConstants.VERSION);
         }
     }
 

--- a/megameklab/src/megameklab/MegaMekLab.java
+++ b/megameklab/src/megameklab/MegaMekLab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -47,6 +47,7 @@ import megamek.MMLoggingConstants;
 import megamek.MegaMek;
 import megamek.SuiteConstants;
 import megamek.client.ui.clientGUI.GUIPreferences;
+import megamek.client.ui.dialogs.LicensingDialog;
 import megamek.client.ui.preferences.SuitePreferences;
 import megamek.client.ui.util.UIUtil;
 import megamek.common.equipment.EquipmentType;
@@ -227,6 +228,10 @@ public class MegaMekLab {
         Locale.setDefault(getMMLOptions().getLocale());
 
         updateGuiScaling(); // also sets the look-and-feel
+
+        // Show licensing/welcome dialog
+        LicensingDialog.showIfNeeded(null,
+              "Welcome to MegaMekLab " + MMLConstants.VERSION);
 
         if (args.length >= 1) {
             String name = args[0];

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -51,6 +51,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 
 import megamek.client.ui.Messages;
 import megamek.client.ui.clientGUI.GUIPreferences;
+import megamek.client.ui.dialogs.LicensingDialog;
 import megamek.client.ui.dialogs.UnitLoadingDialog;
 import megamek.client.ui.dialogs.abstractDialogs.BVDisplayDialog;
 import megamek.client.ui.dialogs.abstractDialogs.CostDisplayDialog;
@@ -1282,13 +1283,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         body.setAlignmentX(Component.CENTER_ALIGNMENT);
         body.addHyperlinkListener(e -> {
             if (e.getEventType() == javax.swing.event.HyperlinkEvent.EventType.ACTIVATED) {
-                if (java.awt.Desktop.isDesktopSupported()) {
-                    try {
-                        java.awt.Desktop.getDesktop().browse(e.getURL().toURI());
-                    } catch (Exception ex) {
-                        logger.error(ex, "Could not open link: {}", e.getURL());
-                    }
-                }
+                UIUtil.browse(e.getURL().toString(), owner.getFrame());
             }
         });
 
@@ -1306,23 +1301,8 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
     }
 
     private static String buildAboutHtml() {
-        int width = UIUtil.scaleForGUI(500);
-        String wikiUrl = Messages.getString("LicensingDialog.wikiUrl");
-        String gameContentRulesUrl = Messages.getString("LicensingDialog.gameContentRulesUrl");
-        String gameContentRulesText = Messages.getString("LicensingDialog.gameContentRulesText");
-        String discordUrl = Messages.getString("LicensingDialog.discordUrl");
-        String discordText = Messages.getString("LicensingDialog.discordText");
-
-        return "<html><body width='" + width + "'>"
-              + "<p>" + Messages.getString("LicensingDialog.disclaimer") + "</p>"
-              + "<p>" + Messages.getString("LicensingDialog.licensing")
-              + " <a href=\"" + gameContentRulesUrl + "\">" + gameContentRulesText + "</a>.</p>"
-              + "<p>" + Messages.getString("LicensingDialog.wiki")
-              + " <a href=\"" + wikiUrl + "\">" + wikiUrl + "</a></p>"
-              + "<p>" + Messages.getString("CommonAboutDialog.community")
-              + " <a href=\"" + discordUrl + "\">" + discordText + "</a>.</p>"
-              + "<p><small><i>" + Messages.getString("LicensingDialog.trademark")
-              + "</i></small></p>"
+        return "<html><body width='" + UIUtil.scaleForGUI(500) + "'>"
+              + LicensingDialog.buildLegalHtml()
               + "</body></html>";
     }
 

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2011-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -49,6 +49,7 @@ import javax.swing.*;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
+import megamek.client.ui.Messages;
 import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.dialogs.UnitLoadingDialog;
 import megamek.client.ui.dialogs.abstractDialogs.BVDisplayDialog;
@@ -1262,23 +1263,23 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
 
     // Show data about MegaMekLab
     private void aboutAction() {
-        // make the dialog
         JDialog dlg = new JDialog(owner.getFrame(), resources.getString("menu.help.about.title"));
 
-        // set up the contents
         JPanel child = new JPanel();
         child.setLayout(new BoxLayout(child, BoxLayout.Y_AXIS));
         child.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
-        // set the text up.
         JLabel version = new JLabel(String.format(resources.getString("menu.help.about.version.format"),
               MMLConstants.VERSION));
+        version.setAlignmentX(Component.CENTER_ALIGNMENT);
+
         JEditorPane body = new JEditorPane();
         body.setContentType("text/html");
         body.setEditable(false);
         body.setOpaque(false);
-        body.setText(resources.getString("menu.help.about.text"));
-
+        body.setText(buildAboutHtml());
+        body.setCaretPosition(0);
+        body.setAlignmentX(Component.CENTER_ALIGNMENT);
         body.addHyperlinkListener(e -> {
             if (e.getEventType() == javax.swing.event.HyperlinkEvent.EventType.ACTIVATED) {
                 if (java.awt.Desktop.isDesktopSupported()) {
@@ -1291,23 +1292,38 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
             }
         });
 
-        // center everything
-        version.setAlignmentX(Component.CENTER_ALIGNMENT);
-        body.setAlignmentX(Component.CENTER_ALIGNMENT);
-
-        // add to child panel
         child.add(new JLabel("\n"));
         child.add(version);
         child.add(new JLabel("\n"));
         child.add(body);
 
-        // then add child panel to the content pane.
         dlg.getContentPane().add(child);
         dlg.setLocationRelativeTo(owner.getFrame());
         dlg.setModal(true);
         dlg.setResizable(false);
         dlg.pack();
         dlg.setVisible(true);
+    }
+
+    private static String buildAboutHtml() {
+        int width = UIUtil.scaleForGUI(500);
+        String wikiUrl = Messages.getString("LicensingDialog.wikiUrl");
+        String gameContentRulesUrl = Messages.getString("LicensingDialog.gameContentRulesUrl");
+        String gameContentRulesText = Messages.getString("LicensingDialog.gameContentRulesText");
+        String discordUrl = Messages.getString("LicensingDialog.discordUrl");
+        String discordText = Messages.getString("LicensingDialog.discordText");
+
+        return "<html><body width='" + width + "'>"
+              + "<p>" + Messages.getString("LicensingDialog.disclaimer") + "</p>"
+              + "<p>" + Messages.getString("LicensingDialog.licensing")
+              + " <a href=\"" + gameContentRulesUrl + "\">" + gameContentRulesText + "</a>.</p>"
+              + "<p>" + Messages.getString("LicensingDialog.wiki")
+              + " <a href=\"" + wikiUrl + "\">" + wikiUrl + "</a></p>"
+              + "<p>" + Messages.getString("CommonAboutDialog.community")
+              + " <a href=\"" + discordUrl + "\">" + discordText + "</a>.</p>"
+              + "<p><small><i>" + Messages.getString("LicensingDialog.trademark")
+              + "</i></small></p>"
+              + "</body></html>";
     }
 
     // Show how to create fluff images for Record Sheets


### PR DESCRIPTION
Note: Depends on MegaMek PR (uses LicensingDialog from megamek) https://github.com/MegaMek/megamek/pull/8164

## Summary

Integrates the MegaMek Suite licensing dialog into MegaMekLab startup and updates the About dialog to use aligned legal text with clickable links.

## Changes

  1. MegaMekLab.java - Added LicensingDialog.showIfNeeded() call in startup() after GUI scaling, showing "Welcome to
  MegaMekLab [VERSION]".
  2. MenuBar.java - Updated aboutAction() to use aligned legal text from MegaMek's LicensingDialog.* message keys via
  Messages.getString(), replacing outdated GPL-only text.

 ## Files Changed

  - megameklab/src/megameklab/MegaMekLab.java
  - megameklab/src/megameklab/ui/MenuBar.java
