### PR TITLE
Use automatic alternate table row coloring

### DIFF
--- a/megameklab/src/megameklab/MegaMekLab.java
+++ b/megameklab/src/megameklab/MegaMekLab.java
@@ -32,7 +32,6 @@
  */
 package megameklab;
 
-import java.awt.Color;
 import java.awt.Window;
 import java.io.File;
 import java.io.ObjectInputFilter;
@@ -155,9 +154,6 @@ public class MegaMekLab {
             final String title = String.format(MMLoggingConstants.UNHANDLED_EXCEPTION_TITLE, name);
             LOGGER.errorDialog(t, message, title);
         });
-
-        // Set an alternate table row color; it uses alpha and is valid for both dark and light UIs
-        UIManager.put("Table.alternateRowColor", new Color(125, 125, 125, 50));
 
         MegaMek.initializeLogging(MMLConstants.PROJECT_NAME);
         MegaMekLab.initializeLogging(MMLConstants.PROJECT_NAME);

--- a/megameklab/src/megameklab/MegaMekLab.java
+++ b/megameklab/src/megameklab/MegaMekLab.java
@@ -32,6 +32,7 @@
  */
 package megameklab;
 
+import java.awt.Color;
 import java.awt.Window;
 import java.io.File;
 import java.io.ObjectInputFilter;
@@ -154,6 +155,9 @@ public class MegaMekLab {
             final String title = String.format(MMLoggingConstants.UNHANDLED_EXCEPTION_TITLE, name);
             LOGGER.errorDialog(t, message, title);
         });
+
+        // Set an alternate table row color; it uses alpha and is valid for both dark and light UIs
+        UIManager.put("Table.alternateRowColor", new Color(125, 125, 125, 50));
 
         MegaMek.initializeLogging(MMLConstants.PROJECT_NAME);
         MegaMekLab.initializeLogging(MMLConstants.PROJECT_NAME);

--- a/megameklab/src/megameklab/ui/mek/BMBuildTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -42,6 +42,7 @@ import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JToggleButton;
+import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
 
@@ -131,7 +132,7 @@ public class BMBuildTab extends ITab {
         unallocatedList.add(resetButton);
 
         Box buttonPanel = Box.createHorizontalBox();
-        buttonPanel.setBackground(UIUtil.alternateTableBGColor());
+        buttonPanel.setBackground(UIManager.getColor("Table.background"));
         buttonPanel.setOpaque(true);
         buttonPanel.setBorder(BorderFactory.createCompoundBorder(
               new LineBorder(getBackground(), 10),

--- a/megameklab/src/megameklab/ui/util/AbstractEquipmentDatabaseView.java
+++ b/megameklab/src/megameklab/ui/util/AbstractEquipmentDatabaseView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -346,7 +346,7 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
         var typeFilterPanel = Box.createHorizontalBox();
         typeFilterPanel.add(new JLabel("Show: "));
         typeFilterPanel.add(buttonAndInfoPanel);
-        typeFilterPanel.setBackground(UIUtil.alternateTableBGColor());
+        typeFilterPanel.setBackground(UIManager.getColor("Table.background"));
         typeFilterPanel.setOpaque(true);
         typeFilterPanel.setBorder(new EmptyBorder(0, 8, 0, 8));
         return typeFilterPanel;
@@ -391,7 +391,7 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
         var hideFilterPanel = Box.createHorizontalBox();
         hideFilterPanel.add(new JLabel("Hide: "));
         hideFilterPanel.add(buttonPanel);
-        hideFilterPanel.setBackground(UIUtil.alternateTableBGColor());
+        hideFilterPanel.setBackground(UIManager.getColor("Table.background"));
         hideFilterPanel.setOpaque(true);
         hideFilterPanel.setBorder(new EmptyBorder(0, 8, 0, 8));
         return hideFilterPanel;
@@ -447,7 +447,7 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
             miscPanel.add(tableModeButton);
             tableModeButton.addActionListener(e -> switchTableMode());
         }
-        miscPanel.setBackground(UIUtil.alternateTableBGColor());
+        miscPanel.setBackground(UIManager.getColor("Table.background"));
         miscPanel.setOpaque(true);
         miscPanel.setBorder(new EmptyBorder(0, 8, 0, 8));
         return miscPanel;
@@ -656,9 +656,11 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
     /** A specialized table used for the equipment database. */
     private static class EquipmentDatabaseTable extends JTable {
 
+        public final static int ROW_HEIGHT_PADDING = 6;
+
         private EquipmentDatabaseTable(EquipmentTableModel dm) {
             super(dm, new XTableColumnModel());
-            setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+            setAutoResizeMode(AUTO_RESIZE_ALL_COLUMNS);
             setIntercellSpacing(new Dimension(2, 0));
             setShowGrid(false);
             setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -679,8 +681,9 @@ public abstract class AbstractEquipmentDatabaseView extends IView {
             if (getRowCount() >= 1) {
                 Component comp = prepareRenderer(getCellRenderer(0, 0), 0, 0);
                 int rowHeight = comp.getPreferredSize().height;
+                // setting the height per row works when changing GUI scaling, setting it via setRowHeight(int) doesnt
                 for (int row = 0; row < getRowCount(); row++) {
-                    setRowHeight(row, rowHeight);
+                    setRowHeight(row, rowHeight + ROW_HEIGHT_PADDING);
                 }
             }
         }

--- a/megameklab/src/megameklab/ui/util/EquipmentTableModel.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentTableModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2011-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -33,10 +33,7 @@
 
 package megameklab.ui.util;
 
-import static megamek.client.ui.util.UIUtil.alternateTableBGColor;
-
 import java.awt.Component;
-import java.awt.Dimension;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
@@ -44,7 +41,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import javax.swing.JTable;
 import javax.swing.SwingConstants;
-import javax.swing.UIManager;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 
@@ -80,7 +76,6 @@ import megameklab.util.InfantryUtil;
  */
 public class EquipmentTableModel extends AbstractTableModel {
 
-    public final static int ROW_HEIGHT_PADDING = 6;
     public final static String VARIABLE = "variable";
 
     public final static int COL_NAME = 0;
@@ -173,13 +168,6 @@ public class EquipmentTableModel extends AbstractTableModel {
             case COL_TON, COL_CRIT, COL_MEDIUM_RANGE -> 5;
             default -> 30;
         };
-    }
-
-    private int getAlignment(int col) {
-        if (col == COL_NAME) {
-            return SwingConstants.LEFT;
-        }
-        return SwingConstants.CENTER;
     }
 
     public Comparator<?> getSorter(int col) {
@@ -517,40 +505,30 @@ public class EquipmentTableModel extends AbstractTableModel {
     }
 
     public EquipmentTableModel.Renderer getRenderer() {
-        return new EquipmentTableModel.Renderer();
+        return new Renderer(this);
     }
 
-    public class Renderer extends DefaultTableCellRenderer {
+    public static class Renderer extends DefaultTableCellRenderer {
 
-        @Override
-        public Component getTableCellRendererComponent(JTable table,
-              Object value, boolean isSelected, boolean hasFocus, int row,
-              int column) {
-            int actualCol = table.convertColumnIndexToModel(column);
-            int actualRow = table.convertRowIndexToModel(row);
-            EquipmentType etype = ((EquipmentTableModel) table.getModel()).getType(actualRow);
-            if (column == COL_NAME) {
-                // Reinstate the real name, as the value will be the sorting-optimized name
-                value = InfantryUtil.trimInfantryWeaponNames(etype.getName());
-            }
-            super.getTableCellRendererComponent(table, value, isSelected,
-                  hasFocus, row, column);
-            setHorizontalAlignment(getAlignment(actualCol));
-            if (null != techManager && !techManager.isLegal(etype)) {
-                setForeground(UIManager.getColor("Label.disabledForeground"));
-            } else {
-                setForeground(UIManager.getColor("Label.foreground"));
-            }
-            if (!isSelected) {
-                setBackground(((row % 2) != 0) ? alternateTableBGColor() : table.getBackground());
-            }
-            return this;
+        private final EquipmentTableModel tableModel;
+
+        public Renderer(EquipmentTableModel tableModel) {
+            this.tableModel = tableModel;
         }
 
         @Override
-        public Dimension getPreferredSize() {
-            Dimension superPreferredSize = super.getPreferredSize();
-            return new Dimension(superPreferredSize.width, superPreferredSize.height + ROW_HEIGHT_PADDING);
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+              boolean hasFocus, int row, int column) {
+
+            if (column == COL_NAME) {
+                // Reinstate the real name, as the value will be the sorting-optimized name
+                int actualRow = table.convertRowIndexToModel(row);
+                EquipmentType etype = tableModel.getType(actualRow);
+                value = InfantryUtil.trimInfantryWeaponNames(etype.getName());
+            }
+            int actualCol = table.convertColumnIndexToModel(column);
+            setHorizontalAlignment((actualCol == COL_NAME) ? SwingConstants.LEFT : SwingConstants.CENTER);
+            return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
         }
     }
 


### PR DESCRIPTION
Edit: the change to use automatic table row coloring is now only in MegaMek, all programs call it upon startup, see megamek/megamek#8197. This PR only contains some renderer adaptations.

~This makes MML use automatic alternate table row coloring. This removes the need for table renderers to do this and it applies to all tables, e.g. in the unit selector and the advanced search (as long as the renderer does not explicitly change it)
I chose a medium gray with high alpha, this is equally ok for light and dark UI and the color difference between rows is softer than it currently is in some tables where we do it manually.~
Also some other, minor code changes

<img width="684" height="229" alt="image" src="https://github.com/user-attachments/assets/1c8b96af-a13b-40fb-a887-1b549410eecc" />
<img width="710" height="218" alt="image" src="https://github.com/user-attachments/assets/741ac4b2-531b-4a38-b1f7-e22de4dcdb69" />
