### PR TITLE
Issue 2191: Show actual RHS heat sink ability

### DIFF
--- a/megameklab/src/megameklab/ui/fighterAero/ASStatusBar.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASStatusBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -38,7 +38,7 @@ import megameklab.ui.generalUnit.StatusBar;
 
 public class ASStatusBar extends StatusBar {
 
-    private static final String HEAT_LABEL = "Heat: %d / %d";
+    private static final String HEAT_LABEL = "Heat: %d / %s";
 
     private final JLabel heat = new JLabel();
 
@@ -53,9 +53,8 @@ public class ASStatusBar extends StatusBar {
     }
 
     public void refreshHeat() {
-        int heatCapacity = getAero().getHeatCapacity();
         long totalHeat = estimatedHeatGeneration();
-        heat.setText(String.format(HEAT_LABEL, totalHeat, heatCapacity));
+        heat.setText(String.format(HEAT_LABEL, totalHeat, getAero().formatHeat()));
         heat.setToolTipText("Estimated Total Heat Generated / Total Heat Dissipated");
         heat.setVisible(getEntity().tracksHeat());
     }

--- a/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
+++ b/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
@@ -90,7 +90,7 @@ public class StatusBar extends ITab {
         this.parent = parent;
         formatter = new DecimalFormat();
 
-        JButton btnValidate = new JButton("Validate Unit");
+        JButton btnValidate = new JButton("Validate");
         ActionListener validationListener = e -> {
             if ((e.getModifiers() & ActionEvent.CTRL_MASK) != 0) {
                 DebugEntity.copyEquipmentState(getEntity());
@@ -112,7 +112,7 @@ public class StatusBar extends ITab {
         invalid.setVisible(false);
 
         if (!getEntity().isConventionalInfantry()) {
-            JButton showEquipmentDatabase = new JButton("Equipment Database");
+            JButton showEquipmentDatabase = new JButton("Equipment");
             showEquipmentDatabase.addActionListener(evt -> parent.getFloatingEquipmentDatabase().setVisible(true));
             add(showEquipmentDatabase);
         }

--- a/megameklab/src/megameklab/ui/mek/BMStatusBar.java
+++ b/megameklab/src/megameklab/ui/mek/BMStatusBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -40,7 +40,7 @@ import megameklab.util.MekUtil;
 
 public class BMStatusBar extends StatusBar {
 
-    private static final String HEAT_LABEL = "Heat: %d / %d";
+    private static final String HEAT_LABEL = "Heat: %d / %s";
     private static final String SLOTS_LABEL = "Free Slots: %d / %d";
 
     private final JLabel slots = new JLabel();
@@ -66,9 +66,8 @@ public class BMStatusBar extends StatusBar {
     }
 
     public void refreshHeat() {
-        int heatCapacity = getMek().getHeatCapacity();
         long totalHeat = estimatedHeatGeneration();
-        heat.setText(String.format(HEAT_LABEL, totalHeat, heatCapacity));
+        heat.setText(String.format(HEAT_LABEL, totalHeat, getMek().formatHeat()));
         heat.setToolTipText("Estimated Total Heat Generated / Total Heat Dissipated");
     }
 }


### PR DESCRIPTION
... rather than BV calculation values in the status bar. This does not change the values shown in the heat sink configuration box.

Relates to #2191 but showing it in the heat sink config box would truly fix the issue

Re-uses the formatted string of the readout. It can get longish, so this PR also shortens the text on the status bar buttons a bit ("Equipment" <- "Equipment Database" and "Validate" <- "Validate Unit")

Mek with 13 DHS+CP
<img width="329" height="69" alt="image" src="https://github.com/user-attachments/assets/33fcd871-255d-4092-ac83-40ccafe17ac4" />

Fighter with 30 single
<img width="353" height="64" alt="image" src="https://github.com/user-attachments/assets/368d709a-c44e-460b-83f8-a8007b3d0d56" />

Mek with 44 DHS:
<img width="486" height="70" alt="image" src="https://github.com/user-attachments/assets/eae6ec0a-d5d3-4f6c-92b2-54b324793617" />
