### PR TITLE
MML#2192 improve mek total generated heat display with better JJ heat

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
+++ b/megameklab/src/megameklab/ui/generalUnit/StatusBar.java
@@ -229,17 +229,10 @@ public class StatusBar extends ITab {
         }
         double heat = 0;
 
-        if (getEntity() instanceof Mek) {
-            if (getEntity().getOriginalJumpMP() > 0) {
-                if (getEntity().getJumpType() == Mek.JUMP_IMPROVED) {
-                    heat += Math.max(3, Math.ceil(getMek().getOriginalJumpMP() / 2.0f));
-                } else {
-                    heat += Math.max(3, getEntity().getOriginalJumpMP());
-                }
-                if (getEntity().getEngineType() == Engine.XXL_ENGINE) {
-                    heat *= 2;
-                }
-            } else if (getEntity().getEngineType() == Engine.XXL_ENGINE) {
+        if (getEntity() instanceof Mek mek) {
+            if (mek.getOriginalJumpMP() > 0) {
+                heat += mek.getJumpHeat(mek.getOriginalJumpMP());
+            } else if (mek.getEngineType() == Engine.XXL_ENGINE) {
                 heat += 6;
             } else {
                 heat += 2;

--- a/megameklab/src/megameklab/ui/mek/BMStatusBar.java
+++ b/megameklab/src/megameklab/ui/mek/BMStatusBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -40,7 +40,7 @@ import megameklab.util.MekUtil;
 
 public class BMStatusBar extends StatusBar {
 
-    private static final String HEAT_LABEL = "Heat: %d / %d";
+    private static final String HEAT_LABEL = "Est. Heat: %d / %d";
     private static final String SLOTS_LABEL = "Free Slots: %d / %d";
 
     private final JLabel slots = new JLabel();


### PR DESCRIPTION
Uses the mek JJ heat calculation to show a better heat estimate on the BM status bar. Also changes the label to "Est. Heat"

Example, mek with 5 P-I-JJ and XXL:
<img width="537" height="78" alt="image" src="https://github.com/user-attachments/assets/56e7d4e4-4409-4211-b712-128b5ab46079" />

Fixes #2192