### PR TITLE
MML #2125 allow loading recent units from cache and ZIPs

### DIFF
--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -45,6 +45,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.ResourceBundle;
+import java.util.regex.Pattern;
 import javax.swing.*;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -810,32 +811,59 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
     }
 
     private @Nullable JMenuItem createCConfigMenuItem(final String recentFileName, final int fileNumber) {
-        File recent = new File(recentFileName);
+        String fileName = recentFileName;
+        String entryName = null;
+        if (recentFileName.contains(CConfig.RECENT_ENTRY_DELIMITER)) {
+            String[] parts = recentFileName.split(Pattern.quote(CConfig.RECENT_ENTRY_DELIMITER));
+            fileName = parts[0];
+            if (parts.length > 1) {
+                entryName = parts[1];
+            }
+        }
+
+        File recent = new File(fileName);
+        String displayName = recent.getName();
+        if (entryName != null) {
+            int lastSlash = Math.max(entryName.lastIndexOf('/'), entryName.lastIndexOf('\\'));
+            if (lastSlash != -1) {
+                displayName = entryName.substring(lastSlash + 1);
+            } else {
+                displayName = entryName;
+            }
+        }
+
         String path = recent.getParent();
         String mmlDirectory = System.getProperty("user.dir");
-        if (recentFileName.startsWith(mmlDirectory)) {
+        if (fileName.startsWith(mmlDirectory)) {
             path = path.substring(mmlDirectory.length());
             if (path.length() > 40) {
                 path = path.substring(0, 40) + "...";
             }
         }
 
-        final JMenuItem miCConfig = getMiCConfig(fileNumber, recent, path);
+        final JMenuItem miCConfig = getMiCConfig(fileNumber, displayName, path);
         miCConfig.setName("miCConfig");
         miCConfig.addActionListener(evt -> loadUnitFromFile(fileNumber));
         miCConfig.setMnemonic(48 + fileNumber); // the number itself, i.e. 1, 2, 3 etc.
+
+        String tooltip = fileName;
+        if (entryName != null) {
+            tooltip += " (" + entryName + ")";
+        }
+        miCConfig.setToolTipText(tooltip);
+
         return miCConfig;
     }
 
-    private static JMenuItem getMiCConfig(int fileNumber, File recent, String path) {
+    private static JMenuItem getMiCConfig(int fileNumber, String displayName, String path) {
         String content;
         if (OSUtil.isMac()) {
-            content = "%d. %s ".formatted(fileNumber, recent.getName()) + "(" + path + ")";
+            content = "%d. %s ".formatted(fileNumber, displayName) + "(" + path + ")";
         } else {
             String html = "<HTML><HEAD><STYLE>%s</STYLE></HEAD><BODY>%s</BODY></HTML>";
             String style = ".small { font-size:smaller; color:gray; }";
             content = html.formatted(style, "<NOBR>%d. %s<BR>".formatted(fileNumber,
-                  recent.getName()) + UIUtil.spanCSS("small", path));
+                  displayName) + UIUtil.spanCSS("small", path));
         }
 
         return new JMenuItem(content);
@@ -1441,26 +1469,46 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
     }
 
     public void loadUnitFromFile(int fileNumber) {
-        File unitFile;
+        String recentFileName;
         if (fileNumber > 0) {
-            String recentFileName = CConfig.getRecentFile(fileNumber);
+            recentFileName = CConfig.getRecentFile(fileNumber);
             if (recentFileName.isBlank()) {
                 return;
             }
-            unitFile = new File(recentFileName);
         } else {
-            unitFile = chooseUnitFileToLoad();
+            File unitFile = chooseUnitFileToLoad();
             if (unitFile == null) {
                 return;
             }
+            recentFileName = unitFile.toString();
         }
 
-        loadFile(unitFile);
+        loadFile(recentFileName);
+    }
+
+    public void loadFile(String unitFileName) {
+        File unitFile;
+        String entryName = null;
+
+        if (unitFileName.contains(CConfig.RECENT_ENTRY_DELIMITER)) {
+            String[] parts = unitFileName.split(Pattern.quote(CConfig.RECENT_ENTRY_DELIMITER));
+            unitFile = new File(parts[0]);
+            if (parts.length > 1) {
+                entryName = parts[1];
+            }
+        } else {
+            unitFile = new File(unitFileName);
+        }
+        loadFile(unitFile, entryName);
     }
 
     public void loadFile(File unitFile) {
+        loadFile(unitFile, null);
+    }
+
+    public void loadFile(File unitFile, String entryName) {
         try {
-            Entity loadedUnit = new MekFileParser(unitFile).getEntity();
+            Entity loadedUnit = new MekFileParser(unitFile, entryName).getEntity();
 
             if (loadedUnit == null) {
                 throw new Exception();
@@ -1468,7 +1516,7 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
 
             warnOnInvalid(loadedUnit);
 
-            newRecentUnit(unitFile.toString());
+            newRecentUnit(unitFile.toString(), entryName);
             if (owner instanceof MegaMekLabTabbedUI tabbedUi) {
                 tabbedUi.addUnit(loadedUnit, unitFile.toString(), true);
                 refresh();
@@ -1488,8 +1536,8 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
      *
      * @param latestUnit The filename of the new most recent unit.
      */
-    private void newRecentUnit(String latestUnit) {
-        CConfig.setMostRecentFile(latestUnit);
+    private void newRecentUnit(String latestUnit, String entryName) {
+        CConfig.setMostRecentFile(latestUnit, entryName);
         createFileMenu();
     }
 

--- a/megameklab/src/megameklab/ui/StartupGUI.java
+++ b/megameklab/src/megameklab/ui/StartupGUI.java
@@ -59,6 +59,7 @@ import megamek.client.ui.widget.SkinXMLHandler;
 import megamek.client.ui.widget.SkinnedJPanel;
 import megamek.common.Configuration;
 import megamek.common.annotations.Nullable;
+import megamek.common.loaders.MekSummary;
 import megamek.common.units.Entity;
 import megamek.common.util.ImageUtil;
 import megamek.common.util.ManagedVolatileImage;
@@ -69,7 +70,6 @@ import megameklab.MMLConstants;
 import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
 import megameklab.ui.dialog.UiLoader;
 import megameklab.ui.util.ExitOnWindowClosingListener;
-import megameklab.ui.util.MegaMekLabFileSaver;
 import megameklab.ui.util.TabUtil;
 import megameklab.util.CConfig;
 import megameklab.util.MMLFileDropTransferHandler;
@@ -532,12 +532,11 @@ public class StartupGUI extends SkinnedJPanel implements MenuBarOwner {
         return targetLogoHeight;
     }
 
-    private static String processFileName(File file, Entity newUnit) {
-        String fileName = file.toString();
+    private static String processFileName(MekSummary mekSummary) {
+        String fileName = mekSummary.getSourceFile().toString();
         if (fileName.toLowerCase().endsWith(".zip")) {
-            fileName = file.getAbsolutePath();
-            fileName = fileName.substring(0, fileName.lastIndexOf(File.separatorChar) + 1);
-            fileName = fileName + MegaMekLabFileSaver.createUnitFilename(newUnit);
+            fileName = mekSummary.getSourceFile().getAbsolutePath() + CConfig.RECENT_ENTRY_DELIMITER
+                  + mekSummary.getEntryName();
         }
         return fileName;
     }
@@ -547,7 +546,7 @@ public class StartupGUI extends SkinnedJPanel implements MenuBarOwner {
         var mekSummaries = viewer.getSelectedMekSummaries();
         var fileNames = new ArrayList<String>();
         for (int i = 0; i < entities.size(); i++) {
-            fileNames.add(processFileName(mekSummaries.get(i).getSourceFile(), entities.get(i)));
+            fileNames.add(processFileName(mekSummaries.get(i)));
         }
         TabUtil.loadMany(entities, fileNames, owner);
     }

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -115,6 +115,7 @@ public final class CConfig {
 
     public static final int RECENT_FILE_COUNT = 10;
     public static final String FILE_RECENT_PREFIX = "Save_File_";
+    public static final String RECENT_ENTRY_DELIMITER = "|";
     public static final String FILE_LAST_DIRECTORY = "Last_directory";
     public static final String FILE_CHOOSER_WINDOW = "File_Chooser_Window";
     public static final String FORCE_BUILD_WINDOW = "Force_Build_Window";
@@ -444,19 +445,43 @@ public final class CConfig {
         }
     }
 
+    /**
+     * Adds a file to the most recent files list.
+     *
+     * @param newFile The path to the file to add.
+     */
     public static void setMostRecentFile(final String newFile) {
+        setMostRecentFile(newFile, null);
+    }
+
+    /**
+     * Adds a file (and optionally an entry name if it's a ZIP) to the most recent files list.
+     *
+     * @param newFile   The path to the file.
+     * @param entryName The name of the entry within the file (e.g., for ZIP files). Can be null.
+     */
+    public static void setMostRecentFile(final String newFile, final String entryName) {
         if ((newFile == null) || newFile.isBlank()) {
             return;
         }
 
+        String recentString = newFile;
+        if ((entryName != null) && !entryName.isBlank()) {
+            recentString += RECENT_ENTRY_DELIMITER + entryName;
+        }
+
         List<String> recentFiles = getRecentFiles();
         List<String> recentFilesWithoutDuplicates = recentFiles.stream().distinct().collect(Collectors.toList());
-        recentFilesWithoutDuplicates.removeIf(f -> f.equalsIgnoreCase(newFile));
-        recentFilesWithoutDuplicates.addFirst(newFile);
+        final String finalRecentString = recentString;
+        recentFilesWithoutDuplicates.removeIf(f -> f.equalsIgnoreCase(finalRecentString));
+        recentFilesWithoutDuplicates.addFirst(recentString);
         setRecentFiles(recentFilesWithoutDuplicates);
         CConfig.saveConfig();
     }
 
+    /**
+     * @return A list of the most recently loaded unit files.
+     */
     public static List<String> getRecentFiles() {
         List<String> result = new ArrayList<>();
         for (int i = 1; i <= RECENT_FILE_COUNT; i++) {
@@ -467,6 +492,11 @@ public final class CConfig {
         return result;
     }
 
+    /**
+     * Updates the stored recent files parameters.
+     *
+     * @param files The list of files to store.
+     */
     private static void setRecentFiles(List<String> files) {
         for (int i = 0; i < RECENT_FILE_COUNT; i++) {
             if (i < files.size()) {


### PR DESCRIPTION
Fixes #2125 

Unfortunately the recent unit files were never made to work properly when loading from a zip, i.e., using the cache. This PR adds ZIP handling.