### PR TITLE
Fix DNI, EI, and DIC cockpit mods cannot be removed

### DIFF
--- a/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
@@ -926,7 +926,7 @@ public class CVStructureTab extends ITab implements CVBuildListener, ArmorAlloca
         } else if (!hasMod && getTank().hasDNICockpitMod()) {
             for (MiscMounted mounted : getTank().getMisc()) {
                 if (mounted.getType().hasFlag(MiscType.F_DNI_COCKPIT_MOD)) {
-                    getTank().removeMisc(mounted.getType().getInternalName());
+                    getTank().removeMisc(mounted.getName());
                     break;
                 }
             }

--- a/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
@@ -816,7 +816,7 @@ public class ASStructureTab extends ITab implements AeroBuildListener, ArmorAllo
         } else if (!hasMod && getAero().hasDNICockpitMod()) {
             for (MiscMounted mounted : getAero().getMisc()) {
                 if (mounted.getType().hasFlag(MiscType.F_DNI_COCKPIT_MOD)) {
-                    getAero().removeMisc(mounted.getType().getInternalName());
+                    getAero().removeMisc(mounted.getName());
                     break;
                 }
             }

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -1281,7 +1281,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         } else if (!hasMod && getMek().hasDNICockpitMod()) {
             for (MiscMounted mounted : getMek().getMisc()) {
                 if (mounted.getType().hasFlag(MiscType.F_DNI_COCKPIT_MOD)) {
-                    getMek().removeMisc(mounted.getType().getInternalName());
+                    getMek().removeMisc(mounted.getName());
                     break;
                 }
             }
@@ -1305,7 +1305,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         } else if (!hasEI && getMek().hasEiCockpit()) {
             for (MiscMounted mounted : getMek().getMisc()) {
                 if (mounted.getType().hasFlag(MiscType.F_EI_INTERFACE)) {
-                    getMek().removeMisc(mounted.getType().getInternalName());
+                    getMek().removeMisc(mounted.getName());
                     break;
                 }
             }
@@ -1329,7 +1329,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
         } else if (!hasDIC && getMek().hasDamageInterruptCircuit()) {
             for (MiscMounted mounted : getMek().getMisc()) {
                 if (mounted.getType().hasFlag(MiscType.F_DAMAGE_INTERRUPT_CIRCUIT)) {
-                    getMek().removeMisc(mounted.getType().getInternalName());
+                    getMek().removeMisc(mounted.getName());
                     break;
                 }
             }

--- a/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -923,7 +923,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
         } else if (!hasMod && getSV().hasDNICockpitMod()) {
             for (MiscMounted mounted : getSV().getMisc()) {
                 if (mounted.getType().hasFlag(MiscType.F_DNI_COCKPIT_MOD)) {
-                    getSV().removeMisc(mounted.getType().getInternalName());
+                    getSV().removeMisc(mounted.getName());
                     break;
                 }
             }


### PR DESCRIPTION
  Fixes #2207

  Root cause: The structure tabs removed cockpit mods by calling removeMisc(getType().getInternalName()), but Entity.removeMisc matches on the display name (Mounted.getName()). The internal and display names differ for these mods, so removeMisc found no match and removed nothing. The equipment survived save and reload, re-checking the box.

  Fix: Pass mounted.getName() so the string matches what removeMisc compares. 
  Covers DNI, EI, and DIC on Meks and DNI on vehicles, fighters, and support
  vehicles. Matches the existing working pattern in SVChassisModView.