### PR TITLE
fix structure slots on undo/redo

### DIFF
--- a/megameklab/src/megameklab/util/UnitMemento.java
+++ b/megameklab/src/megameklab/util/UnitMemento.java
@@ -92,6 +92,7 @@ public class UnitMemento {
             if (entity == null) {
                 return null;
             }
+            UnitUtil.updateLoadedUnit(entity);
             if (getArmorTonnage() >= 0) {
                 entity.setArmorTonnage(getArmorTonnage());
             }


### PR DESCRIPTION
This PR fixes an issue with UNDO/REDO that make structure slots become a single component (with multiple slots) instead of being many single slots components. 