### PR TITLE
MML side of fix for #2222: Cannot load primitive meks

### DIFF
--- a/megameklab/src/megameklab/ui/mek/BMChassisView.java
+++ b/megameklab/src/megameklab/ui/mek/BMChassisView.java
@@ -552,20 +552,20 @@ public class BMChassisView extends BuildView implements ActionListener, ChangeLi
         boolean isClan = techManager.useClanTechBase();
         if (isIndustrial()) {
             String name = EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_INDUSTRIAL, isClan);
-            addAvailableStructure(availableStructures, EquipmentType.get(name));
+            addAvailableStructure(availableStructures, EquipmentType.getStructureFromName(name));
         } else if (isPrimitive()) {
             String name = EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_STANDARD, isClan);
-            addAvailableStructure(availableStructures, EquipmentType.get(name));
+            addAvailableStructure(availableStructures, EquipmentType.getStructureFromName(name));
         } else {
             int[] structureTypes = isSuperheavy() ?
                   SUPERHEAVY_STRUCTURE_TYPES : STRUCTURE_TYPES;
             for (int i : structureTypes) {
                 String name = EquipmentType.getStructureTypeName(i, isClan);
-                EquipmentType structure = EquipmentType.get(name);
+                EquipmentType structure = EquipmentType.getStructureFromName(name);
                 // LAMs cannot use bulky structure
                 addAvailableStructure(availableStructures, structure);
                 name = EquipmentType.getStructureTypeName(i, !isClan);
-                EquipmentType structure2 = EquipmentType.get(name);
+                EquipmentType structure2 = EquipmentType.getStructureFromName(name);
                 addAvailableStructure(availableStructures, structure2);
             }
         }


### PR DESCRIPTION
### DO NOT MERGE UNTIL AFTER MegaMek/megamek#8345 IS MERGED OR ERRORS WILL OCCUR!

Fixes the issue of being unable to load primitive meks created before the introduction of IS Standard Armor type equipment; the root cause was that our lookup of "IS Standard" (structure) returned "IS Standard" (armor) instead.
IS Standard Armor has a later introduction date, so any mek with a build date prior to that would end up with _no_ valid structure types, and cause an NPE while updating the internal structure dropbox.

Uses a new explicit structure getter that will always get the _structure_ with a name, as opposed to the _armor_ (or any other equipment) with that name, thanks to all of our structure types having additional lookup names ending in " structure".

We _shouldn't_ need to use the new function anywhere else, but it's there if we do need it.

Testing:
- Ran all 3 projects' unit tests
- Tested Mackie MSK-5S and OP's custom unit

Fix #2222 