### PR TITLE
Forward mouse wheel to the tab when an inner quirk pane cannot scroll (Fixes #2230)

### DIFF
--- a/megameklab/src/megameklab/ui/generalUnit/QuirksTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/QuirksTab.java
@@ -221,8 +221,14 @@ public class QuirksTab extends ITab implements DialogOptionListener {
     private static void configureInnerScroll(JScrollPane scrollPane) {
         scrollPane.getVerticalScrollBar().setUnitIncrement(16);
         scrollPane.addMouseWheelListener(event -> {
+            // Use precise rotation: high-resolution wheels and trackpads can report 0 from getWheelRotation()
+            // while still producing a non-zero precise value, which would misread the scroll direction.
+            double wheelRotation = event.getPreciseWheelRotation();
+            if (wheelRotation == 0.0) {
+                return;
+            }
             JScrollBar verticalBar = scrollPane.getVerticalScrollBar();
-            boolean scrollingUp = event.getWheelRotation() < 0;
+            boolean scrollingUp = wheelRotation < 0;
             boolean canScroll = verticalBar.isVisible() && (scrollingUp
                   ? verticalBar.getValue() > verticalBar.getMinimum()
                   : verticalBar.getValue() + verticalBar.getVisibleAmount() < verticalBar.getMaximum());

--- a/megameklab/src/megameklab/ui/generalUnit/QuirksTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/QuirksTab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2023-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -53,9 +53,11 @@ import java.util.List;
 import java.util.Map;
 import javax.swing.BorderFactory;
 import javax.swing.JPanel;
+import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.JViewport;
+import javax.swing.SwingUtilities;
 
 import megamek.client.ui.clientGUI.DialogOptionListener;
 import megamek.client.ui.panels.DialogOptionComponentYPanel;
@@ -160,10 +162,13 @@ public class QuirksTab extends ITab implements DialogOptionListener {
         // Wrap panels in scroll panes
         JScrollPane positiveScrollPane = new JScrollPane(positiveQuirksPanel);
         positiveScrollPane.setBorder(null);
+        configureInnerScroll(positiveScrollPane);
         JScrollPane negativeScrollPane = new JScrollPane(negativeQuirksPanel);
         negativeScrollPane.setBorder(null);
+        configureInnerScroll(negativeScrollPane);
         JScrollPane weaponScrollPane = new JScrollPane(weaponQuirksContainer);
         weaponScrollPane.setBorder(null);
+        configureInnerScroll(weaponScrollPane);
 
         // Create nested split panes for three-way horizontal split
         JSplitPane leftSplitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
@@ -203,6 +208,32 @@ public class QuirksTab extends ITab implements DialogOptionListener {
                 }
             });
         }
+    }
+
+    /**
+     * Sets a usable wheel step on an inner quirk scroll pane and forwards the wheel event to the enclosing tab scroll
+     * pane when this pane cannot scroll further in the wheel's direction.
+     *
+     * <p>The quirk lists sit in inner scroll panes nested inside the outer tab scroll pane. By default an inner scroll
+     * pane swallows mouse-wheel events over its content even when it has nothing left to scroll, so the outer tab never
+     * scrolls. Forwarding at the scroll limit lets the wheel work no matter where the cursor sits.</p>
+     */
+    private static void configureInnerScroll(JScrollPane scrollPane) {
+        scrollPane.getVerticalScrollBar().setUnitIncrement(16);
+        scrollPane.addMouseWheelListener(event -> {
+            JScrollBar verticalBar = scrollPane.getVerticalScrollBar();
+            boolean scrollingUp = event.getWheelRotation() < 0;
+            boolean canScroll = verticalBar.isVisible() && (scrollingUp
+                  ? verticalBar.getValue() > verticalBar.getMinimum()
+                  : verticalBar.getValue() + verticalBar.getVisibleAmount() < verticalBar.getMaximum());
+            if (!canScroll) {
+                JScrollPane outerScrollPane = (JScrollPane) SwingUtilities.getAncestorOfClass(JScrollPane.class,
+                      scrollPane);
+                if (outerScrollPane != null) {
+                    outerScrollPane.dispatchEvent(SwingUtilities.convertMouseEvent(scrollPane, event, outerScrollPane));
+                }
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary

In the Quirks tab the mouse wheel only scrolled while the cursor sat on a scrollbar. Over the quirk checkboxes it did nothing. This makes the wheel work anywhere in the tab.

## Bug Fixed

- **Nested scroll panes swallowed the wheel.** The quirk lists sit in three inner scroll panes inside the outer tab scroll pane. An inner pane eats the wheel event over its content even when it has nothing left to scroll, so the outer tab never moves.

## Changes

1. **QuirksTab.java** - Added `configureInnerScroll(JScrollPane)`. It sets a sensible wheel step on each inner pane and forwards the wheel event to the outer tab scroll pane when the inner pane is at its scroll limit.

## Files Changed

- `megameklab/src/megameklab/ui/generalUnit/QuirksTab.java` - Wheel forwarding for the three inner quirk scroll panes.

## Testing

- Manual testing in the Quirks tab on a Mek with many weapon quirks:
  - Wheel over the checkboxes now scrolls (it did nothing before).
  - Wheel over a column whose list overflows scrolls that column.
  - Wheel over a short column scrolls the whole tab.
  
  Fixes #2230