### PR TITLE
Fix: MML #2234 Stop Support Vehicle Fire Control From Being Removed by Reset Button or Critical Dropdown Menu

### DIFF
--- a/megameklab/src/megameklab/ui/supportVehicle/SVBuildTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVBuildTab.java
@@ -148,8 +148,12 @@ public class SVBuildTab extends ITab implements ActionListener {
         for (Mounted<?> mount : getTank().getEquipment()) {
             // Fixed shouldn't be removed
             if (UnitUtil.isFixedLocationSpreadEquipment(mount.getType())
-                  || mount.is(EquipmentTypeLookup.PINTLE_TURRET) || mount.is(EquipmentTypeLookup.MAST_MOUNT)
-                  || ((mount instanceof MiscMounted) && mount.getType().hasFlag(MiscType.F_CHASSIS_MODIFICATION))) {
+                  || mount.is(EquipmentTypeLookup.PINTLE_TURRET)
+                  || mount.is(EquipmentTypeLookup.MAST_MOUNT)
+                  || ((mount instanceof MiscMounted)
+                  && (mount.getType().hasFlag(MiscType.F_CHASSIS_MODIFICATION)
+                  || mount.getType().hasFlag(MiscType.F_BASIC_FIRE_CONTROL)
+                  || mount.getType().hasFlag(MiscType.F_ADVANCED_FIRE_CONTROL)))) {
                 continue;
             }
             UnitUtil.removeCriticalSlots(getTank(), mount);

--- a/megameklab/src/megameklab/ui/util/DropTargetCriticalList.java
+++ b/megameklab/src/megameklab/ui/util/DropTargetCriticalList.java
@@ -305,7 +305,10 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
     private boolean isRemovable(@Nullable Mounted<?> mounted) {
         return (mounted != null) && !UnitUtil.isFixedLocationSpreadEquipment(mounted.getType())
               && !mounted.is(EquipmentTypeLookup.PINTLE_TURRET)
-              && !((mounted instanceof MiscMounted) && mounted.getType().hasFlag(MiscType.F_CHASSIS_MODIFICATION));
+              && !((mounted instanceof MiscMounted)
+              && (mounted.getType().hasFlag(MiscType.F_CHASSIS_MODIFICATION)
+              || mounted.getType().hasFlag(MiscType.F_BASIC_FIRE_CONTROL)
+              || mounted.getType().hasFlag(MiscType.F_ADVANCED_FIRE_CONTROL)));
     }
 
     private boolean isDeletable(@Nullable Mounted<?> mounted) {


### PR DESCRIPTION
Fix MML side of #2234

MegaMek side PR: https://github.com/MegaMek/megamek/pull/8411