### PR TITLE
Fix: MML #2237 Update VTOL/Naval/Superheavy Vehicle Record Sheet Titles

### DIFF
--- a/megameklab/src/megameklab/printing/PrintTank.java
+++ b/megameklab/src/megameklab/printing/PrintTank.java
@@ -133,7 +133,7 @@ public class PrintTank extends PrintEntity {
             // Only take the first word; strip "Support Vehicles"
             sb.append(tank.getWeightClassName().replaceAll(" .*", " "));
         } else if (tank.isSuperHeavy()) {
-            sb.append("SuperHeavy ");
+            sb.append("Super-Heavy ");
         }
         switch (tank.getMovementMode()) {
             case NAVAL:
@@ -151,11 +151,14 @@ public class PrintTank extends PrintEntity {
         if (tank.isSupportVehicle()) {
             sb.append("Support ");
         }
+        if (tank instanceof VTOL) {
+            sb.append("V.T.O.L. ");
+        }
         if (tank.isOmni()) {
             sb.append("Omni");
         }
-        if (tank instanceof VTOL) {
-            sb.append("VTOL");
+        if (tank.isNaval()) {
+            sb.append("Vessel");
         } else {
             sb.append("Vehicle");
         }


### PR DESCRIPTION
Fix MML side of #2237
MMD side PR: https://github.com/MegaMek/mm-data/pull/428

Note for reviewer: For Omni VTOL, title has been changed from 'OmniVTOL Record Sheet' to 'V.T.O.L. OmniVehicle Record Sheet' in order to match the 'V.T.O.L. Vehicle Record Sheet' title as seen in TechManual 6th printing, page 328. If you believe 'OmniV.T.O.L. Vehicle Record Sheet' is better, please comment below.