### PR TITLE
Add analysis preview tab

### DIFF
--- a/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
@@ -47,6 +47,7 @@ import megamek.common.TechConstants;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
@@ -59,6 +60,7 @@ public class BAMainUI extends MegaMekLabMainUI {
     private FluffTab fluffTab;
     private BAStatusBar statusbar;
     private PreviewTab previewTab;
+    private AnalysisTab analysisTab;
 
     @Override
     protected FluffTab getFluffTab() {
@@ -90,6 +92,7 @@ public class BAMainUI extends MegaMekLabMainUI {
         statusbar = new BAStatusBar(this);
         buildTab = new BABuildTab(this);
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
         structureTab.addRefreshedListener(this);
         equipTab.addRefreshedListener(this);
         buildTab.addRefreshedListener(this);
@@ -103,6 +106,7 @@ public class BAMainUI extends MegaMekLabMainUI {
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
@@ -193,6 +197,7 @@ public class BAMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
@@ -52,6 +52,7 @@ import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
@@ -61,6 +62,7 @@ public class CVMainUI extends MegaMekLabMainUI {
     private CVStructureTab structureTab;
     private AbstractEquipmentTab equipmentTab;
     private PreviewTab previewTab;
+    private AnalysisTab analysisTab;
     private CVBuildTab buildTab;
     private FluffTab fluffTab;
     private CVStatusBar statusbar;
@@ -102,6 +104,7 @@ public class CVMainUI extends MegaMekLabMainUI {
         statusbar.addRefreshedListener(this);
 
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
         configPane.addTab("Equipment", equipmentTab);
@@ -109,6 +112,7 @@ public class CVMainUI extends MegaMekLabMainUI {
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
@@ -134,6 +138,7 @@ public class CVMainUI extends MegaMekLabMainUI {
         quirksTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
+        analysisTab.refresh();
         floatingEquipmentDatabase.refresh();
         refreshHeader();
         repaint();
@@ -239,6 +244,7 @@ public class CVMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/combatVehicle/GEMainUI.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/GEMainUI.java
@@ -45,6 +45,7 @@ import megamek.common.units.Entity;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.StatusBar;
 import megameklab.ui.util.TabScrollPane;
@@ -54,6 +55,7 @@ public class GEMainUI extends MegaMekLabMainUI {
     private GEEquipmentTab equipmentTab;
     private FluffTab fluffTab;
     private PreviewTab previewTab;
+    private AnalysisTab analysisTab;
 
     @Override
     protected FluffTab getFluffTab() {
@@ -84,12 +86,14 @@ public class GEMainUI extends MegaMekLabMainUI {
         fluffTab = new FluffTab(this);
         fluffTab.setRefreshedListener(this);
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
         structureTab.addRefreshedListener(this);
 
         configPane.addTab("Structure", new TabScrollPane(structureTab));
         configPane.addTab("Equipment", new TabScrollPane(equipmentTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         statusbar = new GEStatusBar(this);
         statusbar.addRefreshedListener(this);
@@ -111,6 +115,7 @@ public class GEMainUI extends MegaMekLabMainUI {
         structureTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
+        analysisTab.refresh();
         statusbar.refresh();
         equipmentTab.refresh();
         refreshHeader();
@@ -162,6 +167,7 @@ public class GEMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
@@ -50,6 +50,7 @@ import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
@@ -60,6 +61,7 @@ public class ASMainUI extends MegaMekLabMainUI {
     private ASStructureTab structureTab;
     private AbstractEquipmentTab equipmentTab;
     private PreviewTab previewTab;
+    private AnalysisTab analysisTab;
     private ASBuildTab buildTab;
     private FluffTab fluffTab;
     private ASStatusBar statusbar;
@@ -89,6 +91,7 @@ public class ASMainUI extends MegaMekLabMainUI {
 
         structureTab = new ASStructureTab(this);
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
         statusbar = new ASStatusBar(this);
         equipmentTab = new ASEquipmentTab(this);
         buildTab = new ASBuildTab(this);
@@ -107,6 +110,7 @@ public class ASMainUI extends MegaMekLabMainUI {
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
@@ -174,6 +178,7 @@ public class ASMainUI extends MegaMekLabMainUI {
         quirksTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
+        analysisTab.refresh();
         floatingEquipmentDatabase.refresh();
         refreshHeader();
     }
@@ -204,6 +209,7 @@ public class ASMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
 
     }
 

--- a/megameklab/src/megameklab/ui/generalUnit/AnalysisTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AnalysisTab.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.ui.generalUnit;
+
+import java.awt.BorderLayout;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import javax.swing.Timer;
+
+import megamek.client.ui.dialogs.unitSelectorDialogs.DamageAnalysisPanel;
+import megamek.client.ui.util.UIUtil;
+import megameklab.ui.EntitySource;
+import megameklab.ui.util.ITab;
+
+/**
+ * A top-level editor tab showing the unit's damage analysis: the damage-vs-range curves and the
+ * direction/reach radars from megamek's {@link DamageAnalysisPanel}. Refreshes itself with the
+ * same debounce pattern as {@link PreviewTab}: updates are deferred while the tab is hidden and
+ * applied when it is shown, so the charts follow the unit as it is built.
+ */
+public class AnalysisTab extends ITab {
+    private static final int REFRESH_DEBOUNCE_DELAY_MS = 100;
+
+    private final DamageAnalysisPanel analysisPanel = new DamageAnalysisPanel();
+    private final Timer refreshTimer = new Timer(REFRESH_DEBOUNCE_DELAY_MS, event -> performUpdate());
+    private boolean refreshPending;
+
+    public AnalysisTab(EntitySource eSource) {
+        super(eSource);
+        setLayout(new BorderLayout());
+        refreshTimer.setRepeats(false);
+        // The panel's own minimum is sized for the unit selector; the editor pane can be narrower,
+        // and the charts degrade gracefully at small sizes.
+        analysisPanel.setMinimumSize(UIUtil.scaleForGUI(400, 500));
+        add(analysisPanel, BorderLayout.CENTER);
+        addComponentListener(refreshOnShow);
+    }
+
+    public void update() {
+        analysisPanel.setEntity(eSource.getEntity());
+    }
+
+    private void performUpdate() {
+        if (!isVisible()) {
+            refreshPending = true;
+            return;
+        }
+        refreshPending = false;
+        update();
+    }
+
+    private void scheduleUpdate() {
+        refreshPending = true;
+        if (isVisible()) {
+            refreshTimer.restart();
+        }
+    }
+
+    public void refresh() {
+        scheduleUpdate();
+    }
+
+    @Override
+    public void removeNotify() {
+        refreshTimer.stop();
+        super.removeNotify();
+    }
+
+    private final ComponentListener refreshOnShow = new ComponentAdapter() {
+        @Override
+        public void componentShown(ComponentEvent event) {
+            if (refreshPending) {
+                scheduleUpdate();
+            } else {
+                refreshTimer.stop();
+                update();
+            }
+        }
+    };
+}

--- a/megameklab/src/megameklab/ui/generalUnit/PreviewTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/PreviewTab.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2008 - jtighe (torren@users.sourceforge.net)
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -47,8 +47,10 @@ import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.clientGUI.calculationReport.FlexibleCalculationReport;
 import megamek.client.ui.dialogs.unitSelectorDialogs.AvailabilityPanel;
 import megamek.client.ui.dialogs.unitSelectorDialogs.ConfigurableMekViewPanel;
+import megamek.client.ui.dialogs.unitSelectorDialogs.DamageAnalysisPanel;
 import megamek.client.ui.dialogs.unitSelectorDialogs.EntityReadoutPanel;
 import megamek.client.ui.panels.alphaStrike.ConfigurableASCardPanel;
+import megamek.client.ui.util.UIUtil;
 import megamek.client.ui.util.ViewFormatting;
 import megamek.common.alphaStrike.conversion.ASConverter;
 import megamek.common.templates.TROView;
@@ -69,6 +71,7 @@ public class PreviewTab extends ITab {
     private final ConfigurableASCardPanel cardPanel = new ConfigurableASCardPanel(null);
     private final RecordSheetPreviewPanel rsPanel = new RecordSheetPreviewPanel();
     private final AvailabilityPanel factionPanel = new AvailabilityPanel();
+    private final DamageAnalysisPanel analysisPanel = new DamageAnalysisPanel();
     private final String tabIndexSettingName = "PreviewTab.panPreview.selectedIndex";
     private final EnhancedTabbedPane panPreview;
     private final Timer refreshTimer = new Timer(REFRESH_DEBOUNCE_DELAY_MS, e -> performUpdate());
@@ -80,6 +83,9 @@ public class PreviewTab extends ITab {
         refreshTimer.setRepeats(false);
         panelMekView.setMinimumSize(new Dimension(400, panelMekView.getMinimumSize().height));
         panelTROView.setMinimumSize(new Dimension(400, panelTROView.getMinimumSize().height));
+        // The analysis panel's own minimum is wider than the editor's preview pane; it degrades
+        // gracefully at small sizes, so relax the minimum to the pane's usual width.
+        analysisPanel.setMinimumSize(UIUtil.scaleForGUI(400, 500));
         rsPanel.setMinZoom(1.0f);
         rsPanel.setFullAsyncMode(false);
 
@@ -100,6 +106,7 @@ public class PreviewTab extends ITab {
         panPreview.addTab("Factions", factionPanel.getPanel());
         panPreview.addTab("AS Card", cardPanel);
         panPreview.addTab("Record Sheet", rsPanel);
+        panPreview.addTab("Analysis", analysisPanel);
         List<String> tabsOrder = GUIPreferences.getInstance().getTabOrder(this.getClass().getName());
         panPreview.setTabOrder(tabsOrder);
         add(panPreview, BorderLayout.CENTER);
@@ -149,6 +156,7 @@ public class PreviewTab extends ITab {
         panelTROView.setPreferredSize(new Dimension(panelWidth, panelTROView.getPreferredSize().height));
         cardPanel.setPreferredSize(new Dimension(panelWidth, cardPanel.getPreferredSize().height));
         rsPanel.setPreferredSize(new Dimension(panelWidth, rsPanel.getPreferredSize().height));
+        analysisPanel.setPreferredSize(new Dimension(panelWidth, analysisPanel.getPreferredSize().height));
 
         // Force a refresh to ensure content uses the new width
         revalidate();
@@ -177,12 +185,14 @@ public class PreviewTab extends ITab {
             }
             rsPanel.setEntity(selectedUnit);
             factionPanel.setUnit(selectedUnit.getModel(), selectedUnit.getFullChassis());
+            analysisPanel.setEntity(selectedUnit);
         } else {
             panelMekView.reset();
             panelTROView.reset();
             cardPanel.setASElement(null);
             rsPanel.setEntity(null);
             factionPanel.reset();
+            analysisPanel.setEntity(null);
         }
     }
 

--- a/megameklab/src/megameklab/ui/generalUnit/PreviewTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/PreviewTab.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2008 - jtighe (torren@users.sourceforge.net)
- * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -47,10 +47,8 @@ import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.clientGUI.calculationReport.FlexibleCalculationReport;
 import megamek.client.ui.dialogs.unitSelectorDialogs.AvailabilityPanel;
 import megamek.client.ui.dialogs.unitSelectorDialogs.ConfigurableMekViewPanel;
-import megamek.client.ui.dialogs.unitSelectorDialogs.DamageAnalysisPanel;
 import megamek.client.ui.dialogs.unitSelectorDialogs.EntityReadoutPanel;
 import megamek.client.ui.panels.alphaStrike.ConfigurableASCardPanel;
-import megamek.client.ui.util.UIUtil;
 import megamek.client.ui.util.ViewFormatting;
 import megamek.common.alphaStrike.conversion.ASConverter;
 import megamek.common.templates.TROView;
@@ -71,7 +69,6 @@ public class PreviewTab extends ITab {
     private final ConfigurableASCardPanel cardPanel = new ConfigurableASCardPanel(null);
     private final RecordSheetPreviewPanel rsPanel = new RecordSheetPreviewPanel();
     private final AvailabilityPanel factionPanel = new AvailabilityPanel();
-    private final DamageAnalysisPanel analysisPanel = new DamageAnalysisPanel();
     private final String tabIndexSettingName = "PreviewTab.panPreview.selectedIndex";
     private final EnhancedTabbedPane panPreview;
     private final Timer refreshTimer = new Timer(REFRESH_DEBOUNCE_DELAY_MS, e -> performUpdate());
@@ -83,9 +80,6 @@ public class PreviewTab extends ITab {
         refreshTimer.setRepeats(false);
         panelMekView.setMinimumSize(new Dimension(400, panelMekView.getMinimumSize().height));
         panelTROView.setMinimumSize(new Dimension(400, panelTROView.getMinimumSize().height));
-        // The analysis panel's own minimum is wider than the editor's preview pane; it degrades
-        // gracefully at small sizes, so relax the minimum to the pane's usual width.
-        analysisPanel.setMinimumSize(UIUtil.scaleForGUI(400, 500));
         rsPanel.setMinZoom(1.0f);
         rsPanel.setFullAsyncMode(false);
 
@@ -106,7 +100,6 @@ public class PreviewTab extends ITab {
         panPreview.addTab("Factions", factionPanel.getPanel());
         panPreview.addTab("AS Card", cardPanel);
         panPreview.addTab("Record Sheet", rsPanel);
-        panPreview.addTab("Analysis", analysisPanel);
         List<String> tabsOrder = GUIPreferences.getInstance().getTabOrder(this.getClass().getName());
         panPreview.setTabOrder(tabsOrder);
         add(panPreview, BorderLayout.CENTER);
@@ -156,7 +149,6 @@ public class PreviewTab extends ITab {
         panelTROView.setPreferredSize(new Dimension(panelWidth, panelTROView.getPreferredSize().height));
         cardPanel.setPreferredSize(new Dimension(panelWidth, cardPanel.getPreferredSize().height));
         rsPanel.setPreferredSize(new Dimension(panelWidth, rsPanel.getPreferredSize().height));
-        analysisPanel.setPreferredSize(new Dimension(panelWidth, analysisPanel.getPreferredSize().height));
 
         // Force a refresh to ensure content uses the new width
         revalidate();
@@ -185,14 +177,12 @@ public class PreviewTab extends ITab {
             }
             rsPanel.setEntity(selectedUnit);
             factionPanel.setUnit(selectedUnit.getModel(), selectedUnit.getFullChassis());
-            analysisPanel.setEntity(selectedUnit);
         } else {
             panelMekView.reset();
             panelTROView.reset();
             cardPanel.setASElement(null);
             rsPanel.setEntity(null);
             factionPanel.reset();
-            analysisPanel.setEntity(null);
         }
     }
 

--- a/megameklab/src/megameklab/ui/handheldWeapon/HHWMainUI.java
+++ b/megameklab/src/megameklab/ui/handheldWeapon/HHWMainUI.java
@@ -45,6 +45,7 @@ import megamek.common.interfaces.ITechManager;
 import megamek.common.units.Entity;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -53,6 +54,7 @@ public class HHWMainUI extends MegaMekLabMainUI {
     private HHWEquipmentTab equipmentTab;
     private FluffTab fluffTab;
     private PreviewTab previewTab;
+    private AnalysisTab analysisTab;
 
     @Override
     protected FluffTab getFluffTab() {
@@ -82,12 +84,14 @@ public class HHWMainUI extends MegaMekLabMainUI {
         fluffTab = new FluffTab(this);
         fluffTab.setRefreshedListener(this);
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
         structureTab.addRefreshedListener(this);
 
         configPane.addTab("Structure", new TabScrollPane(structureTab));
         configPane.addTab("Equipment", new TabScrollPane(equipmentTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         statusbar = new HHWStatusBar(this);
         statusbar.addRefreshedListener(this);
@@ -105,6 +109,7 @@ public class HHWMainUI extends MegaMekLabMainUI {
         structureTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
+        analysisTab.refresh();
         statusbar.refresh();
         equipmentTab.refresh();
         refreshHeader();
@@ -156,6 +161,7 @@ public class HHWMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/infantry/CIMainUI.java
+++ b/megameklab/src/megameklab/ui/infantry/CIMainUI.java
@@ -50,6 +50,7 @@ import megamek.common.weapons.infantry.InfantryWeapon;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.PopupMessages;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -57,6 +58,7 @@ public class CIMainUI extends MegaMekLabMainUI {
 
     CIStructureTab structureTab;
     PreviewTab previewTab;
+    AnalysisTab analysisTab;
     FluffTab fluffTab;
     CIStatusBar statusbar;
 
@@ -85,6 +87,7 @@ public class CIMainUI extends MegaMekLabMainUI {
         structureTab = new CIStructureTab(this);
         fluffTab = new FluffTab(this);
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
 
         structureTab.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
@@ -93,6 +96,7 @@ public class CIMainUI extends MegaMekLabMainUI {
         configPane.addTab("Build", structureTab);
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
@@ -129,6 +133,7 @@ public class CIMainUI extends MegaMekLabMainUI {
         structureTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
+        analysisTab.refresh();
         refreshHeader();
     }
 
@@ -173,6 +178,7 @@ public class CIMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -53,6 +53,7 @@ import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.generalUnit.StatusBar;
@@ -70,6 +71,7 @@ public class DSMainUI extends MegaMekLabMainUI {
     private DSStructureTab structureTab;
     private AbstractEquipmentTab equipmentTab;
     private PreviewTab previewTab;
+    private AnalysisTab analysisTab;
     private LABuildTab buildTab;
     private TransportTab transportTab;
     private StatusBar statusbar;
@@ -188,6 +190,7 @@ public class DSMainUI extends MegaMekLabMainUI {
         structureTab = new DSStructureTab(this);
 
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
 
         statusbar = new StatusBar(this);
         equipmentTab = new LAEquipmentTab(this);
@@ -210,6 +213,7 @@ public class DSMainUI extends MegaMekLabMainUI {
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
@@ -235,6 +239,7 @@ public class DSMainUI extends MegaMekLabMainUI {
         quirksTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
+        analysisTab.refresh();
         floatingEquipmentDatabase.refresh();
         refreshHeader();
     }
@@ -277,6 +282,7 @@ public class DSMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
@@ -53,6 +53,7 @@ import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.generalUnit.StatusBar;
@@ -70,6 +71,7 @@ public class WSMainUI extends MegaMekLabMainUI {
     private WSStructureTab structureTab;
     private AbstractEquipmentTab equipmentTab;
     private PreviewTab previewTab;
+    private AnalysisTab analysisTab;
     private LABuildTab buildTab;
     private TransportTab transportTab;
     private QuirksTab quirksTab;
@@ -196,6 +198,7 @@ public class WSMainUI extends MegaMekLabMainUI {
 
         structureTab = new WSStructureTab(this);
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
         statusbar = new StatusBar(this);
         equipmentTab = new LAEquipmentTab(this);
         buildTab = new LABuildTab(this);
@@ -217,6 +220,7 @@ public class WSMainUI extends MegaMekLabMainUI {
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
@@ -241,6 +245,7 @@ public class WSMainUI extends MegaMekLabMainUI {
         buildTab.refresh();
         quirksTab.refresh();
         previewTab.refresh();
+        analysisTab.refresh();
         floatingEquipmentDatabase.refresh();
         refreshHeader();
     }
@@ -283,6 +288,7 @@ public class WSMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/mek/BMMainUI.java
+++ b/megameklab/src/megameklab/ui/mek/BMMainUI.java
@@ -53,6 +53,7 @@ import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
@@ -65,6 +66,7 @@ public class BMMainUI extends MegaMekLabMainUI {
     private TabScrollPane frankenMekStructureTab;
     private AbstractEquipmentTab equipmentTab;
     private PreviewTab previewTab;
+    private AnalysisTab analysisTab;
     private BMBuildTab buildTab;
     private FluffTab fluffTab;
     private BMStatusBar statusbar;
@@ -95,6 +97,7 @@ public class BMMainUI extends MegaMekLabMainUI {
         structureTab = new BMStructureTab(this);
         frankenMekStructureTab = new TabScrollPane(structureTab.getFrankenMekStructureView());
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
         statusbar = new BMStatusBar(this);
         equipmentTab = new BMEquipmentTab(this);
         buildTab = new BMBuildTab(this);
@@ -113,6 +116,7 @@ public class BMMainUI extends MegaMekLabMainUI {
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
@@ -231,6 +235,7 @@ public class BMMainUI extends MegaMekLabMainUI {
         buildTab.refresh();
         quirksTab.refresh();
         previewTab.refresh();
+        analysisTab.refresh();
         floatingEquipmentDatabase.refresh();
         fluffTab.refresh();
         refreshHeader();
@@ -263,6 +268,7 @@ public class BMMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
@@ -49,6 +49,7 @@ import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
@@ -63,6 +64,7 @@ public class PMMainUI extends MegaMekLabMainUI {
     private PMStructureTab structureTab;
     private AbstractEquipmentTab equipmentTab;
     private PreviewTab previewTab;
+    private AnalysisTab analysisTab;
     private PMBuildTab buildTab;
     private PMStatusBar statusbar;
     private QuirksTab quirksTab;
@@ -92,6 +94,7 @@ public class PMMainUI extends MegaMekLabMainUI {
 
         structureTab = new PMStructureTab(this);
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
         statusbar = new PMStatusBar(this);
         equipmentTab = new PMEquipmentTab(this);
         buildTab = new PMBuildTab(this, this);
@@ -109,6 +112,7 @@ public class PMMainUI extends MegaMekLabMainUI {
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
@@ -160,6 +164,7 @@ public class PMMainUI extends MegaMekLabMainUI {
         quirksTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
+        analysisTab.refresh();
         floatingEquipmentDatabase.refresh();
         refreshHeader();
     }
@@ -190,6 +195,7 @@ public class PMMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
     }
 
     @Override

--- a/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
@@ -51,6 +51,7 @@ import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
+import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.generalUnit.TransportTab;
@@ -66,6 +67,7 @@ public class SVMainUI extends MegaMekLabMainUI {
     private AbstractEquipmentTab equipmentTab;
     private TransportTab transportTab;
     private PreviewTab previewTab;
+    private AnalysisTab analysisTab;
     private SVBuildTab buildTab;
     private FluffTab fluffTab;
     private SVStatusBar statusbar;
@@ -111,6 +113,7 @@ public class SVMainUI extends MegaMekLabMainUI {
         statusbar.addRefreshedListener(this);
 
         previewTab = new PreviewTab(this);
+        analysisTab = new AnalysisTab(this);
 
         configPane.addTab("Structure", new TabScrollPane(structureTab));
         configPane.addTab("Armor", new TabScrollPane(armorTab));
@@ -120,6 +123,7 @@ public class SVMainUI extends MegaMekLabMainUI {
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
+        configPane.addTab("Analysis", analysisTab);
 
         add(configPane, BorderLayout.CENTER);
         add(statusbar, BorderLayout.SOUTH);
@@ -147,6 +151,7 @@ public class SVMainUI extends MegaMekLabMainUI {
         quirksTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
+        analysisTab.refresh();
         floatingEquipmentDatabase.refresh();
         refreshHeader();
     }
@@ -256,6 +261,7 @@ public class SVMainUI extends MegaMekLabMainUI {
     public void refreshPreview() {
         super.refreshPreview();
         previewTab.refresh();
+        analysisTab.refresh();
     }
 
     @Override


### PR DESCRIPTION
## Summary

Adds the damage Analysis tab from MegaMek/megamek#8477 to every unit editor, as a top-level tab beside Preview. It shows the unit's damage-vs-range curves and the direction/reach radars, and updates live while the unit is being built — swap a weapon and the curves reshape about 100ms later.


## Depends on MegaMek/megamek#8477. 
## Merge that first; this PR does not compile without it.

## Changes Made

- AnalysisTab (new): wraps megamek's DamageAnalysisPanel with the same show/hide-aware debounced refresh pattern as PreviewTab — updates defer while the tab is hidden and apply when shown.
- All 11 unit editors (Mek, Combat Vehicle, Gun Emplacement, Aero, Battle Armor, Infantry, ProtoMek, Support Vehicle, Handheld Weapon, DropShip, WarShip): add the tab after Preview and refresh it wherever they refresh the preview.
- Weapons not yet allocated to a location count in the damage curves but in no radar arc (a megamek-side rule from #8477), so the radars fill in as the loadoutlinked ammo shows nothing — it isn'tfunctional yet.

## Changes

1. AnalysisTab.java (NEW) - the tab wrapper with debounced refresh
2. BMMainUI.java and the 10 other editor Mai refresh wiring (5-6 lines each)

## Files Changed

- megameklab/src/megameklab/ui/generalUnit/AnalysisTab.java - NEW: tab wrapper
- megameklab/src/megameklab/ui/mek/BMMainUI.java - wiring
- megameklab/src/megameklab/ui/combatVehicle
- megameklab/src/megameklab/ui/combatVehicle/GEMainUI.java - wiring
- megameklab/src/megameklab/ui/fighterAero/ASMainUI.java - wiring
- megameklab/src/megameklab/ui/battleArmor/B
- megameklab/src/megameklab/ui/infantry/CIMainUI.java - wiring
- megameklab/src/megameklab/ui/protoMek/PMMainUI.java - wiring
- megameklab/src/megameklab/ui/supportVehicl
- megameklab/src/megameklab/ui/handheldWeapon/HHWMainUI.java - wiring
- megameklab/src/megameklab/ui/largeAero/DSMainUI.java - wiring
- megameklab/src/megameklab/ui/largeAero/WSM

## Testing

- The chart math and rendering are tested in megamek (23 unit tests against canon units in #8477); this PR is mount-and-refresh wiring only.
- Manual testing: open each editor type, confirm the Analysis tab appears beside Preview; edit a loadout and watch the curves update; place an unallocated weapon and watch its arc appear on the radars; large craft (DropShip/WarShip editors) show bay weapons and capital-scale axes.