### PR TITLE
Add Reports > Composite Tech Level

### DIFF
--- a/megameklab/resources/megameklab/resources/Menu.properties
+++ b/megameklab/resources/megameklab/resources/Menu.properties
@@ -116,6 +116,8 @@ unitBVBreakdownMenu.text=BV Breakdown
 unitCostBreakdownMenu.text=Unit Cost Breakdown
 ## Unit Weight Breakdown Menu
 unitWeightBreakdownMenu.text=Unit Weight Breakdown
+## Composite Tech Level Menu
+unitTechLevelBreakdownMenu.text=Composite Tech Level
 ### Help Menu
 helpMenu.text=Help
 miResetWindow.text=Reset Window Positions

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -56,6 +56,7 @@ import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.dialogs.UnitLoadingDialog;
 import megamek.client.ui.dialogs.abstractDialogs.BVDisplayDialog;
 import megamek.client.ui.dialogs.abstractDialogs.CostDisplayDialog;
+import megamek.client.ui.dialogs.abstractDialogs.TechLevelDisplayDialog;
 import megamek.client.ui.dialogs.abstractDialogs.WeightDisplayDialog;
 import megamek.client.ui.dialogs.unitSelectorDialogs.EntityReadoutDialog;
 import megamek.client.ui.entityreadout.EntityReadout;
@@ -63,6 +64,8 @@ import megamek.client.ui.util.UIUtil;
 import megamek.client.ui.util.ViewFormatting;
 import megamek.common.annotations.Nullable;
 import megamek.common.battleArmor.BattleArmor;
+import megamek.common.enums.Faction;
+import megamek.common.interfaces.ITechManager;
 import megamek.common.loaders.MekFileParser;
 import megamek.common.loaders.MekSummaryCache;
 import megamek.common.templates.TROView;
@@ -1028,8 +1031,54 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         reportsMenu.add(createUnitBVBreakdownMenu());
         reportsMenu.add(createUnitCostBreakdownMenu());
         reportsMenu.add(createUnitWeightBreakdownMenu());
+        reportsMenu.add(createUnitTechLevelBreakdownMenu());
 
         return reportsMenu;
+    }
+
+    /**
+     * @return the created Composite Tech Level menu
+     */
+    private JMenu createUnitTechLevelBreakdownMenu() {
+        final JMenu unitTechLevelBreakdownMenu = new JMenu(resources.getString("unitTechLevelBreakdownMenu.text"));
+        unitTechLevelBreakdownMenu.setName("unitTechLevelBreakdownMenu");
+        unitTechLevelBreakdownMenu.setMnemonic(KeyEvent.VK_T);
+
+        final JMenuItem miCurrentUnitTechLevelBreakdown = new JMenuItem(resources.getString("CurrentUnit.text"));
+        miCurrentUnitTechLevelBreakdown.setName("miCurrentUnitTechLevelBreakdown");
+        miCurrentUnitTechLevelBreakdown.setMnemonic(KeyEvent.VK_U);
+        miCurrentUnitTechLevelBreakdown.addActionListener(evt -> showTechLevelBreakdown(owner.getFrame(),
+              owner.getEntity(),
+              currentTechManager()));
+        miCurrentUnitTechLevelBreakdown.setEnabled(isUnitGui());
+        unitTechLevelBreakdownMenu.add(miCurrentUnitTechLevelBreakdown);
+
+        final JMenuItem miUnitTechLevelBreakdownFromCache = new JMenuItem(resources.getString("FromCache.text"));
+        miUnitTechLevelBreakdownFromCache.setName("miUnitTechLevelBreakdownFromCache");
+        miUnitTechLevelBreakdownFromCache.setMnemonic(KeyEvent.VK_C);
+        miUnitTechLevelBreakdownFromCache
+              .addActionListener(evt -> jMenuGetUnitTechLevelBreakdownFromCache_actionPerformed());
+        unitTechLevelBreakdownMenu.add(miUnitTechLevelBreakdownFromCache);
+
+        final JMenuItem miUnitTechLevelBreakdownFromFile = new JMenuItem(resources.getString("FromFile.text"));
+        miUnitTechLevelBreakdownFromFile.setName("miUnitTechLevelBreakdownFromFile");
+        miUnitTechLevelBreakdownFromFile.setMnemonic(KeyEvent.VK_F);
+        miUnitTechLevelBreakdownFromFile
+              .addActionListener(evt -> jMenuGetUnitTechLevelBreakdownFromFile_actionPerformed());
+        unitTechLevelBreakdownMenu.add(miUnitTechLevelBreakdownFromFile);
+
+        return unitTechLevelBreakdownMenu;
+    }
+
+    /**
+     * Returns the tech manager of the unit currently being edited, which carries the year, faction and Variable Tech
+     * Level setting the tech level report should be evaluated with.
+     *
+     * @return The current editor's tech manager, or {@code null} when no unit is being edited
+     */
+    private @Nullable ITechManager currentTechManager() {
+        MegaMekLabMainUI mainUi = getUnitMainUi();
+        return (mainUi == null) ? null : mainUi.getTechManager();
     }
 
     /**
@@ -1268,6 +1317,35 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         } finally {
             unitLoadingDialog.dispose();
             viewer.dispose();
+        }
+    }
+
+    private void jMenuGetUnitTechLevelBreakdownFromCache_actionPerformed() {
+        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(owner.getFrame());
+        unitLoadingDialog.setVisible(true);
+        MegaMekLabUnitSelectorDialog viewer = new MegaMekLabUnitSelectorDialog(owner.getFrame(), unitLoadingDialog,
+              false);
+        try {
+            Entity chosenEntity = viewer.getChosenEntity();
+            if (chosenEntity != null) {
+                showTechLevelBreakdown(owner.getFrame(), chosenEntity, null);
+            }
+        } finally {
+            unitLoadingDialog.dispose();
+            viewer.dispose();
+        }
+    }
+
+    private void jMenuGetUnitTechLevelBreakdownFromFile_actionPerformed() {
+        File unitFile = chooseUnitFileToLoad();
+        if (unitFile == null) {
+            return;
+        }
+
+        try {
+            showTechLevelBreakdown(owner.getFrame(), new MekFileParser(unitFile).getEntity(), null);
+        } catch (Exception ex) {
+            PopupMessages.showFileReadError(owner.getFrame(), unitFile.toString(), ex.getMessage());
         }
     }
 
@@ -1620,6 +1698,31 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
         if (entity != null) {
             new BVDisplayDialog(frame, entity).setVisible(true);
         }
+    }
+
+    /**
+     * Opens the composite tech level report for the given unit. The report is evaluated with the year, faction and
+     * Variable Tech Level setting of the given tech manager; when no tech manager is available, as for a unit loaded
+     * from the cache or from a file, the unit's own introduction year is used together with the Variable Tech Level
+     * setting from the MegaMekLab configuration.
+     *
+     * @param frame       The parent frame of the dialog
+     * @param entity      The unit to report on; nothing happens when this is {@code null}
+     * @param techManager The tech manager of the unit being edited, or {@code null} when the unit is not being edited
+     */
+    public static void showTechLevelBreakdown(final JFrame frame, final @Nullable Entity entity,
+          final @Nullable ITechManager techManager) {
+        if (entity == null) {
+            return;
+        }
+
+        boolean useVariableTechLevel = (techManager != null)
+              ? techManager.useVariableTechLevel()
+              : CConfig.getBooleanParam(CConfig.TECH_PROGRESSION);
+        int evaluationYear = (techManager != null) ? techManager.getGameYear() : entity.getYear();
+        Faction techFaction = (techManager != null) ? techManager.getTechFaction() : Faction.NONE;
+
+        new TechLevelDisplayDialog(frame, entity, techFaction, evaluationYear, useVariableTechLevel).setVisible(true);
     }
 
     public void viewForce() {

--- a/megameklab/src/megameklab/ui/MenuBar.java
+++ b/megameklab/src/megameklab/ui/MenuBar.java
@@ -1703,8 +1703,8 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
     /**
      * Opens the composite tech level report for the given unit. The report is evaluated with the year, faction and
      * Variable Tech Level setting of the given tech manager; when no tech manager is available, as for a unit loaded
-     * from the cache or from a file, the unit's own introduction year is used together with the Variable Tech Level
-     * setting from the MegaMekLab configuration.
+     * from the cache or from a file, the unit's own introduction year and tech faction are used together with the
+     * Variable Tech Level setting from the MegaMekLab configuration.
      *
      * @param frame       The parent frame of the dialog
      * @param entity      The unit to report on; nothing happens when this is {@code null}
@@ -1720,7 +1720,9 @@ public class MenuBar extends JMenuBar implements ClipboardOwner {
               ? techManager.useVariableTechLevel()
               : CConfig.getBooleanParam(CConfig.TECH_PROGRESSION);
         int evaluationYear = (techManager != null) ? techManager.getGameYear() : entity.getYear();
-        Faction techFaction = (techManager != null) ? techManager.getTechFaction() : Faction.NONE;
+        // A unit opened from the cache or a file has no editor, so fall back to the faction it was designed
+        // with rather than no faction, which would drop faction-specific availability dates.
+        Faction techFaction = (techManager != null) ? techManager.getTechFaction() : entity.getTechFaction();
 
         new TechLevelDisplayDialog(frame, entity, techFaction, evaluationYear, useVariableTechLevel).setVisible(true);
     }


### PR DESCRIPTION
Opens the composite tech level report for the current unit, a unit from the cache, or a unit from a file, matching the BV, Cost and Weight breakdown entries alongside it.

The report is evaluated with the year, faction and Use Variable Tech Level setting of the unit being edited, so it shows the tech level under the rule actually in force as well as what it would be under the other one. Units loaded from the cache or from a file have no editor, so those fall back to the unit's own introduction year and the Variable Tech Level setting from the MegaMekLab configuration.

## Requires the matching MegaMek change adding TechLevelDisplayDialog. - https://github.com/MegaMek/megamek/pull/8516