### PR TITLE
Add a Force Generator Availability tab to MegaMekLab

### DIFF
--- a/megameklab/resources/megameklab/resources/Dialogs.properties
+++ b/megameklab/resources/megameklab/resources/Dialogs.properties
@@ -136,10 +136,10 @@ ConfigurationDialog.chkIncludeLicense.text=I am a member of The MegaMek Team
 ConfigurationDialog.chkIncludeLicense.tooltip=<html>Includes a license header in generated unit files,<br>\
   licensing them as CC BY-NC-SA 4.0 and grants ownership of them to The MegaMek Team.</html>
 ConfigurationDialog.chkShowAvailabilityTab.text=Show the Force Generator Availability tab
-ConfigurationDialog.chkShowAvailabilityTab.tooltip=<html>Adds an Availability tab to the unit editor for setting which factions field a unit,<br>\
+ConfigurationDialog.chkShowAvailabilityTab.tooltip=<html>Shows an Availability tab in the unit editor for setting which factions field a unit,<br>\
   and how often, so it shows up in generated forces (RAT Generator / Force Generator).<br>\
-  This is an advanced feature; leave it off if you do not build availability data.<br>\
-  Takes effect on units opened after the change.<br>\
+  Uncheck to hide it if you do not build availability data.<br>\
+  Takes effect on the next unit opened, not on units already open.<br>\
   See docs/Customization/RAT and Force Generator Stuff/custom-unit-availability.txt for how to use it.</html>
 ConfigurationDialog.startup.text=MML Startup:
 ConfigurationDialog.startup.tooltip=<html>Depending on the startup type selected, MML will start in the main menu or, alternatively, directly load the most recent unit or start with a new unit instead of the main menu, or restore all of your opened tabs.<br>Restoring tabs restores the state of the entities as they were in the editor, not as you saved them!</html>

--- a/megameklab/resources/megameklab/resources/Dialogs.properties
+++ b/megameklab/resources/megameklab/resources/Dialogs.properties
@@ -135,6 +135,12 @@ ConfigurationDialog.chkSkipSavePrompts.tooltip=Disables all safety prompts that 
 ConfigurationDialog.chkIncludeLicense.text=I am a member of The MegaMek Team
 ConfigurationDialog.chkIncludeLicense.tooltip=<html>Includes a license header in generated unit files,<br>\
   licensing them as CC BY-NC-SA 4.0 and grants ownership of them to The MegaMek Team.</html>
+ConfigurationDialog.chkShowAvailabilityTab.text=Show the Force Generator Availability tab
+ConfigurationDialog.chkShowAvailabilityTab.tooltip=<html>Adds an Availability tab to the unit editor for setting which factions field a unit,<br>\
+  and how often, so it shows up in generated forces (RAT Generator / Force Generator).<br>\
+  This is an advanced feature; leave it off if you do not build availability data.<br>\
+  Takes effect on units opened after the change.<br>\
+  See docs/Customization/RAT and Force Generator Stuff/custom-unit-availability.txt for how to use it.</html>
 ConfigurationDialog.startup.text=MML Startup:
 ConfigurationDialog.startup.tooltip=<html>Depending on the startup type selected, MML will start in the main menu or, alternatively, directly load the most recent unit or start with a new unit instead of the main menu, or restore all of your opened tabs.<br>Restoring tabs restores the state of the entities as they were in the editor, not as you saved them!</html>
 ConfigurationDialog.mekChassis.text=Mek Chassis Arrangement:

--- a/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
@@ -49,6 +49,7 @@ import megameklab.ui.dialog.FloatingEquipmentDatabaseDialog;
 import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
+import megameklab.ui.generalUnit.AvailabilityTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -67,6 +68,7 @@ public class BAMainUI extends MegaMekLabMainUI {
         return fluffTab;
     }
     private QuirksTab quirksTab;
+    private AvailabilityTab availabilityTab;
     private FloatingEquipmentDatabaseDialog floatingEquipmentDatabase;
 
     public BAMainUI(Entity entity, String filename) {
@@ -89,6 +91,7 @@ public class BAMainUI extends MegaMekLabMainUI {
         equipTab = new BAEquipmentTab(this);
         fluffTab = new FluffTab(this);
         quirksTab = new QuirksTab(this);
+        availabilityTab = new AvailabilityTab(this);
         statusbar = new BAStatusBar(this);
         buildTab = new BABuildTab(this);
         previewTab = new PreviewTab(this);
@@ -99,12 +102,14 @@ public class BAMainUI extends MegaMekLabMainUI {
         statusbar.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
         quirksTab.addRefreshedListener(this);
+        availabilityTab.addRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
         configPane.addTab("Equipment", equipTab);
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
+        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 
@@ -148,6 +153,7 @@ public class BAMainUI extends MegaMekLabMainUI {
         refreshStructure();
         refreshEquipmentTable();
         quirksTab.refresh();
+        availabilityTab.refresh();
         fluffTab.refresh();
         refreshBuild();
         refreshPreview();

--- a/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BAMainUI.java
@@ -50,6 +50,7 @@ import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.AvailabilityTab;
+import megameklab.util.CConfig;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -109,7 +110,9 @@ public class BAMainUI extends MegaMekLabMainUI {
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
-        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        if (CConfig.showAvailabilityTab()) {
+            configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        }
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 

--- a/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
@@ -54,6 +54,7 @@ import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
+import megameklab.ui.generalUnit.AvailabilityTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -72,6 +73,7 @@ public class CVMainUI extends MegaMekLabMainUI {
         return fluffTab;
     }
     private QuirksTab quirksTab;
+    private AvailabilityTab availabilityTab;
     private FloatingEquipmentDatabaseDialog floatingEquipmentDatabase;
 
     public CVMainUI(Entity entity, String filename) {
@@ -96,11 +98,13 @@ public class CVMainUI extends MegaMekLabMainUI {
         buildTab = new CVBuildTab(this);
         fluffTab = new FluffTab(this);
         quirksTab = new QuirksTab(this);
+        availabilityTab = new AvailabilityTab(this);
         structureTab.addRefreshedListener(this);
         equipmentTab.addRefreshedListener(this);
         buildTab.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
         quirksTab.addRefreshedListener(this);
+        availabilityTab.addRefreshedListener(this);
         statusbar.addRefreshedListener(this);
 
         previewTab = new PreviewTab(this);
@@ -111,6 +115,7 @@ public class CVMainUI extends MegaMekLabMainUI {
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
+        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 
@@ -136,6 +141,7 @@ public class CVMainUI extends MegaMekLabMainUI {
         buildTab.refresh();
         statusbar.refresh();
         quirksTab.refresh();
+        availabilityTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
         analysisTab.refresh();

--- a/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
@@ -55,6 +55,7 @@ import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.AvailabilityTab;
+import megameklab.util.CConfig;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -115,7 +116,9 @@ public class CVMainUI extends MegaMekLabMainUI {
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
-        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        if (CConfig.showAvailabilityTab()) {
+            configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        }
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 

--- a/megameklab/src/megameklab/ui/dialog/AddFactionsDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/AddFactionsDialog.java
@@ -43,6 +43,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.swing.BorderFactory;
@@ -60,6 +61,9 @@ import javax.swing.event.DocumentListener;
 import megamek.client.ratgenerator.FactionRecord;
 import megamek.client.ratgenerator.RATGenerator;
 import megamek.client.ui.util.UIUtil;
+import megamek.common.universe.Faction2;
+import megamek.common.universe.FactionTag;
+import megamek.common.universe.Factions2;
 
 /**
  * Picks the factions that field a unit. Multi-select, because "list the factions I want" is one step, not one trip
@@ -100,6 +104,7 @@ public class AddFactionsDialog extends JDialog {
 
     private final JTextField filterField = new JTextField();
     private final JCheckBox showMinorCheckBox = new JCheckBox("Show minor factions");
+    private final JCheckBox showFutureCheckBox = new JCheckBox("Show factions from later eras");
     private final JPanel factionListPanel = new JPanel();
     private final JButton addButton = new JButton("Add");
 
@@ -111,7 +116,8 @@ public class AddFactionsDialog extends JDialog {
     /**
      * @param parent        the window to sit over
      * @param year          the unit's introduction year, which decides which factions exist
-     * @param alreadyChosen faction codes already in the table, shown ticked and disabled
+     * @param alreadyChosen faction codes already in the table, labelled "already added" but still selectable so one
+     *                      faction can be given a second year range
      */
     public AddFactionsDialog(Component parent, int year, List<String> alreadyChosen) {
         super((Dialog) null, "Add factions", true);
@@ -179,6 +185,11 @@ public class AddFactionsDialog extends JDialog {
         showMinorCheckBox.addActionListener(event -> populateFactions());
         topPanel.add(minorPanel);
 
+        JPanel futurePanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        futurePanel.add(showFutureCheckBox);
+        showFutureCheckBox.addActionListener(event -> populateFactions());
+        topPanel.add(futurePanel);
+
         add(topPanel, BorderLayout.NORTH);
 
         factionListPanel.setLayout(new BoxLayout(factionListPanel, BoxLayout.Y_AXIS));
@@ -215,10 +226,20 @@ public class AddFactionsDialog extends JDialog {
                 // A command, not a faction. The long tail; not offered yet.
                 continue;
             }
+            if (isSpecialFaction(factionRecord.getKey())) {
+                // Not a real faction: a game mechanic that happens to have a faction entry, like the Piracy Success
+                // Index. It must never be offered as somewhere a unit can be fielded.
+                continue;
+            }
             if (factionRecord.isMinor() && !showMinorCheckBox.isSelected()) {
                 continue;
             }
-            if (!factionRecord.isActiveInYear(year)) {
+            // By default only factions that exist at the unit's introduction year. Ticking "later eras" also offers
+            // factions that appear afterwards, so a unit can be given to, say, the Republic of the Sphere.
+            boolean active = showFutureCheckBox.isSelected()
+                  ? factionRecord.isActiveInOrAfterYear(year)
+                  : factionRecord.isActiveInYear(year);
+            if (!active) {
                 continue;
             }
             factions.add(factionRecord);
@@ -228,9 +249,11 @@ public class AddFactionsDialog extends JDialog {
 
         for (FactionRecord factionRecord : factions) {
             String code = factionRecord.getKey();
-            JCheckBox checkBox = new JCheckBox(factionRecord.getName(year) + " (" + code + ")");
-            checkBox.setEnabled(!alreadyChosen.contains(code));
-            checkBox.setSelected(alreadyChosen.contains(code));
+            // Already-chosen factions stay selectable: adding one again makes a second row, which is how a player gives
+            // one faction different availability in different year ranges.
+            String label = factionRecord.getName(year) + " (" + code + ")"
+                  + (alreadyChosen.contains(code) ? " - already added" : "");
+            JCheckBox checkBox = new JCheckBox(label);
             factionCheckBoxes.put(code, checkBox);
             factionListPanel.add(checkBox);
         }
@@ -238,6 +261,20 @@ public class AddFactionsDialog extends JDialog {
         applyFilter();
         factionListPanel.revalidate();
         factionListPanel.repaint();
+    }
+
+    /**
+     * Whether a faction code is a special, non-fielding entry rather than a real faction. Some game mechanics, such as
+     * the Piracy Success Index, are stored as factions but must never be offered as somewhere a unit is deployed.
+     *
+     * @param factionCode the faction key
+     *
+     * @return {@code true} if the faction is tagged special
+     */
+    private static boolean isSpecialFaction(String factionCode) {
+        Optional<Faction2> faction = Factions2.getInstance().getFaction(factionCode);
+
+        return faction.isPresent() && faction.get().is(FactionTag.SPECIAL);
     }
 
     private void applyFilter() {
@@ -263,7 +300,8 @@ public class AddFactionsDialog extends JDialog {
             }
         }
         for (Map.Entry<String, JCheckBox> entry : factionCheckBoxes.entrySet()) {
-            if (entry.getValue().isSelected() && !alreadyChosen.contains(entry.getKey())) {
+            // No already-chosen guard here: re-adding a faction is how a player gives it a second year range.
+            if (entry.getValue().isSelected()) {
                 chosen.add(entry.getKey());
             }
         }

--- a/megameklab/src/megameklab/ui/dialog/AddFactionsDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/AddFactionsDialog.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMekLab was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.ui.dialog;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Dialog;
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+
+import megamek.client.ratgenerator.FactionRecord;
+import megamek.client.ratgenerator.RATGenerator;
+import megamek.client.ui.util.UIUtil;
+
+/**
+ * Picks the factions that field a unit. Multi-select, because "list the factions I want" is one step, not one trip
+ * through a dropdown per faction.
+ * <p>
+ * There are over 400 faction files, which sounds unmanageable. It is not: the unit's introduction year is already known
+ * by the time a player reaches the Availability tab, and filtering to the factions that actually exist in that year
+ * leaves about 45. That also stops a whole class of mistake, since a faction that does not exist in the unit's year
+ * cannot be picked at all. Clan Wolf simply does not appear for a 3150 unit.
+ * </p>
+ */
+public class AddFactionsDialog extends JDialog {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private static final int DIALOG_WIDTH = 420;
+    private static final int DIALOG_HEIGHT = 560;
+    private static final int GROUP_COLUMNS = 1;
+
+    /**
+     * The umbrella keys. They are not factions, so they get their own block rather than being buried in an
+     * alphabetical list of them. Each one reaches every faction that falls back to it.
+     */
+    private static final Map<String, String> UMBRELLA_KEYS = new LinkedHashMap<>();
+
+    static {
+        UMBRELLA_KEYS.put("General", "Everybody");
+        UMBRELLA_KEYS.put("IS", "All Inner Sphere");
+        UMBRELLA_KEYS.put("CLAN", "All Clans");
+        UMBRELLA_KEYS.put("Periphery", "All Periphery");
+    }
+
+    /** The umbrella keys, for callers that need to know a code is one of them rather than a real faction. */
+    public static final Set<String> UMBRELLA_CODES = Set.copyOf(UMBRELLA_KEYS.keySet());
+
+    private final int year;
+    private final List<String> alreadyChosen;
+
+    private final JTextField filterField = new JTextField();
+    private final JCheckBox showMinorCheckBox = new JCheckBox("Show minor factions");
+    private final JPanel factionListPanel = new JPanel();
+    private final JButton addButton = new JButton("Add");
+
+    private final Map<String, JCheckBox> factionCheckBoxes = new LinkedHashMap<>();
+    private final Map<String, JCheckBox> umbrellaCheckBoxes = new LinkedHashMap<>();
+
+    private List<String> chosenFactionCodes = List.of();
+
+    /**
+     * @param parent        the window to sit over
+     * @param year          the unit's introduction year, which decides which factions exist
+     * @param alreadyChosen faction codes already in the table, shown ticked and disabled
+     */
+    public AddFactionsDialog(Component parent, int year, List<String> alreadyChosen) {
+        super((Dialog) null, "Add factions", true);
+        this.year = year;
+        this.alreadyChosen = List.copyOf(alreadyChosen);
+
+        buildLayout();
+        populateFactions();
+
+        setSize(UIUtil.scaleForGUI(DIALOG_WIDTH, DIALOG_HEIGHT));
+        setLocationRelativeTo(parent);
+    }
+
+    /**
+     * The faction codes the player ticked. Empty if they cancelled.
+     *
+     * @return the chosen codes
+     */
+    public List<String> getChosenFactionCodes() {
+        return chosenFactionCodes;
+    }
+
+    private void buildLayout() {
+        setLayout(new BorderLayout());
+
+        JPanel topPanel = new JPanel();
+        topPanel.setLayout(new BoxLayout(topPanel, BoxLayout.Y_AXIS));
+        topPanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 4, 8));
+
+        JPanel filterPanel = new JPanel(new BorderLayout(8, 0));
+        filterPanel.add(new JLabel("Filter:"), BorderLayout.WEST);
+        filterPanel.add(filterField, BorderLayout.CENTER);
+        filterField.getDocument().addDocumentListener(new DocumentListener() {
+            @Override
+            public void insertUpdate(DocumentEvent event) {
+                applyFilter();
+            }
+
+            @Override
+            public void removeUpdate(DocumentEvent event) {
+                applyFilter();
+            }
+
+            @Override
+            public void changedUpdate(DocumentEvent event) {
+                applyFilter();
+            }
+        });
+        topPanel.add(filterPanel);
+
+        JPanel umbrellaPanel = new JPanel(new GridLayout(0, GROUP_COLUMNS));
+        umbrellaPanel.setBorder(BorderFactory.createTitledBorder("Groups"));
+        for (Map.Entry<String, String> umbrella : UMBRELLA_KEYS.entrySet()) {
+            JCheckBox checkBox = new JCheckBox(umbrella.getValue() + " (" + umbrella.getKey() + ")");
+            checkBox.setEnabled(!alreadyChosen.contains(umbrella.getKey()));
+            checkBox.setSelected(alreadyChosen.contains(umbrella.getKey()));
+            umbrellaCheckBoxes.put(umbrella.getKey(), checkBox);
+            umbrellaPanel.add(checkBox);
+        }
+        topPanel.add(umbrellaPanel);
+
+        JPanel minorPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        minorPanel.add(new JLabel("Factions that exist in " + year));
+        minorPanel.add(showMinorCheckBox);
+        showMinorCheckBox.addActionListener(event -> populateFactions());
+        topPanel.add(minorPanel);
+
+        add(topPanel, BorderLayout.NORTH);
+
+        factionListPanel.setLayout(new BoxLayout(factionListPanel, BoxLayout.Y_AXIS));
+        add(new JScrollPane(factionListPanel), BorderLayout.CENTER);
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton cancelButton = new JButton("Cancel");
+        cancelButton.addActionListener(event -> dispose());
+        addButton.addActionListener(event -> confirm());
+        buttonPanel.add(cancelButton);
+        buttonPanel.add(addButton);
+        add(buttonPanel, BorderLayout.SOUTH);
+    }
+
+    /**
+     * Fills the list with the factions that exist in the unit's year. Top-level factions only: a command such as
+     * FS.CMB is a faction key too, but commands are the long tail and are not offered yet.
+     */
+    private void populateFactions() {
+        factionListPanel.removeAll();
+        factionCheckBoxes.clear();
+
+        RATGenerator ratGenerator = RATGenerator.getInstance();
+        if (!ratGenerator.isInitialized()) {
+            factionListPanel.add(new JLabel("Loading factions..."));
+            factionListPanel.revalidate();
+            factionListPanel.repaint();
+            return;
+        }
+
+        List<FactionRecord> factions = new ArrayList<>();
+        for (FactionRecord factionRecord : ratGenerator.getFactionList()) {
+            if (factionRecord.getKey().contains(".")) {
+                // A command, not a faction. The long tail; not offered yet.
+                continue;
+            }
+            if (factionRecord.isMinor() && !showMinorCheckBox.isSelected()) {
+                continue;
+            }
+            if (!factionRecord.isActiveInYear(year)) {
+                continue;
+            }
+            factions.add(factionRecord);
+        }
+
+        factions.sort(Comparator.comparing(factionRecord -> factionRecord.getName(year)));
+
+        for (FactionRecord factionRecord : factions) {
+            String code = factionRecord.getKey();
+            JCheckBox checkBox = new JCheckBox(factionRecord.getName(year) + " (" + code + ")");
+            checkBox.setEnabled(!alreadyChosen.contains(code));
+            checkBox.setSelected(alreadyChosen.contains(code));
+            factionCheckBoxes.put(code, checkBox);
+            factionListPanel.add(checkBox);
+        }
+
+        applyFilter();
+        factionListPanel.revalidate();
+        factionListPanel.repaint();
+    }
+
+    private void applyFilter() {
+        String filter = filterField.getText().trim().toLowerCase();
+
+        for (Map.Entry<String, JCheckBox> entry : factionCheckBoxes.entrySet()) {
+            JCheckBox checkBox = entry.getValue();
+            boolean matches = filter.isEmpty()
+                  || checkBox.getText().toLowerCase().contains(filter);
+            checkBox.setVisible(matches);
+        }
+
+        factionListPanel.revalidate();
+        factionListPanel.repaint();
+    }
+
+    private void confirm() {
+        List<String> chosen = new ArrayList<>();
+
+        for (Map.Entry<String, JCheckBox> entry : umbrellaCheckBoxes.entrySet()) {
+            if (entry.getValue().isSelected() && !alreadyChosen.contains(entry.getKey())) {
+                chosen.add(entry.getKey());
+            }
+        }
+        for (Map.Entry<String, JCheckBox> entry : factionCheckBoxes.entrySet()) {
+            if (entry.getValue().isSelected() && !alreadyChosen.contains(entry.getKey())) {
+                chosen.add(entry.getKey());
+            }
+        }
+
+        chosenFactionCodes = chosen;
+        dispose();
+    }
+}

--- a/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
@@ -70,6 +70,7 @@ public class MiscSettingsPanel extends JPanel {
     private final JCheckBox chkApplicationExitPrompt = new JCheckBox();
     private final JCheckBox chkSkipSavePrompts = new JCheckBox();
     private final JCheckBox chkIncludeLicense = new JCheckBox();
+    private final JCheckBox chkShowAvailabilityTab = new JCheckBox();
     private final JTextField txtUserDir = new JTextField(20);
     private final JSlider guiScale = new JSlider();
     private final MMComboBox<MulDndBehaviour> cbMulOpenBehaviour = new MMComboBox<>("MUL Drag and Drop behaviour",
@@ -144,6 +145,10 @@ public class MiscSettingsPanel extends JPanel {
         chkIncludeLicense.setToolTipText(resources.getString("ConfigurationDialog.chkIncludeLicense.tooltip"));
         chkIncludeLicense.setSelected(CConfig.includeLicense());
 
+        chkShowAvailabilityTab.setText(resources.getString("ConfigurationDialog.chkShowAvailabilityTab.text"));
+        chkShowAvailabilityTab.setToolTipText(resources.getString("ConfigurationDialog.chkShowAvailabilityTab.tooltip"));
+        chkShowAvailabilityTab.setSelected(CConfig.showAvailabilityTab());
+
         guiScale.setMajorTickSpacing(3);
         guiScale.setMinimum(7);
         guiScale.setMaximum(24);
@@ -171,9 +176,10 @@ public class MiscSettingsPanel extends JPanel {
         gridPanel.add(chkSummaryFormatTRO);
         gridPanel.add(chkSkipSavePrompts);
         gridPanel.add(chkIncludeLicense);
+        gridPanel.add(chkShowAvailabilityTab);
         gridPanel.add(scaleLine);
 
-        SpringUtilities.makeCompactGrid(gridPanel, 8, 1, 0, 0, 15, 10);
+        SpringUtilities.makeCompactGrid(gridPanel, 9, 1, 0, 0, 15, 10);
         gridPanel.setBorder(new EmptyBorder(20, 30, 20, 30));
         setLayout(new FlowLayout(FlowLayout.LEFT));
         add(gridPanel);
@@ -185,6 +191,7 @@ public class MiscSettingsPanel extends JPanel {
         miscSettings.put(CConfig.MISC_SUMMARY_FORMAT_TRO, String.valueOf(chkSummaryFormatTRO.isSelected()));
         miscSettings.put(CConfig.MISC_SKIP_SAFETY_PROMPTS, String.valueOf(chkSkipSavePrompts.isSelected()));
         miscSettings.put(CConfig.MISC_INCLUDE_LICENSE, String.valueOf(chkIncludeLicense.isSelected()));
+        miscSettings.put(CConfig.MISC_SHOW_AVAILABILITY_TAB, String.valueOf(chkShowAvailabilityTab.isSelected()));
         MMLStartUp startUp = startUpMMComboBox.getSelectedItem() == null
               ? MMLStartUp.SPLASH_SCREEN
               : startUpMMComboBox.getSelectedItem();

--- a/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
@@ -52,6 +52,7 @@ import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
+import megameklab.ui.generalUnit.AvailabilityTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -71,6 +72,7 @@ public class ASMainUI extends MegaMekLabMainUI {
         return fluffTab;
     }
     private QuirksTab quirksTab;
+    private AvailabilityTab availabilityTab;
     private FloatingEquipmentDatabaseDialog floatingEquipmentDatabase;
 
     public ASMainUI(Entity entity, String filename) {
@@ -97,11 +99,13 @@ public class ASMainUI extends MegaMekLabMainUI {
         buildTab = new ASBuildTab(this);
         fluffTab = new FluffTab(this);
         quirksTab = new QuirksTab(this);
+        availabilityTab = new AvailabilityTab(this);
         structureTab.addRefreshedListener(this);
         equipmentTab.addRefreshedListener(this);
         buildTab.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
         quirksTab.addRefreshedListener(this);
+        availabilityTab.addRefreshedListener(this);
         statusbar.addRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
@@ -109,6 +113,7 @@ public class ASMainUI extends MegaMekLabMainUI {
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
+        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 
@@ -176,6 +181,7 @@ public class ASMainUI extends MegaMekLabMainUI {
         equipmentTab.refresh();
         buildTab.refresh();
         quirksTab.refresh();
+        availabilityTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
         analysisTab.refresh();

--- a/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASMainUI.java
@@ -53,6 +53,7 @@ import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.AvailabilityTab;
+import megameklab.util.CConfig;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -113,7 +114,9 @@ public class ASMainUI extends MegaMekLabMainUI {
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
-        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        if (CConfig.showAvailabilityTab()) {
+            configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        }
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -141,6 +141,15 @@ public class AvailabilityTab extends ITab {
     }
 
     /**
+     * The rows the tab is showing.
+     *
+     * @return the table model
+     */
+    public AvailabilityTableModel getTableModel() {
+        return tableModel;
+    }
+
+    /**
      * Reloads the tab from the unit. The introduction year lives on Basic Info, so it can change under this tab; the
      * faction list and the warnings are rebuilt every time.
      */

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -128,6 +128,9 @@ public class AvailabilityTab extends ITab {
     private final JPanel editorPanel = new JPanel();
 
     private final Map<MissionRole, JCheckBox> roleCheckBoxes = new LinkedHashMap<>();
+    private final JPanel rolesPanel = new JPanel(new GridLayout(0, ROLE_COLUMNS));
+    /** Roles the unit file declares that do not apply to this unit type. Shown, not dropped. */
+    private final Set<MissionRole> mismatchedRoles = EnumSet.noneOf(MissionRole.class);
 
     private final JButton addButton = new JButton("+ Add factions...");
     private final JButton removeButton = new JButton("- Remove");
@@ -153,6 +156,29 @@ public class AvailabilityTab extends ITab {
      */
     public AvailabilityTableModel getTableModel() {
         return tableModel;
+    }
+
+    /**
+     * Whether a role is on offer for this unit. A role that does not apply to the unit type is hidden, unless the unit
+     * file already declares it.
+     *
+     * @param role the role to check
+     *
+     * @return {@code true} if the player can see and tick it
+     */
+    public boolean isRoleOffered(MissionRole role) {
+        JCheckBox checkBox = roleCheckBoxes.get(role);
+
+        return (checkBox != null) && checkBox.isVisible();
+    }
+
+    /**
+     * The roles the unit file declares that do not apply to this unit type. The Force Generator ignores these.
+     *
+     * @return the mismatched roles
+     */
+    public Set<MissionRole> getMismatchedRoles() {
+        return Set.copyOf(mismatchedRoles);
     }
 
     /**
@@ -320,17 +346,16 @@ public class AvailabilityTab extends ITab {
     }
 
     private JPanel buildRolesPanel() {
-        JPanel panel = new JPanel(new GridLayout(0, ROLE_COLUMNS));
-        panel.setBorder(BorderFactory.createTitledBorder("Mission roles (optional)"));
+        rolesPanel.setBorder(BorderFactory.createTitledBorder("Mission roles (optional)"));
 
         for (MissionRole role : MissionRole.values()) {
             JCheckBox checkBox = new JCheckBox(role.toString().replace('_', ' '));
             checkBox.addActionListener(event -> writeBack());
             roleCheckBoxes.put(role, checkBox);
-            panel.add(checkBox);
+            rolesPanel.add(checkBox);
         }
 
-        return panel;
+        return rolesPanel;
     }
 
     // --- Faction list -------------------------------------------------------------------------------------------
@@ -466,6 +491,14 @@ public class AvailabilityTab extends ITab {
 
     // --- Mission roles ------------------------------------------------------------------------------------------
 
+    /**
+     * Shows only the roles that mean anything for this unit type. A Mek has no business being offered "mek carrier" or
+     * "paratrooper", and the Force Generator would ignore them anyway.
+     * <p>
+     * A role the unit file declares that does not fit is kept, selected and visible, so the player can see it and
+     * decide. Quietly dropping something out of somebody's file is not this tab's job.
+     * </p>
+     */
     private void loadMissionRoles(String missionRoles) {
         Set<MissionRole> chosen = EnumSet.noneOf(MissionRole.class);
         for (String roleName : missionRoles.split(",")) {
@@ -479,9 +512,25 @@ public class AvailabilityTab extends ITab {
             }
         }
 
+        int unitType = getEntity().getUnitType();
+        mismatchedRoles.clear();
+
         for (Map.Entry<MissionRole, JCheckBox> entry : roleCheckBoxes.entrySet()) {
-            entry.getValue().setSelected(chosen.contains(entry.getKey()));
+            MissionRole role = entry.getKey();
+            JCheckBox checkBox = entry.getValue();
+            boolean isSelected = chosen.contains(role);
+            boolean fits = role.fitsUnitType(unitType);
+
+            checkBox.setSelected(isSelected);
+            checkBox.setVisible(fits || isSelected);
+
+            if (isSelected && !fits) {
+                mismatchedRoles.add(role);
+            }
         }
+
+        rolesPanel.revalidate();
+        rolesPanel.repaint();
     }
 
     private String missionRolesText() {
@@ -519,6 +568,12 @@ public class AvailabilityTab extends ITab {
                 warnings.add(row.factionCode() + " starts in " + row.fromYear()
                       + ", but the unit does not exist until " + getEntity().getYear() + ".");
             }
+        }
+
+        if (!mismatchedRoles.isEmpty()) {
+            StringJoiner roleNames = new StringJoiner(", ");
+            mismatchedRoles.forEach(role -> roleNames.add(role.toString().replace('_', ' ')));
+            warnings.add("These mission roles do not apply to this unit type and will be ignored: " + roleNames + ".");
         }
 
         if (tableModel.hasStaleRows()) {

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -55,6 +55,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSlider;
@@ -64,16 +65,20 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.table.DefaultTableCellRenderer;
 
+import megamek.client.ratgenerator.AvailabilityRating;
 import megamek.client.ratgenerator.ChassisRecord;
 import megamek.client.ratgenerator.FactionRecord;
 import megamek.client.ratgenerator.MissionRole;
 import megamek.client.ratgenerator.RATGenerator;
+import megamek.client.ui.dialogs.UnitLoadingDialog;
 import megamek.client.ui.util.UIUtil;
 import megamek.common.loaders.MekFileParser;
 import megamek.common.units.Entity;
 import megamek.common.units.ForceGeneratorAvailability;
+import megamek.common.units.UnitType;
 import megameklab.ui.EntitySource;
 import megameklab.ui.dialog.AddFactionsDialog;
+import megameklab.ui.dialog.MegaMekLabUnitSelectorDialog;
 import megameklab.ui.generalUnit.AvailabilityTableModel.AvailabilityRow;
 import megameklab.ui.util.ITab;
 import megameklab.ui.util.RefreshListener;
@@ -126,6 +131,7 @@ public class AvailabilityTab extends ITab {
 
     private final JButton addButton = new JButton("+ Add factions...");
     private final JButton removeButton = new JButton("- Remove");
+    private final JButton copyFromUnitButton = new JButton("Copy numbers from a unit...");
 
     /** Guards the listeners while the editor is being filled in from the selected row. */
     private boolean updatingEditor = false;
@@ -204,11 +210,79 @@ public class AvailabilityTab extends ITab {
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         addButton.addActionListener(event -> addFactions());
         removeButton.addActionListener(event -> removeSelectedFaction());
+        copyFromUnitButton.addActionListener(event -> copyNumbersFromUnit());
+        copyFromUnitButton.setToolTipText("Start from a design you already know, rather than from a blank table.");
         buttonPanel.add(addButton);
         buttonPanel.add(removeButton);
+        buttonPanel.add(copyFromUnitButton);
         panel.add(buttonPanel, BorderLayout.SOUTH);
 
         return panel;
+    }
+
+    /**
+     * Fills the table from a canon design's own numbers.
+     * <p>
+     * Nobody has intuition for a base-2 log scale, so the surest way to a sane table is to start from a design whose
+     * commonness the player already understands and adjust from there.
+     * </p>
+     */
+    private void copyNumbersFromUnit() {
+        UnitLoadingDialog unitLoadingDialog = new UnitLoadingDialog(null);
+        unitLoadingDialog.setVisible(true);
+
+        Entity chosenEntity;
+        try {
+            MegaMekLabUnitSelectorDialog selector =
+                  new MegaMekLabUnitSelectorDialog(null, unitLoadingDialog, false);
+            chosenEntity = selector.getChosenEntity();
+        } finally {
+            unitLoadingDialog.setVisible(false);
+        }
+
+        if (chosenEntity == null) {
+            return;
+        }
+
+        List<AvailabilityRating> ratings = AvailabilityCalibration.ratingsOf(chassisKeyOf(chosenEntity),
+              getEntity().getYear());
+
+        if (ratings.isEmpty()) {
+            JOptionPane.showMessageDialog(this,
+                  "The Force Generator has no availability for " + chosenEntity.getShortNameRaw() + " in "
+                        + getEntity().getYear() + ", so there is nothing to copy.",
+                  "Nothing to copy",
+                  JOptionPane.INFORMATION_MESSAGE);
+            return;
+        }
+
+        for (AvailabilityRating rating : ratings) {
+            tableModel.addRow(new AvailabilityRow(rating.getFactionCode(),
+                  factionNameOf(rating.getFactionCode()),
+                  rating.getAvailability(),
+                  ForceGeneratorAvailability.UNSPECIFIED_YEAR,
+                  ForceGeneratorAvailability.UNSPECIFIED_YEAR,
+                  false));
+        }
+
+        tableModel.markStaleFactions(activeFactionCodes());
+        writeBack();
+    }
+
+    /**
+     * Builds the key the Force Generator files a design's chassis under.
+     *
+     * @param entity the design
+     *
+     * @return the chassis key, e.g. "Archer[Mek]"
+     */
+    private static String chassisKeyOf(Entity entity) {
+        String key = entity.getChassis() + '[' + UnitType.getTypeName(entity.getUnitType()) + ']';
+        if (!entity.isOmni()) {
+            return key;
+        }
+
+        return key + (entity.isClan() ? "ClanOmni" : "ISOmni");
     }
 
     private JPanel buildEditorPanel() {

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -1,0 +1,555 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMekLab was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.ui.generalUnit;
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSlider;
+import javax.swing.JSpinner;
+import javax.swing.JTable;
+import javax.swing.ListSelectionModel;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.table.DefaultTableCellRenderer;
+
+import megamek.client.ratgenerator.ChassisRecord;
+import megamek.client.ratgenerator.FactionRecord;
+import megamek.client.ratgenerator.MissionRole;
+import megamek.client.ratgenerator.RATGenerator;
+import megamek.client.ui.util.UIUtil;
+import megamek.common.loaders.MekFileParser;
+import megamek.common.units.Entity;
+import megamek.common.units.ForceGeneratorAvailability;
+import megameklab.ui.EntitySource;
+import megameklab.ui.dialog.AddFactionsDialog;
+import megameklab.ui.generalUnit.AvailabilityTableModel.AvailabilityRow;
+import megameklab.ui.util.ITab;
+import megameklab.ui.util.RefreshListener;
+import megameklab.util.AvailabilityCalibration;
+
+/**
+ * Lets a player say which factions field a custom unit, and how often, so it turns up in generated forces.
+ * <p>
+ * The tab is built around the order a player actually works in: the unit is already built and its introduction year is
+ * already set on Basic Info, so this tab comes last. List the factions, set the number, and only then worry about year
+ * ranges.
+ * </p>
+ * <p>
+ * The number runs 0 to 10 on a base-2 log scale and means nothing on its own, so the slider says it in words and the
+ * tab names canon designs of about the same commonness. That is the difference between a considered number and a
+ * guess.
+ * </p>
+ */
+public class AvailabilityTab extends ITab {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /** What a new faction starts at. 6 is what the canon data uses when the source books give no hint either way. */
+    private static final int DEFAULT_AVAILABILITY = 6;
+    private static final int MIN_AVAILABILITY = 0;
+    private static final int MAX_AVAILABILITY = 10;
+    private static final int MIN_YEAR = 1950;
+    private static final int MAX_YEAR = 3200;
+    private static final int TABLE_WIDTH = 640;
+    private static final int TABLE_HEIGHT = 200;
+    private static final int ROLE_COLUMNS = 4;
+
+    private RefreshListener refresh;
+
+    private final AvailabilityTableModel tableModel = new AvailabilityTableModel();
+    private final JTable factionTable = new JTable(tableModel);
+
+    private final JLabel headerLabel = new JLabel();
+    private final JLabel warningLabel = new JLabel();
+
+    private final JSlider availabilitySlider = new JSlider(MIN_AVAILABILITY, MAX_AVAILABILITY);
+    private final JLabel availabilityWordLabel = new JLabel();
+    private final JLabel comparableLabel = new JLabel();
+    private final JSpinner fromYearSpinner = new JSpinner(new SpinnerNumberModel(MIN_YEAR, MIN_YEAR, MAX_YEAR, 1));
+    private final JSpinner toYearSpinner = new JSpinner(new SpinnerNumberModel(MIN_YEAR, MIN_YEAR, MAX_YEAR, 1));
+    private final JCheckBox neverStopsCheckBox = new JCheckBox("never stops");
+    private final JPanel editorPanel = new JPanel();
+
+    private final Map<MissionRole, JCheckBox> roleCheckBoxes = new LinkedHashMap<>();
+
+    private final JButton addButton = new JButton("+ Add factions...");
+    private final JButton removeButton = new JButton("- Remove");
+
+    /** Guards the listeners while the editor is being filled in from the selected row. */
+    private boolean updatingEditor = false;
+
+    public AvailabilityTab(EntitySource eSource) {
+        super(eSource);
+        buildLayout();
+        refresh();
+    }
+
+    public void addRefreshedListener(RefreshListener listener) {
+        refresh = listener;
+    }
+
+    /**
+     * Reloads the tab from the unit. The introduction year lives on Basic Info, so it can change under this tab; the
+     * faction list and the warnings are rebuilt every time.
+     */
+    public void refresh() {
+        Entity entity = getEntity();
+
+        headerLabel.setText(entity.getShortNameRaw()
+              + "  -  introduced " + entity.getYear()
+              + "  -  " + (isCanonUnit() ? "canon unit" : "custom unit"));
+
+        tableModel.loadFrom(entity.getForceGeneratorAvailability(), this::factionNameOf);
+        tableModel.markStaleFactions(activeFactionCodes());
+        loadMissionRoles(entity.getMissionRoles());
+
+        updateWarnings();
+        updateEditorFromSelection();
+    }
+
+    private void buildLayout() {
+        setLayout(new BorderLayout());
+
+        JPanel headerPanel = new JPanel(new BorderLayout());
+        headerPanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 4, 8));
+        headerPanel.add(headerLabel, BorderLayout.NORTH);
+        warningLabel.setForeground(Color.RED);
+        headerPanel.add(warningLabel, BorderLayout.CENTER);
+        add(headerPanel, BorderLayout.NORTH);
+
+        JPanel centrePanel = new JPanel();
+        centrePanel.setLayout(new BoxLayout(centrePanel, BoxLayout.Y_AXIS));
+        centrePanel.add(buildFactionPanel());
+        centrePanel.add(buildEditorPanel());
+        centrePanel.add(buildRolesPanel());
+        add(new JScrollPane(centrePanel), BorderLayout.CENTER);
+    }
+
+    private JPanel buildFactionPanel() {
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.setBorder(BorderFactory.createTitledBorder("Who fields this unit?"));
+
+        factionTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        factionTable.getSelectionModel().addListSelectionListener(event -> {
+            if (!event.getValueIsAdjusting()) {
+                updateEditorFromSelection();
+            }
+        });
+        factionTable.setDefaultRenderer(Object.class, new StaleRowRenderer());
+        JScrollPane tableScroll = new JScrollPane(factionTable);
+        tableScroll.setPreferredSize(UIUtil.scaleForGUI(TABLE_WIDTH, TABLE_HEIGHT));
+        panel.add(tableScroll, BorderLayout.CENTER);
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        addButton.addActionListener(event -> addFactions());
+        removeButton.addActionListener(event -> removeSelectedFaction());
+        buttonPanel.add(addButton);
+        buttonPanel.add(removeButton);
+        panel.add(buttonPanel, BorderLayout.SOUTH);
+
+        return panel;
+    }
+
+    private JPanel buildEditorPanel() {
+        editorPanel.setLayout(new BoxLayout(editorPanel, BoxLayout.Y_AXIS));
+        editorPanel.setBorder(BorderFactory.createTitledBorder("Selected faction"));
+
+        availabilitySlider.setMajorTickSpacing(2);
+        availabilitySlider.setPaintTicks(true);
+        availabilitySlider.setPaintLabels(true);
+        availabilitySlider.setSnapToTicks(false);
+        availabilitySlider.addChangeListener(event -> onAvailabilityChanged());
+
+        JPanel sliderPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        sliderPanel.add(new JLabel("How common?"));
+        sliderPanel.add(availabilitySlider);
+        sliderPanel.add(availabilityWordLabel);
+        editorPanel.add(sliderPanel);
+
+        JPanel comparablePanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        comparablePanel.add(comparableLabel);
+        editorPanel.add(comparablePanel);
+
+        JPanel yearPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        yearPanel.add(new JLabel("Years: from"));
+        yearPanel.add(fromYearSpinner);
+        yearPanel.add(new JLabel("to"));
+        yearPanel.add(toYearSpinner);
+        yearPanel.add(neverStopsCheckBox);
+        fromYearSpinner.addChangeListener(event -> onYearsChanged());
+        toYearSpinner.addChangeListener(event -> onYearsChanged());
+        neverStopsCheckBox.addActionListener(event -> onYearsChanged());
+        editorPanel.add(yearPanel);
+
+        return editorPanel;
+    }
+
+    private JPanel buildRolesPanel() {
+        JPanel panel = new JPanel(new GridLayout(0, ROLE_COLUMNS));
+        panel.setBorder(BorderFactory.createTitledBorder("Mission roles (optional)"));
+
+        for (MissionRole role : MissionRole.values()) {
+            JCheckBox checkBox = new JCheckBox(role.toString().replace('_', ' '));
+            checkBox.addActionListener(event -> writeBack());
+            roleCheckBoxes.put(role, checkBox);
+            panel.add(checkBox);
+        }
+
+        return panel;
+    }
+
+    // --- Faction list -------------------------------------------------------------------------------------------
+
+    private void addFactions() {
+        List<String> alreadyChosen = new ArrayList<>();
+        for (AvailabilityRow row : tableModel.getRows()) {
+            alreadyChosen.add(row.factionCode());
+        }
+
+        AddFactionsDialog dialog = new AddFactionsDialog(this, getEntity().getYear(), alreadyChosen);
+        dialog.setVisible(true);
+
+        for (String factionCode : dialog.getChosenFactionCodes()) {
+            tableModel.addRow(new AvailabilityRow(factionCode,
+                  factionNameOf(factionCode),
+                  DEFAULT_AVAILABILITY,
+                  ForceGeneratorAvailability.UNSPECIFIED_YEAR,
+                  ForceGeneratorAvailability.UNSPECIFIED_YEAR,
+                  false));
+        }
+
+        tableModel.markStaleFactions(activeFactionCodes());
+        writeBack();
+    }
+
+    private void removeSelectedFaction() {
+        int selected = factionTable.getSelectedRow();
+        if (selected < 0) {
+            return;
+        }
+
+        tableModel.removeRow(selected);
+        writeBack();
+    }
+
+    // --- Editor strip -------------------------------------------------------------------------------------------
+
+    private void updateEditorFromSelection() {
+        int selected = factionTable.getSelectedRow();
+        boolean hasSelection = (selected >= 0) && (selected < tableModel.getRowCount());
+
+        availabilitySlider.setEnabled(hasSelection);
+        fromYearSpinner.setEnabled(hasSelection);
+        toYearSpinner.setEnabled(hasSelection);
+        neverStopsCheckBox.setEnabled(hasSelection);
+
+        if (!hasSelection) {
+            availabilityWordLabel.setText("");
+            comparableLabel.setText("Select a faction to set how common this unit is.");
+            return;
+        }
+
+        AvailabilityRow row = tableModel.getRow(selected);
+
+        updatingEditor = true;
+        availabilitySlider.setValue(row.availability());
+        int fromYear = (row.fromYear() == ForceGeneratorAvailability.UNSPECIFIED_YEAR)
+              ? getEntity().getYear()
+              : row.fromYear();
+        fromYearSpinner.setValue(Math.clamp(fromYear, MIN_YEAR, MAX_YEAR));
+        boolean neverStops = (row.toYear() == ForceGeneratorAvailability.UNSPECIFIED_YEAR);
+        neverStopsCheckBox.setSelected(neverStops);
+        toYearSpinner.setEnabled(!neverStops);
+        toYearSpinner.setValue(Math.clamp(neverStops ? MAX_YEAR : row.toYear(), MIN_YEAR, MAX_YEAR));
+        updatingEditor = false;
+
+        updateAvailabilityText(row);
+    }
+
+    private void onAvailabilityChanged() {
+        if (updatingEditor) {
+            return;
+        }
+
+        int selected = factionTable.getSelectedRow();
+        if (selected < 0) {
+            return;
+        }
+
+        AvailabilityRow row = tableModel.getRow(selected).withAvailability(availabilitySlider.getValue());
+        tableModel.setRow(selected, row);
+        updateAvailabilityText(row);
+        writeBack();
+    }
+
+    private void onYearsChanged() {
+        if (updatingEditor) {
+            return;
+        }
+
+        int selected = factionTable.getSelectedRow();
+        if (selected < 0) {
+            return;
+        }
+
+        toYearSpinner.setEnabled(!neverStopsCheckBox.isSelected());
+
+        int fromYear = (int) fromYearSpinner.getValue();
+        int toYear = neverStopsCheckBox.isSelected()
+              ? ForceGeneratorAvailability.UNSPECIFIED_YEAR
+              : (int) toYearSpinner.getValue();
+
+        tableModel.setRow(selected, tableModel.getRow(selected).withYears(fromYear, toYear));
+        updateWarnings();
+        writeBack();
+    }
+
+    /**
+     * Says the number in words and names canon designs of about the same commonness. Without this the number is a
+     * guess: nobody has intuition for a base-2 log scale.
+     *
+     * @param row the row being edited
+     */
+    private void updateAvailabilityText(AvailabilityRow row) {
+        availabilityWordLabel.setText(row.availability() + "  " + AvailabilityCalibration.describe(row.availability()));
+
+        List<String> comparable = AvailabilityCalibration.comparableUnits(getEntity().getUnitType(),
+              row.factionCode(),
+              getEntity().getYear(),
+              row.availability());
+
+        if (comparable.isEmpty()) {
+            comparableLabel.setText(" ");
+            return;
+        }
+
+        StringJoiner names = new StringJoiner(", ");
+        comparable.forEach(names::add);
+        comparableLabel.setText("At " + row.factionCode() + ":" + row.availability()
+              + " this is about as common as: " + names);
+    }
+
+    // --- Mission roles ------------------------------------------------------------------------------------------
+
+    private void loadMissionRoles(String missionRoles) {
+        Set<MissionRole> chosen = EnumSet.noneOf(MissionRole.class);
+        for (String roleName : missionRoles.split(",")) {
+            String trimmed = roleName.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            MissionRole role = MissionRole.parseRole(trimmed);
+            if (role != null) {
+                chosen.add(role);
+            }
+        }
+
+        for (Map.Entry<MissionRole, JCheckBox> entry : roleCheckBoxes.entrySet()) {
+            entry.getValue().setSelected(chosen.contains(entry.getKey()));
+        }
+    }
+
+    private String missionRolesText() {
+        StringJoiner roles = new StringJoiner(",");
+        for (Map.Entry<MissionRole, JCheckBox> entry : roleCheckBoxes.entrySet()) {
+            if (entry.getValue().isSelected()) {
+                roles.add(entry.getKey().toString());
+            }
+        }
+
+        return roles.toString();
+    }
+
+    // --- Warnings -----------------------------------------------------------------------------------------------
+
+    /**
+     * Tells the player when what they are doing will silently not work. Everything here is a rule a hand-editing
+     * player would only discover by reading megamek.log, which is not a reasonable ask.
+     */
+    private void updateWarnings() {
+        List<String> warnings = new ArrayList<>();
+
+        if (isCanonUnit()) {
+            warnings.add("This is a canon unit. The Force Generator will IGNORE everything on this tab. "
+                  + "Save it under a new model name to make it a custom variant.");
+        } else if (isCanonChassis()) {
+            warnings.add("This is a custom variant of a canon chassis. Factions that already field the chassis keep "
+                  + "their canon rating, so your number only decides which variant they get. Factions that do not "
+                  + "field it will now get this variant.");
+        }
+
+        for (AvailabilityRow row : tableModel.getRows()) {
+            if ((row.fromYear() != ForceGeneratorAvailability.UNSPECIFIED_YEAR)
+                  && (row.fromYear() < getEntity().getYear())) {
+                warnings.add(row.factionCode() + " starts in " + row.fromYear()
+                      + ", but the unit does not exist until " + getEntity().getYear() + ".");
+            }
+        }
+
+        if (tableModel.hasStaleRows()) {
+            warnings.add("Some factions in the table do not exist in " + getEntity().getYear()
+                  + ". Those entries will never be used.");
+        }
+
+        if (warnings.isEmpty()) {
+            warningLabel.setText(" ");
+            return;
+        }
+
+        StringJoiner text = new StringJoiner("<br>", "<html>", "</html>");
+        warnings.forEach(text::add);
+        warningLabel.setText(text.toString());
+    }
+
+    /**
+     * Entity.isCanon() is stamped when the unit is loaded, so it goes stale the moment the player renames the unit,
+     * which is exactly how a canon design becomes a custom variant. Ask by the current name instead.
+     *
+     * @return true if the unit's current name is a canon unit
+     */
+    private boolean isCanonUnit() {
+        return MekFileParser.isCanonUnitName(getEntity().getShortNameRaw());
+    }
+
+    private boolean isCanonChassis() {
+        RATGenerator ratGenerator = RATGenerator.getInstance();
+        if (!ratGenerator.isInitialized()) {
+            return false;
+        }
+
+        for (ChassisRecord chassisRecord : ratGenerator.getChassisList()) {
+            if (chassisRecord.getChassis().equalsIgnoreCase(getEntity().getChassis())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // --- Force Generator lookups --------------------------------------------------------------------------------
+
+    private String factionNameOf(String factionCode) {
+        RATGenerator ratGenerator = RATGenerator.getInstance();
+        if (!ratGenerator.isInitialized()) {
+            return factionCode;
+        }
+
+        FactionRecord factionRecord = ratGenerator.getFaction(factionCode);
+
+        return (factionRecord == null) ? factionCode : factionRecord.getName(getEntity().getYear());
+    }
+
+    private Set<String> activeFactionCodes() {
+        RATGenerator ratGenerator = RATGenerator.getInstance();
+        Set<String> codes = new HashSet<>(AddFactionsDialog.UMBRELLA_CODES);
+        if (!ratGenerator.isInitialized()) {
+            return codes;
+        }
+
+        for (FactionRecord factionRecord : ratGenerator.getFactionList()) {
+            if (factionRecord.isActiveInYear(getEntity().getYear())) {
+                codes.add(factionRecord.getKey());
+            }
+        }
+
+        return codes;
+    }
+
+    // --- Persistence --------------------------------------------------------------------------------------------
+
+    /**
+     * Stores the tab's state on the unit. MegaMekLab's savers write the entity out, so nothing else is needed to get
+     * these onto disk.
+     */
+    private void writeBack() {
+        List<ForceGeneratorAvailability> entries = tableModel.toAvailabilityEntries();
+        getEntity().setForceGeneratorAvailability(entries);
+        getEntity().setMissionRoles(missionRolesText());
+
+        updateWarnings();
+
+        if (refresh != null) {
+            refresh.refreshStatus();
+        }
+    }
+
+    /** Highlights rows whose faction does not exist in the unit's year. */
+    private static class StaleRowRenderer extends DefaultTableCellRenderer {
+        @Serial
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
+              boolean hasFocus, int row, int column) {
+            Component component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+
+            AvailabilityTableModel model = (AvailabilityTableModel) table.getModel();
+            if (model.getRow(row).stale() && !isSelected) {
+                component.setForeground(Color.RED);
+            } else if (!isSelected) {
+                component.setForeground(table.getForeground());
+            }
+
+            return component;
+        }
+    }
+
+    public ComponentListener refreshOnShow = new ComponentAdapter() {
+        @Override
+        public void componentShown(ComponentEvent event) {
+            refresh();
+        }
+    };
+}

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -130,6 +130,8 @@ public class AvailabilityTab extends ITab {
 
     private final Map<MissionRole, JCheckBox> roleCheckBoxes = new LinkedHashMap<>();
     private final JPanel rolesPanel = new JPanel(new GridLayout(0, ROLE_COLUMNS));
+    /** Roles currently shown, being those that fit the unit type plus any the file declares. */
+    private final Set<MissionRole> offeredRoles = EnumSet.noneOf(MissionRole.class);
     /** Roles the unit file declares that do not apply to this unit type. Shown, not dropped. */
     private final Set<MissionRole> mismatchedRoles = EnumSet.noneOf(MissionRole.class);
 
@@ -168,9 +170,17 @@ public class AvailabilityTab extends ITab {
      * @return {@code true} if the player can see and tick it
      */
     public boolean isRoleOffered(MissionRole role) {
-        JCheckBox checkBox = roleCheckBoxes.get(role);
+        return offeredRoles.contains(role);
+    }
 
-        return (checkBox != null) && checkBox.isVisible();
+    /**
+     * How many role checkboxes are actually in the grid. Equals the number of offered roles when the grid packs with
+     * no hidden placeholder cells; used to guard against the holes that setVisible-based hiding left behind.
+     *
+     * @return the checkbox count
+     */
+    int missionRoleGridSize() {
+        return rolesPanel.getComponentCount();
     }
 
     /**
@@ -349,11 +359,12 @@ public class AvailabilityTab extends ITab {
     private JPanel buildRolesPanel() {
         rolesPanel.setBorder(BorderFactory.createTitledBorder("Mission roles (optional)"));
 
+        // Build every checkbox once, but leave the panel empty: loadMissionRoles adds only the ones to show, so the
+        // grid packs with no holes where a role does not apply to this unit type.
         for (MissionRole role : MissionRole.values()) {
             JCheckBox checkBox = new JCheckBox(role.toString().replace('_', ' '));
             checkBox.addActionListener(event -> writeBack());
             roleCheckBoxes.put(role, checkBox);
-            rolesPanel.add(checkBox);
         }
 
         return rolesPanel;
@@ -496,8 +507,9 @@ public class AvailabilityTab extends ITab {
      * Shows only the roles that mean anything for this unit type. A Mek has no business being offered "mek carrier" or
      * "paratrooper", and the Force Generator would ignore them anyway.
      * <p>
-     * A role the unit file declares that does not fit is kept, selected and visible, so the player can see it and
-     * decide. Quietly dropping something out of somebody's file is not this tab's job.
+     * Only the roles to show are added to the grid, in role order, so the checkboxes pack together with no gaps where a
+     * role does not apply. A role the unit file declares that does not fit is kept, selected, so the player can see it
+     * and decide. Quietly dropping something out of somebody's file is not this tab's job.
      * </p>
      */
     private void loadMissionRoles(String missionRoles) {
@@ -515,15 +527,20 @@ public class AvailabilityTab extends ITab {
 
         int unitType = getEntity().getUnitType();
         mismatchedRoles.clear();
+        offeredRoles.clear();
+        rolesPanel.removeAll();
 
-        for (Map.Entry<MissionRole, JCheckBox> entry : roleCheckBoxes.entrySet()) {
-            MissionRole role = entry.getKey();
-            JCheckBox checkBox = entry.getValue();
+        for (MissionRole role : MissionRole.values()) {
             boolean isSelected = chosen.contains(role);
             boolean fits = role.fitsUnitType(unitType);
+            if (!fits && !isSelected) {
+                continue;
+            }
 
+            JCheckBox checkBox = roleCheckBoxes.get(role);
             checkBox.setSelected(isSelected);
-            checkBox.setVisible(fits || isSelected);
+            rolesPanel.add(checkBox);
+            offeredRoles.add(role);
 
             if (isSelected && !fits) {
                 mismatchedRoles.add(role);

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -74,6 +74,8 @@ import megamek.client.ratgenerator.RATGenerator;
 import megamek.client.ui.dialogs.UnitLoadingDialog;
 import megamek.client.ui.util.UIUtil;
 import megamek.common.loaders.MekFileParser;
+import megamek.common.loaders.MekSummary;
+import megamek.common.loaders.MekSummaryCache;
 import megamek.common.units.Entity;
 import megamek.common.units.ForceGeneratorAvailability;
 import megamek.common.units.UnitType;
@@ -111,6 +113,9 @@ public class AvailabilityTab extends ITab {
     private static final int TABLE_WIDTH = 640;
     private static final int TABLE_HEIGHT = 200;
     private static final int ROLE_COLUMNS = 4;
+
+    /** Cached canon chassis names, lowercased. Built once; canon data does not change within a session. */
+    private static Set<String> cachedCanonChassisNames;
 
     private RefreshListener refresh;
 
@@ -734,14 +739,35 @@ public class AvailabilityTab extends ITab {
     }
 
     private boolean isCanonChassis() {
-        RATGenerator ratGenerator = RATGenerator.getInstance();
-        if (!ratGenerator.isInitialized()) {
-            return false;
+        return canonChassisNames().contains(getEntity().getChassis().toLowerCase());
+    }
+
+    /**
+     * The chassis names that belong to canon units, lowercased. Built once from the unit cache. The Force Generator's
+     * own chassis list cannot answer this: it holds custom chassis this feature injected into it, so a brand new custom
+     * chassis would wrongly read as canon.
+     *
+     * @return the canon chassis names, or an empty set until the unit cache is ready
+     */
+    private static Set<String> canonChassisNames() {
+        if (cachedCanonChassisNames != null) {
+            return cachedCanonChassisNames;
         }
 
-        // Direct key lookup rather than scanning every chassis: O(1), and it never iterates a collection the Force
-        // Generator's loader thread might still be writing to.
-        return ratGenerator.getChassisRecord(chassisKeyOf(getEntity())) != null;
+        MekSummaryCache mekSummaryCache = MekSummaryCache.getInstance();
+        if (!mekSummaryCache.isInitialized()) {
+            return Set.of();
+        }
+
+        Set<String> names = new HashSet<>();
+        for (MekSummary mekSummary : mekSummaryCache.getAllMeks()) {
+            if (mekSummary.isCanon()) {
+                names.add(mekSummary.getChassis().toLowerCase());
+            }
+        }
+        cachedCanonChassisNames = names;
+
+        return names;
     }
 
     // --- Force Generator lookups --------------------------------------------------------------------------------

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -604,8 +604,9 @@ public class AvailabilityTab extends ITab {
         List<String> warnings = new ArrayList<>();
 
         if (isCanonUnit()) {
-            warnings.add("This is a canon unit. The Force Generator will IGNORE everything on this tab. "
-                  + "Save it under a new model name to make it a custom variant.");
+            warnings.add("This is a canon unit. What you set here REPLACES its canon availability for the factions you "
+                  + "list, so it changes how canon forces generate for anyone who installs this file. To leave canon "
+                  + "alone, save it under a new model name as a custom variant instead.");
         } else if (isCanonChassis()) {
             warnings.add("This is a custom variant of a canon chassis. Factions that already field the chassis keep "
                   + "their canon rating, so your number only decides which variant they get. Factions that do not "

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -62,12 +62,12 @@ import javax.swing.JScrollPane;
 import javax.swing.JSlider;
 import javax.swing.JSpinner;
 import javax.swing.JTable;
+import javax.swing.JTextArea;
 import javax.swing.ListSelectionModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.table.DefaultTableCellRenderer;
 
 import megamek.client.ratgenerator.AvailabilityRating;
-import megamek.client.ratgenerator.ChassisRecord;
 import megamek.client.ratgenerator.FactionRecord;
 import megamek.client.ratgenerator.MissionRole;
 import megamek.client.ratgenerator.RATGenerator;
@@ -118,7 +118,7 @@ public class AvailabilityTab extends ITab {
     private final JTable factionTable = new JTable(tableModel);
 
     private final JLabel headerLabel = new JLabel();
-    private final JLabel warningLabel = new JLabel();
+    private final JTextArea warningArea = new JTextArea();
 
     private final JSlider availabilitySlider = new JSlider(MIN_AVAILABILITY, MAX_AVAILABILITY);
     private final JLabel availabilityWordLabel = new JLabel();
@@ -217,8 +217,15 @@ public class AvailabilityTab extends ITab {
         JPanel headerPanel = new JPanel(new BorderLayout());
         headerPanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 4, 8));
         headerPanel.add(headerLabel, BorderLayout.NORTH);
-        warningLabel.setForeground(Color.RED);
-        headerPanel.add(warningLabel, BorderLayout.CENTER);
+        // A text area, not a label, so a long warning wraps to the width instead of being clipped
+        warningArea.setEditable(false);
+        warningArea.setLineWrap(true);
+        warningArea.setWrapStyleWord(true);
+        warningArea.setOpaque(false);
+        warningArea.setForeground(Color.RED);
+        warningArea.setFont(headerLabel.getFont());
+        warningArea.setBorder(null);
+        headerPanel.add(warningArea, BorderLayout.CENTER);
         add(headerPanel, BorderLayout.NORTH);
 
         JPanel centrePanel = new JPanel();
@@ -341,6 +348,10 @@ public class AvailabilityTab extends ITab {
         JPanel comparablePanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         comparablePanel.add(comparableLabel);
         editorPanel.add(comparablePanel);
+
+        // A year is not a quantity: show "3056", not the locale-grouped "3,056"
+        fromYearSpinner.setEditor(new JSpinner.NumberEditor(fromYearSpinner, "0"));
+        toYearSpinner.setEditor(new JSpinner.NumberEditor(toYearSpinner, "0"));
 
         JPanel yearPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         yearPanel.add(new JLabel("Years: from"));
@@ -638,13 +649,11 @@ public class AvailabilityTab extends ITab {
         }
 
         if (warnings.isEmpty()) {
-            warningLabel.setText(" ");
+            warningArea.setText("");
             return;
         }
 
-        StringJoiner text = new StringJoiner("<br>", "<html>", "</html>");
-        warnings.forEach(text::add);
-        warningLabel.setText(text.toString());
+        warningArea.setText(String.join("\n", warnings));
     }
 
     /**
@@ -730,13 +739,9 @@ public class AvailabilityTab extends ITab {
             return false;
         }
 
-        for (ChassisRecord chassisRecord : ratGenerator.getChassisList()) {
-            if (chassisRecord.getChassis().equalsIgnoreCase(getEntity().getChassis())) {
-                return true;
-            }
-        }
-
-        return false;
+        // Direct key lookup rather than scanning every chassis: O(1), and it never iterates a collection the Force
+        // Generator's loader thread might still be writing to.
+        return ratGenerator.getChassisRecord(chassisKeyOf(getEntity())) != null;
     }
 
     // --- Force Generator lookups --------------------------------------------------------------------------------

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -466,14 +466,42 @@ public class AvailabilityTab extends ITab {
 
         toYearSpinner.setEnabled(!neverStopsCheckBox.isSelected());
 
-        int fromYear = (int) fromYearSpinner.getValue();
+        AvailabilityRow currentRow = tableModel.getRow(selected);
+        int fromYear = resolveFromYear((int) fromYearSpinner.getValue(), currentRow.fromYear(), getEntity().getYear());
         int toYear = neverStopsCheckBox.isSelected()
               ? ForceGeneratorAvailability.UNSPECIFIED_YEAR
               : (int) toYearSpinner.getValue();
 
-        tableModel.setRow(selected, tableModel.getRow(selected).withYears(fromYear, toYear));
+        tableModel.setRow(selected, currentRow.withYears(fromYear, toYear));
         updateWarnings();
         writeBack();
+    }
+
+    /**
+     * Keeps "start at the unit's introduction year" stored as the sentinel rather than a concrete year, so it still
+     * tracks the intro year if that later changes on Basic Info. Editing the year controls must not freeze the
+     * sentinel just because the spinner happens to show the intro year.
+     *
+     * @param spinnerFromYear the value in the from-year spinner
+     * @param rowFromYear     the row's current start year, which may be the sentinel
+     * @param introYear       the unit's introduction year
+     *
+     * @return the start year to store
+     */
+    static int resolveFromYear(int spinnerFromYear, int rowFromYear, int introYear) {
+        boolean stillAtIntro = (rowFromYear == ForceGeneratorAvailability.UNSPECIFIED_YEAR)
+              && (spinnerFromYear == introYear);
+
+        return stillAtIntro ? ForceGeneratorAvailability.UNSPECIFIED_YEAR : spinnerFromYear;
+    }
+
+    /**
+     * The mission roles the tab would write to the unit, for tests to check a hidden checkbox does not leak in.
+     *
+     * @return the comma-separated role text
+     */
+    String currentMissionRolesText() {
+        return missionRolesText();
     }
 
     /**
@@ -533,12 +561,16 @@ public class AvailabilityTab extends ITab {
         for (MissionRole role : MissionRole.values()) {
             boolean isSelected = chosen.contains(role);
             boolean fits = role.fitsUnitType(unitType);
+
+            // Set every checkbox's state, even ones not shown. missionRolesText() reads them all, so a checkbox left
+            // selected from a previous refresh would otherwise be written back into the unit.
+            JCheckBox checkBox = roleCheckBoxes.get(role);
+            checkBox.setSelected(isSelected);
+
             if (!fits && !isSelected) {
                 continue;
             }
 
-            JCheckBox checkBox = roleCheckBoxes.get(role);
-            checkBox.setSelected(isSelected);
             rolesPanel.add(checkBox);
             offeredRoles.add(role);
 

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -42,6 +42,7 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.io.Serial;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -66,6 +67,7 @@ import javax.swing.JTextArea;
 import javax.swing.ListSelectionModel;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableRowSorter;
 
 import megamek.client.ratgenerator.AvailabilityRating;
 import megamek.client.ratgenerator.FactionRecord;
@@ -208,8 +210,9 @@ public class AvailabilityTab extends ITab {
               + "  -  introduced " + entity.getYear()
               + "  -  " + (isCanonUnit() ? "canon unit" : "custom unit"));
 
+        tableModel.setIntroYear(entity.getYear());
         tableModel.loadFrom(entity.getForceGeneratorAvailability(), this::factionNameOf);
-        tableModel.markStaleFactions(activeFactionCodes());
+        tableModel.markStaleRows(this::isRowStale);
         loadMissionRoles(entity.getMissionRoles());
 
         updateWarnings();
@@ -251,6 +254,15 @@ public class AvailabilityTab extends ITab {
                 updateEditorFromSelection();
             }
         });
+
+        // Clicking a column header sorts by it. The cells are display text ("4  rare", "3085"), so the numeric columns
+        // need comparators that read the number rather than sorting the text.
+        TableRowSorter<AvailabilityTableModel> sorter = new TableRowSorter<>(tableModel);
+        sorter.setComparator(AvailabilityTableModel.COL_AVAILABILITY, Comparator.comparingInt(AvailabilityTab::leadingInt));
+        sorter.setComparator(AvailabilityTableModel.COL_FROM, Comparator.comparingInt(AvailabilityTab::yearValue));
+        sorter.setComparator(AvailabilityTableModel.COL_TO, Comparator.comparingInt(AvailabilityTab::yearValue));
+        factionTable.setRowSorter(sorter);
+
         factionTable.setDefaultRenderer(Object.class, new StaleRowRenderer());
         JScrollPane tableScroll = new JScrollPane(factionTable);
         tableScroll.setPreferredSize(UIUtil.scaleForGUI(TABLE_WIDTH, TABLE_HEIGHT));
@@ -314,7 +326,7 @@ public class AvailabilityTab extends ITab {
                   false));
         }
 
-        tableModel.markStaleFactions(activeFactionCodes());
+        tableModel.markStaleRows(this::isRowStale);
         writeBack();
     }
 
@@ -406,12 +418,12 @@ public class AvailabilityTab extends ITab {
                   false));
         }
 
-        tableModel.markStaleFactions(activeFactionCodes());
+        tableModel.markStaleRows(this::isRowStale);
         writeBack();
     }
 
     private void removeSelectedFaction() {
-        int selected = factionTable.getSelectedRow();
+        int selected = selectedModelRow();
         if (selected < 0) {
             return;
         }
@@ -420,10 +432,39 @@ public class AvailabilityTab extends ITab {
         writeBack();
     }
 
+    /**
+     * The model index of the selected row, or -1 if none. The table can be sorted, so the selected view row is mapped
+     * back to the model before it is used to read or change a row.
+     *
+     * @return the selected model row, or -1
+     */
+    private int selectedModelRow() {
+        int viewRow = factionTable.getSelectedRow();
+
+        return (viewRow < 0) ? -1 : factionTable.convertRowIndexToModel(viewRow);
+    }
+
+    /** Reads the leading number out of a cell like "4  rare", for sorting the How common column by value. */
+    private static int leadingInt(String text) {
+        int end = 0;
+        while ((end < text.length()) && Character.isDigit(text.charAt(end))) {
+            end++;
+        }
+
+        return (end == 0) ? 0 : Integer.parseInt(text.substring(0, end));
+    }
+
+    /** Reads a year out of a cell, treating a blank (never stops) as the largest value so it sorts last. */
+    private static int yearValue(String text) {
+        String trimmed = text.trim();
+
+        return trimmed.isEmpty() ? Integer.MAX_VALUE : Integer.parseInt(trimmed);
+    }
+
     // --- Editor strip -------------------------------------------------------------------------------------------
 
     private void updateEditorFromSelection() {
-        int selected = factionTable.getSelectedRow();
+        int selected = selectedModelRow();
         boolean hasSelection = (selected >= 0) && (selected < tableModel.getRowCount());
 
         availabilitySlider.setEnabled(hasSelection);
@@ -459,7 +500,7 @@ public class AvailabilityTab extends ITab {
             return;
         }
 
-        int selected = factionTable.getSelectedRow();
+        int selected = selectedModelRow();
         if (selected < 0) {
             return;
         }
@@ -475,7 +516,7 @@ public class AvailabilityTab extends ITab {
             return;
         }
 
-        int selected = factionTable.getSelectedRow();
+        int selected = selectedModelRow();
         if (selected < 0) {
             return;
         }
@@ -644,8 +685,8 @@ public class AvailabilityTab extends ITab {
         }
 
         if (tableModel.hasStaleRows()) {
-            warnings.add("Some factions in the table do not exist in " + getEntity().getYear()
-                  + ". Those entries will never be used.");
+            warnings.add("Some factions never exist during the years their row covers, so those entries will never be "
+                  + "used. Give them a year range that reaches the years they exist, or remove them.");
         }
 
         String eraAlignmentWarning = eraAlignmentWarning();
@@ -783,20 +824,36 @@ public class AvailabilityTab extends ITab {
         return (factionRecord == null) ? factionCode : factionRecord.getName(getEntity().getYear());
     }
 
-    private Set<String> activeFactionCodes() {
+    /**
+     * Whether a row's faction can never be used during the years that row applies. A future faction added on purpose,
+     * whose range reaches the years it exists, is fine; a faction that died out before the row's years is not. This is
+     * checked against the row's own start year, not the unit's intro year, so deliberately adding a later faction does
+     * not trip the warning.
+     *
+     * @param row the row to check
+     *
+     * @return {@code true} if the faction is not active at or after the row's first year
+     */
+    private boolean isRowStale(AvailabilityRow row) {
+        if (AddFactionsDialog.UMBRELLA_CODES.contains(row.factionCode())) {
+            return false;
+        }
+
         RATGenerator ratGenerator = RATGenerator.getInstance();
-        Set<String> codes = new HashSet<>(AddFactionsDialog.UMBRELLA_CODES);
         if (!ratGenerator.isInitialized()) {
-            return codes;
+            return false;
         }
 
-        for (FactionRecord factionRecord : ratGenerator.getFactionList()) {
-            if (factionRecord.isActiveInYear(getEntity().getYear())) {
-                codes.add(factionRecord.getKey());
-            }
+        FactionRecord factionRecord = ratGenerator.getFaction(row.factionCode());
+        if (factionRecord == null) {
+            return false;
         }
 
-        return codes;
+        int firstYear = (row.fromYear() == ForceGeneratorAvailability.UNSPECIFIED_YEAR)
+              ? getEntity().getYear()
+              : row.fromYear();
+
+        return !factionRecord.isActiveInOrAfterYear(firstYear);
     }
 
     // --- Persistence --------------------------------------------------------------------------------------------
@@ -828,7 +885,8 @@ public class AvailabilityTab extends ITab {
             Component component = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 
             AvailabilityTableModel model = (AvailabilityTableModel) table.getModel();
-            if (model.getRow(row).stale() && !isSelected) {
+            // row is a view index; the sorter can reorder rows, so map it back to the model before reading the row
+            if (model.getRow(table.convertRowIndexToModel(row)).stale() && !isSelected) {
                 component.setForeground(Color.RED);
             } else if (!isSelected) {
                 component.setForeground(table.getForeground());

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java
@@ -47,6 +47,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Set;
 import java.util.StringJoiner;
 
@@ -581,6 +582,11 @@ public class AvailabilityTab extends ITab {
                   + ". Those entries will never be used.");
         }
 
+        String eraAlignmentWarning = eraAlignmentWarning();
+        if (eraAlignmentWarning != null) {
+            warnings.add(eraAlignmentWarning);
+        }
+
         if (warnings.isEmpty()) {
             warningLabel.setText(" ");
             return;
@@ -589,6 +595,73 @@ public class AvailabilityTab extends ITab {
         StringJoiner text = new StringJoiner("<br>", "<html>", "</html>");
         warnings.forEach(text::add);
         warningLabel.setText(text.toString());
+    }
+
+    /**
+     * Warns when a year range does not line up with the game's eras. The Force Generator stores availability in fixed
+     * era buckets, so a change written inside a bucket is spread across it rather than taking effect exactly then. This
+     * is what let the QA report's Periphery ranges land in the wrong era; telling the player up front is how they avoid
+     * it.
+     *
+     * @return the warning, or {@code null} if every range lines up with an era
+     */
+    private String eraAlignmentWarning() {
+        RATGenerator ratGenerator = RATGenerator.getInstance();
+        if (!ratGenerator.isInitialized() || ratGenerator.getEraSet().isEmpty()) {
+            return null;
+        }
+
+        List<String> problems = eraAlignmentProblems(tableModel.getRows(), getEntity().getYear(),
+              ratGenerator.getEraSet());
+        if (problems.isEmpty()) {
+            return null;
+        }
+
+        return "The Force Generator works in eras, so a year inside an era is approximated to its edge rather than "
+              + "taking effect exactly: " + String.join("; ", problems) + ".";
+    }
+
+    /**
+     * Finds the year-range boundaries that fall inside an era rather than on its edge. A range should start on an era's
+     * first year and end on its last, or the change it describes is smeared across the era.
+     * <p>
+     * Pure so it can be tested without a loaded Force Generator.
+     * </p>
+     *
+     * @param rows      the table rows
+     * @param introYear the unit's introduction year, which is a natural start and never a problem
+     * @param eras      the era boundary years, each being an era's first year
+     *
+     * @return one message per misaligned boundary, in row order; empty if all line up
+     */
+    static List<String> eraAlignmentProblems(List<AvailabilityRow> rows, int introYear, NavigableSet<Integer> eras) {
+        List<String> problems = new ArrayList<>();
+
+        for (AvailabilityRow row : rows) {
+            int fromYear = row.fromYear();
+            if ((fromYear != ForceGeneratorAvailability.UNSPECIFIED_YEAR)
+                  && (fromYear != introYear)
+                  && !eras.contains(fromYear)) {
+                Integer eraStart = eras.floor(fromYear);
+                Integer nextEra = eras.higher(fromYear);
+                if ((eraStart != null) && (nextEra != null)) {
+                    problems.add(row.factionCode() + " starts at " + fromYear + ", inside the " + eraStart + "-"
+                          + (nextEra - 1) + " era (use " + eraStart + " or " + nextEra + ")");
+                }
+            }
+
+            int toYear = row.toYear();
+            if (toYear != ForceGeneratorAvailability.UNSPECIFIED_YEAR) {
+                Integer nextEra = eras.higher(toYear);
+                Integer eraStart = eras.floor(toYear);
+                if ((nextEra != null) && (eraStart != null) && ((toYear + 1) != nextEra)) {
+                    problems.add(row.factionCode() + " ends at " + toYear + ", inside the " + eraStart + "-"
+                          + (nextEra - 1) + " era (use " + (nextEra - 1) + ")");
+                }
+            }
+        }
+
+        return problems;
     }
 
     /**

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTableModel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTableModel.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMekLab was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.ui.generalUnit;
+
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.swing.table.AbstractTableModel;
+
+import megamek.common.units.ForceGeneratorAvailability;
+import megameklab.util.AvailabilityCalibration;
+
+/**
+ * The rows of the Availability tab: one faction, how common the unit is for them, and the years it applies.
+ * <p>
+ * A row maps to one faction code inside a {@link ForceGeneratorAvailability} entry. The file format groups codes by
+ * year range, so several rows can share one entry; {@link #toAvailabilityEntries()} regroups them on the way out.
+ * </p>
+ */
+public class AvailabilityTableModel extends AbstractTableModel {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    public static final int COL_FACTION = 0;
+    public static final int COL_AVAILABILITY = 1;
+    public static final int COL_FROM = 2;
+    public static final int COL_TO = 3;
+    private static final int COLUMN_COUNT = 4;
+
+    private final List<AvailabilityRow> rows = new ArrayList<>();
+
+    /**
+     * One faction's availability, as the player sees it.
+     *
+     * @param factionCode  the faction key, e.g. "FS", or an umbrella key such as "IS"
+     * @param factionName  what to show the player, e.g. "Federated Suns"
+     * @param availability 0 to 10
+     * @param fromYear     first year, or {@link ForceGeneratorAvailability#UNSPECIFIED_YEAR} for the unit's intro year
+     * @param toYear       last year, or {@link ForceGeneratorAvailability#UNSPECIFIED_YEAR} for never stops
+     * @param stale        true when this faction does not exist in the unit's current year
+     */
+    public record AvailabilityRow(String factionCode, String factionName, int availability, int fromYear, int toYear,
+                                  boolean stale) {
+
+        public AvailabilityRow withAvailability(int newAvailability) {
+            return new AvailabilityRow(factionCode, factionName, newAvailability, fromYear, toYear, stale);
+        }
+
+        public AvailabilityRow withYears(int newFromYear, int newToYear) {
+            return new AvailabilityRow(factionCode, factionName, availability, newFromYear, newToYear, stale);
+        }
+
+        public AvailabilityRow withStale(boolean nowStale) {
+            return new AvailabilityRow(factionCode, factionName, availability, fromYear, toYear, nowStale);
+        }
+    }
+
+    @Override
+    public int getRowCount() {
+        return rows.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return COLUMN_COUNT;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return switch (column) {
+            case COL_FACTION -> "Faction";
+            case COL_AVAILABILITY -> "How common";
+            case COL_FROM -> "From";
+            case COL_TO -> "To";
+            default -> "";
+        };
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        AvailabilityRow row = rows.get(rowIndex);
+
+        return switch (columnIndex) {
+            case COL_FACTION -> row.factionName() + " (" + row.factionCode() + ")";
+            case COL_AVAILABILITY -> row.availability() + "  " + AvailabilityCalibration.describe(row.availability());
+            case COL_FROM -> yearText(row.fromYear());
+            case COL_TO -> yearText(row.toYear());
+            default -> "";
+        };
+    }
+
+    private static String yearText(int year) {
+        return (year == ForceGeneratorAvailability.UNSPECIFIED_YEAR) ? "" : String.valueOf(year);
+    }
+
+    public AvailabilityRow getRow(int rowIndex) {
+        return rows.get(rowIndex);
+    }
+
+    public List<AvailabilityRow> getRows() {
+        return List.copyOf(rows);
+    }
+
+    public void setRow(int rowIndex, AvailabilityRow row) {
+        rows.set(rowIndex, row);
+        fireTableRowsUpdated(rowIndex, rowIndex);
+    }
+
+    /**
+     * Adds a faction, ignoring it if that faction is already in the table. A player who ticks the same faction twice
+     * means it once.
+     *
+     * @param row the row to add
+     *
+     * @return the index of the row, whether it was added now or was already there
+     */
+    public int addRow(AvailabilityRow row) {
+        for (int index = 0; index < rows.size(); index++) {
+            if (rows.get(index).factionCode().equals(row.factionCode())) {
+                return index;
+            }
+        }
+
+        rows.add(row);
+        fireTableRowsInserted(rows.size() - 1, rows.size() - 1);
+
+        return rows.size() - 1;
+    }
+
+    public void removeRow(int rowIndex) {
+        rows.remove(rowIndex);
+        fireTableRowsDeleted(rowIndex, rowIndex);
+    }
+
+    public void clear() {
+        int previousSize = rows.size();
+        rows.clear();
+        if (previousSize > 0) {
+            fireTableRowsDeleted(0, previousSize - 1);
+        }
+    }
+
+    /**
+     * Marks the rows whose faction does not exist in the given year. Happens when the player changes the intro year on
+     * Basic Info after filling this tab in: Clan Wolf is a real choice for a 3050 unit and a dead one for a 3150 unit.
+     *
+     * @param activeFactionCodes the factions that exist in the unit's current year
+     */
+    public void markStaleFactions(Set<String> activeFactionCodes) {
+        for (int index = 0; index < rows.size(); index++) {
+            AvailabilityRow row = rows.get(index);
+            boolean stale = !activeFactionCodes.contains(row.factionCode());
+            if (stale != row.stale()) {
+                rows.set(index, row.withStale(stale));
+                fireTableRowsUpdated(index, index);
+            }
+        }
+    }
+
+    public boolean hasStaleRows() {
+        return rows.stream().anyMatch(AvailabilityRow::stale);
+    }
+
+    /**
+     * Fills the table from a unit's declared availability. Each entry can name several factions, and each becomes its
+     * own row.
+     *
+     * @param entries       the unit's availability entries
+     * @param factionNamer  turns a faction code into a display name
+     */
+    public void loadFrom(List<ForceGeneratorAvailability> entries, Function<String, String> factionNamer) {
+        clear();
+
+        for (ForceGeneratorAvailability entry : entries) {
+            for (String code : entry.availabilityCodes().split(",")) {
+                String trimmed = code.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+
+                int separator = trimmed.lastIndexOf(':');
+                if (separator < 0) {
+                    continue;
+                }
+
+                String factionCode = trimmed.substring(0, separator);
+                int availability = parseAvailability(trimmed.substring(separator + 1));
+
+                rows.add(new AvailabilityRow(factionCode,
+                      factionNamer.apply(factionCode),
+                      availability,
+                      entry.startYear(),
+                      entry.endYear(),
+                      false));
+            }
+        }
+
+        fireTableDataChanged();
+    }
+
+    /**
+     * Reads the number out of an availability code, tolerating the +/- suffixes the file format allows. The tab does
+     * not offer those, but a hand-edited file may carry them and must not be mangled by being opened.
+     *
+     * @param value the part of the code after the colon
+     *
+     * @return the availability value, or 0 if it cannot be read
+     */
+    private static int parseAvailability(String value) {
+        StringBuilder digits = new StringBuilder();
+        for (char character : value.toCharArray()) {
+            if (Character.isDigit(character)) {
+                digits.append(character);
+            }
+        }
+
+        return digits.isEmpty() ? 0 : Integer.parseInt(digits.toString());
+    }
+
+    /**
+     * Turns the rows back into the file's shape. Rows that share a year range are grouped into one entry, which is how
+     * a hand-written file would look.
+     *
+     * @return the entries to store on the unit
+     */
+    public List<ForceGeneratorAvailability> toAvailabilityEntries() {
+        Map<String, List<AvailabilityRow>> byYearRange = new LinkedHashMap<>();
+
+        for (AvailabilityRow row : rows) {
+            String rangeKey = row.fromYear() + "-" + row.toYear();
+            byYearRange.computeIfAbsent(rangeKey, key -> new ArrayList<>()).add(row);
+        }
+
+        List<ForceGeneratorAvailability> entries = new ArrayList<>();
+        for (List<AvailabilityRow> group : byYearRange.values()) {
+            StringBuilder codes = new StringBuilder();
+            for (AvailabilityRow row : group) {
+                if (!codes.isEmpty()) {
+                    codes.append(',');
+                }
+                codes.append(row.factionCode()).append(':').append(row.availability());
+            }
+
+            entries.add(new ForceGeneratorAvailability(group.getFirst().fromYear(),
+                  group.getFirst().toYear(),
+                  codes.toString()));
+        }
+
+        return entries;
+    }
+}

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTableModel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTableModel.java
@@ -142,8 +142,9 @@ public class AvailabilityTableModel extends AbstractTableModel {
     }
 
     /**
-     * Adds a faction, ignoring it if that faction is already in the table. A player who ticks the same faction twice
-     * means it once.
+     * Adds a row, unless a row for the same faction AND the same year range is already present. One faction can appear
+     * more than once, as long as the ranges differ: that is how a player gives it a different availability early and
+     * late. Only an exact duplicate is ignored.
      *
      * @param row the row to add
      *
@@ -151,7 +152,10 @@ public class AvailabilityTableModel extends AbstractTableModel {
      */
     public int addRow(AvailabilityRow row) {
         for (int index = 0; index < rows.size(); index++) {
-            if (rows.get(index).factionCode().equals(row.factionCode())) {
+            AvailabilityRow existing = rows.get(index);
+            if (existing.factionCode().equals(row.factionCode())
+                  && (existing.fromYear() == row.fromYear())
+                  && (existing.toYear() == row.toYear())) {
                 return index;
             }
         }

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTableModel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTableModel.java
@@ -37,8 +37,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import javax.swing.table.AbstractTableModel;
 
@@ -63,6 +63,9 @@ public class AvailabilityTableModel extends AbstractTableModel {
     private static final int COLUMN_COUNT = 4;
 
     private final List<AvailabilityRow> rows = new ArrayList<>();
+
+    /** The unit's introduction year, shown in the From column for rows that start at intro rather than a set year. */
+    private int introYear = ForceGeneratorAvailability.UNSPECIFIED_YEAR;
 
     /**
      * One faction's availability, as the player sees it.
@@ -118,10 +121,25 @@ public class AvailabilityTableModel extends AbstractTableModel {
         return switch (columnIndex) {
             case COL_FACTION -> row.factionName() + " (" + row.factionCode() + ")";
             case COL_AVAILABILITY -> row.availability() + "  " + AvailabilityCalibration.describe(row.availability());
-            case COL_FROM -> yearText(row.fromYear());
+            // A row that starts at the unit's intro year shows that year rather than a blank, so the column is not
+            // confusingly empty. The stored value stays unspecified, so it still tracks the intro year if it changes.
+            case COL_FROM -> yearText((row.fromYear() == ForceGeneratorAvailability.UNSPECIFIED_YEAR)
+                  ? introYear : row.fromYear());
             case COL_TO -> yearText(row.toYear());
             default -> "";
         };
+    }
+
+    /**
+     * Sets the unit's introduction year, used to fill in the From column for rows that start at intro.
+     *
+     * @param introYear the unit's introduction year
+     */
+    public void setIntroYear(int introYear) {
+        if (this.introYear != introYear) {
+            this.introYear = introYear;
+            fireTableDataChanged();
+        }
     }
 
     private static String yearText(int year) {
@@ -180,15 +198,16 @@ public class AvailabilityTableModel extends AbstractTableModel {
     }
 
     /**
-     * Marks the rows whose faction does not exist in the given year. Happens when the player changes the intro year on
-     * Basic Info after filling this tab in: Clan Wolf is a real choice for a 3050 unit and a dead one for a 3150 unit.
+     * Marks rows whose faction is never active during the years that row applies. A future faction added on purpose,
+     * with a year range that reaches the years it exists, is NOT stale; a faction that died before the unit's time is.
+     * The check is passed in because it needs the Force Generator's faction data, which the model does not hold.
      *
-     * @param activeFactionCodes the factions that exist in the unit's current year
+     * @param staleCheck returns true when a row's faction cannot be used in that row's years
      */
-    public void markStaleFactions(Set<String> activeFactionCodes) {
+    public void markStaleRows(Predicate<AvailabilityRow> staleCheck) {
         for (int index = 0; index < rows.size(); index++) {
             AvailabilityRow row = rows.get(index);
-            boolean stale = !activeFactionCodes.contains(row.factionCode());
+            boolean stale = staleCheck.test(row);
             if (stale != row.stale()) {
                 rows.set(index, row.withStale(stale));
                 fireTableRowsUpdated(index, index);

--- a/megameklab/src/megameklab/ui/generalUnit/AvailabilityTableModel.java
+++ b/megameklab/src/megameklab/ui/generalUnit/AvailabilityTableModel.java
@@ -249,7 +249,17 @@ public class AvailabilityTableModel extends AbstractTableModel {
             }
         }
 
-        return digits.isEmpty() ? 0 : Integer.parseInt(digits.toString());
+        if (digits.isEmpty()) {
+            return 0;
+        }
+
+        try {
+            return Integer.parseInt(digits.toString());
+        } catch (NumberFormatException exception) {
+            // Character.isDigit accepts non-ASCII digits, and a very long run of digits overflows an int. Either way
+            // the value cannot be read, so return 0 per the method contract rather than failing the whole load.
+            return 0;
+        }
     }
 
     /**

--- a/megameklab/src/megameklab/ui/infantry/CIMainUI.java
+++ b/megameklab/src/megameklab/ui/infantry/CIMainUI.java
@@ -49,6 +49,7 @@ import megamek.common.TechConstants;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.PopupMessages;
+import megameklab.ui.generalUnit.AvailabilityTab;
 import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
@@ -60,6 +61,7 @@ public class CIMainUI extends MegaMekLabMainUI {
     PreviewTab previewTab;
     AnalysisTab analysisTab;
     FluffTab fluffTab;
+    AvailabilityTab availabilityTab;
     CIStatusBar statusbar;
 
     @Override
@@ -86,15 +88,18 @@ public class CIMainUI extends MegaMekLabMainUI {
         statusbar = new CIStatusBar(this);
         structureTab = new CIStructureTab(this);
         fluffTab = new FluffTab(this);
+        availabilityTab = new AvailabilityTab(this);
         previewTab = new PreviewTab(this);
         analysisTab = new AnalysisTab(this);
 
         structureTab.addRefreshedListener(this);
+        availabilityTab.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
         statusbar.addRefreshedListener(this);
 
         configPane.addTab("Build", structureTab);
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
+        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 
@@ -132,6 +137,7 @@ public class CIMainUI extends MegaMekLabMainUI {
         statusbar.refresh();
         structureTab.refresh();
         fluffTab.refresh();
+        availabilityTab.refresh();
         previewTab.refresh();
         analysisTab.refresh();
         refreshHeader();

--- a/megameklab/src/megameklab/ui/infantry/CIMainUI.java
+++ b/megameklab/src/megameklab/ui/infantry/CIMainUI.java
@@ -50,6 +50,7 @@ import megamek.common.weapons.infantry.InfantryWeapon;
 import megameklab.ui.MegaMekLabMainUI;
 import megameklab.ui.PopupMessages;
 import megameklab.ui.generalUnit.AvailabilityTab;
+import megameklab.util.CConfig;
 import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
@@ -99,7 +100,9 @@ public class CIMainUI extends MegaMekLabMainUI {
 
         configPane.addTab("Build", structureTab);
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
-        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        if (CConfig.showAvailabilityTab()) {
+            configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        }
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -55,6 +55,7 @@ import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
+import megameklab.ui.generalUnit.AvailabilityTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.generalUnit.StatusBar;
 import megameklab.ui.generalUnit.TransportTab;
@@ -76,6 +77,7 @@ public class DSMainUI extends MegaMekLabMainUI {
     private TransportTab transportTab;
     private StatusBar statusbar;
     private QuirksTab quirksTab;
+    private AvailabilityTab availabilityTab;
     private FluffTab fluffTab;
     private FloatingEquipmentDatabaseDialog floatingEquipmentDatabase;
 
@@ -197,6 +199,7 @@ public class DSMainUI extends MegaMekLabMainUI {
         buildTab = new LABuildTab(this);
         transportTab = new TransportTab(this);
         quirksTab = new QuirksTab(this);
+        availabilityTab = new AvailabilityTab(this);
         fluffTab = new FluffTab(this);
         structureTab.addRefreshedListener(this);
         equipmentTab.addRefreshedListener(this);
@@ -205,6 +208,7 @@ public class DSMainUI extends MegaMekLabMainUI {
         statusbar.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
         quirksTab.addRefreshedListener(this);
+        availabilityTab.addRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
         configPane.addTab("Equipment", equipmentTab);
@@ -212,6 +216,7 @@ public class DSMainUI extends MegaMekLabMainUI {
         configPane.addTab("Transport Bays", new TabScrollPane(transportTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
+        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 
@@ -237,6 +242,7 @@ public class DSMainUI extends MegaMekLabMainUI {
         equipmentTab.refresh();
         buildTab.refresh();
         quirksTab.refresh();
+        availabilityTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
         analysisTab.refresh();

--- a/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/DSMainUI.java
@@ -56,6 +56,7 @@ import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.AvailabilityTab;
+import megameklab.util.CConfig;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.generalUnit.StatusBar;
 import megameklab.ui.generalUnit.TransportTab;
@@ -216,7 +217,9 @@ public class DSMainUI extends MegaMekLabMainUI {
         configPane.addTab("Transport Bays", new TabScrollPane(transportTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
-        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        if (CConfig.showAvailabilityTab()) {
+            configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        }
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 

--- a/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
@@ -55,6 +55,7 @@ import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
+import megameklab.ui.generalUnit.AvailabilityTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.generalUnit.StatusBar;
 import megameklab.ui.generalUnit.TransportTab;
@@ -75,6 +76,7 @@ public class WSMainUI extends MegaMekLabMainUI {
     private LABuildTab buildTab;
     private TransportTab transportTab;
     private QuirksTab quirksTab;
+    private AvailabilityTab availabilityTab;
     private StatusBar statusbar;
     private FluffTab fluffTab;
     private FloatingEquipmentDatabaseDialog floatingEquipmentDatabase;
@@ -205,12 +207,14 @@ public class WSMainUI extends MegaMekLabMainUI {
         fluffTab = new FluffTab(this);
         transportTab = new TransportTab(this);
         quirksTab = new QuirksTab(this);
+        availabilityTab = new AvailabilityTab(this);
         structureTab.addRefreshedListener(this);
         equipmentTab.addRefreshedListener(this);
         buildTab.addRefreshedListener(this);
         transportTab.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
         quirksTab.addRefreshedListener(this);
+        availabilityTab.addRefreshedListener(this);
         statusbar.addRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
@@ -219,6 +223,7 @@ public class WSMainUI extends MegaMekLabMainUI {
         configPane.addTab("Transport Bays", new TabScrollPane(transportTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
+        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 
@@ -244,6 +249,7 @@ public class WSMainUI extends MegaMekLabMainUI {
         equipmentTab.refresh();
         buildTab.refresh();
         quirksTab.refresh();
+        availabilityTab.refresh();
         previewTab.refresh();
         analysisTab.refresh();
         floatingEquipmentDatabase.refresh();

--- a/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSMainUI.java
@@ -56,6 +56,7 @@ import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.AvailabilityTab;
+import megameklab.util.CConfig;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.generalUnit.StatusBar;
 import megameklab.ui.generalUnit.TransportTab;
@@ -223,7 +224,9 @@ public class WSMainUI extends MegaMekLabMainUI {
         configPane.addTab("Transport Bays", new TabScrollPane(transportTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
-        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        if (CConfig.showAvailabilityTab()) {
+            configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        }
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 

--- a/megameklab/src/megameklab/ui/mek/BMMainUI.java
+++ b/megameklab/src/megameklab/ui/mek/BMMainUI.java
@@ -55,6 +55,7 @@ import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
+import megameklab.ui.generalUnit.AvailabilityTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 import megameklab.util.MekUtil;
@@ -76,6 +77,7 @@ public class BMMainUI extends MegaMekLabMainUI {
         return fluffTab;
     }
     private QuirksTab quirksTab;
+    private AvailabilityTab availabilityTab;
     private FloatingEquipmentDatabaseDialog floatingEquipmentDatabase;
 
     public BMMainUI(Entity entity, String filename) {
@@ -103,11 +105,13 @@ public class BMMainUI extends MegaMekLabMainUI {
         buildTab = new BMBuildTab(this);
         fluffTab = new FluffTab(this);
         quirksTab = new QuirksTab(this);
+        availabilityTab = new AvailabilityTab(this);
         structureTab.addRefreshedListener(this);
         equipmentTab.addRefreshedListener(this);
         buildTab.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
         quirksTab.addRefreshedListener(this);
+        availabilityTab.addRefreshedListener(this);
         statusbar.addRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
@@ -115,6 +119,7 @@ public class BMMainUI extends MegaMekLabMainUI {
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
+        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 
@@ -234,6 +239,7 @@ public class BMMainUI extends MegaMekLabMainUI {
         equipmentTab.refresh();
         buildTab.refresh();
         quirksTab.refresh();
+        availabilityTab.refresh();
         previewTab.refresh();
         analysisTab.refresh();
         floatingEquipmentDatabase.refresh();

--- a/megameklab/src/megameklab/ui/mek/BMMainUI.java
+++ b/megameklab/src/megameklab/ui/mek/BMMainUI.java
@@ -56,6 +56,7 @@ import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.AvailabilityTab;
+import megameklab.util.CConfig;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 import megameklab.util.MekUtil;
@@ -119,7 +120,9 @@ public class BMMainUI extends MegaMekLabMainUI {
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
-        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        if (CConfig.showAvailabilityTab()) {
+            configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        }
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 

--- a/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
@@ -51,6 +51,7 @@ import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
+import megameklab.ui.generalUnit.AvailabilityTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -68,6 +69,7 @@ public class PMMainUI extends MegaMekLabMainUI {
     private PMBuildTab buildTab;
     private PMStatusBar statusbar;
     private QuirksTab quirksTab;
+    private AvailabilityTab availabilityTab;
     private FluffTab fluffTab;
     private FloatingEquipmentDatabaseDialog floatingEquipmentDatabase;
 
@@ -99,18 +101,21 @@ public class PMMainUI extends MegaMekLabMainUI {
         equipmentTab = new PMEquipmentTab(this);
         buildTab = new PMBuildTab(this, this);
         quirksTab = new QuirksTab(this);
+        availabilityTab = new AvailabilityTab(this);
         fluffTab = new FluffTab(this);
         structureTab.addRefreshedListener(this);
         equipmentTab.addRefreshedListener(this);
         statusbar.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
         quirksTab.addRefreshedListener(this);
+        availabilityTab.addRefreshedListener(this);
 
         configPane.addTab("Structure/Armor", new TabScrollPane(structureTab));
         configPane.addTab("Equipment", equipmentTab);
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
+        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 
@@ -162,6 +167,7 @@ public class PMMainUI extends MegaMekLabMainUI {
         equipmentTab.refresh();
         buildTab.refresh();
         quirksTab.refresh();
+        availabilityTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
         analysisTab.refresh();

--- a/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMMainUI.java
@@ -52,6 +52,7 @@ import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.AvailabilityTab;
+import megameklab.util.CConfig;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.util.TabScrollPane;
 
@@ -115,7 +116,9 @@ public class PMMainUI extends MegaMekLabMainUI {
         configPane.addTab("Assign Criticals", new TabScrollPane(buildTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
-        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        if (CConfig.showAvailabilityTab()) {
+            configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        }
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 

--- a/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
@@ -53,6 +53,7 @@ import megameklab.ui.generalUnit.AbstractEquipmentTab;
 import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
+import megameklab.ui.generalUnit.AvailabilityTab;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.generalUnit.TransportTab;
 import megameklab.ui.util.TabScrollPane;
@@ -77,6 +78,7 @@ public class SVMainUI extends MegaMekLabMainUI {
         return fluffTab;
     }
     private QuirksTab quirksTab;
+    private AvailabilityTab availabilityTab;
     private FloatingEquipmentDatabaseDialog floatingEquipmentDatabase;
 
     public SVMainUI(Entity entity, String filename) {
@@ -103,6 +105,7 @@ public class SVMainUI extends MegaMekLabMainUI {
         transportTab = new TransportTab(this);
         fluffTab = new FluffTab(this);
         quirksTab = new QuirksTab(this);
+        availabilityTab = new AvailabilityTab(this);
         structureTab.addRefreshedListener(this);
         armorTab.addRefreshedListener(this);
         equipmentTab.addRefreshedListener(this);
@@ -110,6 +113,7 @@ public class SVMainUI extends MegaMekLabMainUI {
         transportTab.addRefreshedListener(this);
         fluffTab.setRefreshedListener(this);
         quirksTab.addRefreshedListener(this);
+        availabilityTab.addRefreshedListener(this);
         statusbar.addRefreshedListener(this);
 
         previewTab = new PreviewTab(this);
@@ -122,6 +126,7 @@ public class SVMainUI extends MegaMekLabMainUI {
         configPane.addTab("Transport", new TabScrollPane(transportTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
+        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 
@@ -149,6 +154,7 @@ public class SVMainUI extends MegaMekLabMainUI {
         transportTab.refresh();
         statusbar.refresh();
         quirksTab.refresh();
+        availabilityTab.refresh();
         fluffTab.refresh();
         previewTab.refresh();
         analysisTab.refresh();

--- a/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java
@@ -54,6 +54,7 @@ import megameklab.ui.generalUnit.FluffTab;
 import megameklab.ui.generalUnit.AnalysisTab;
 import megameklab.ui.generalUnit.PreviewTab;
 import megameklab.ui.generalUnit.AvailabilityTab;
+import megameklab.util.CConfig;
 import megameklab.ui.generalUnit.QuirksTab;
 import megameklab.ui.generalUnit.TransportTab;
 import megameklab.ui.util.TabScrollPane;
@@ -126,7 +127,9 @@ public class SVMainUI extends MegaMekLabMainUI {
         configPane.addTab("Transport", new TabScrollPane(transportTab));
         configPane.addTab("Fluff", new TabScrollPane(fluffTab));
         configPane.addTab("Quirks", new TabScrollPane(quirksTab, quirksTab.refreshOnShow));
-        configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        if (CConfig.showAvailabilityTab()) {
+            configPane.addTab("Availability", new TabScrollPane(availabilityTab, availabilityTab.refreshOnShow));
+        }
         configPane.addTab("Preview", previewTab);
         configPane.addTab("Analysis", analysisTab);
 

--- a/megameklab/src/megameklab/util/AvailabilityCalibration.java
+++ b/megameklab/src/megameklab/util/AvailabilityCalibration.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMekLab was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+import megamek.client.ratgenerator.AvailabilityRating;
+import megamek.client.ratgenerator.ChassisRecord;
+import megamek.client.ratgenerator.FactionRecord;
+import megamek.client.ratgenerator.RATGenerator;
+
+/**
+ * Turns a raw availability number into something a player can judge.
+ * <p>
+ * Availability runs 0 to 10 on a base-2 log scale, so the number on its own means nothing to anyone who has not read
+ * the rules. Two things fix that, and both work by pointing at units the player already knows:
+ * </p>
+ * <ul>
+ *     <li>{@link #comparableUnits}: which canon designs are about this common for this faction, right now.</li>
+ *     <li>{@link #ratingsOf}: what a canon design's own numbers are, so they can be used as a starting point.</li>
+ * </ul>
+ * <p>
+ * This class is deliberately free of Swing so it can be tested without a display.
+ * </p>
+ */
+public final class AvailabilityCalibration {
+
+    /** How many comparable designs to offer. Enough to calibrate against, few enough to read at a glance. */
+    public static final int COMPARABLE_UNIT_COUNT = 3;
+
+    /** How far a design's rating may sit from the one being judged and still be worth showing as comparable. */
+    private static final int MAX_COMPARABLE_DIFFERENCE = 1;
+
+    private static final String[] COMMONNESS_WORDS = {
+          "none", "very rare", "very rare", "rare", "rare", "uncommon",
+          "typical", "common", "common", "ubiquitous", "ubiquitous"
+    };
+
+    private AvailabilityCalibration() {
+    }
+
+    /**
+     * Describes an availability value in words. This is what the slider shows, so a player never has to know that the
+     * scale is logarithmic.
+     *
+     * @param availability the availability value, 0 to 10
+     *
+     * @return a word for it, for example "typical"
+     */
+    public static String describe(int availability) {
+        int clamped = Math.clamp(availability, 0, COMMONNESS_WORDS.length - 1);
+
+        return COMMONNESS_WORDS[clamped];
+    }
+
+    /**
+     * Finds canon designs that are about as common as the given rating, for one faction in one era. Showing these next
+     * to the slider is what tells a player whether they have set a sane number.
+     * <p>
+     * Only chassis of the same unit type are offered, since a Mek is no help in judging how common a DropShip is.
+     * </p>
+     *
+     * @param unitType     the unit type to compare within, from {@code UnitType}
+     * @param factionCode  the faction the number is for
+     * @param year         the year to judge in
+     * @param availability the availability value to match
+     *
+     * @return up to {@link #COMPARABLE_UNIT_COUNT} chassis names, closest match first; empty if nothing is comparable
+     */
+    public static List<String> comparableUnits(int unitType, String factionCode, int year, int availability) {
+        RATGenerator ratGenerator = RATGenerator.getInstance();
+        if (!ratGenerator.isInitialized()) {
+            return List.of();
+        }
+
+        FactionRecord factionRecord = ratGenerator.getFaction(factionCode);
+        if (factionRecord == null) {
+            return List.of();
+        }
+
+        int era = ratGenerator.eraForYear(year);
+        List<ComparableChassis> matches = new ArrayList<>();
+
+        for (ChassisRecord chassisRecord : ratGenerator.getChassisList()) {
+            if (chassisRecord.getUnitType() != unitType) {
+                continue;
+            }
+            if (chassisRecord.getIntroYear() > year) {
+                continue;
+            }
+
+            AvailabilityRating rating = ratGenerator.findChassisAvailabilityRecord(era,
+                  chassisRecord.getKey(),
+                  factionRecord,
+                  year);
+            if (rating == null) {
+                continue;
+            }
+
+            int difference = Math.abs(rating.getAvailability() - availability);
+            if (difference <= MAX_COMPARABLE_DIFFERENCE) {
+                matches.add(new ComparableChassis(chassisRecord.getChassis(), difference));
+            }
+        }
+
+        return pickComparable(matches);
+    }
+
+    /**
+     * Chooses which of the candidate designs to show: closest rating first, then alphabetical so the list is stable,
+     * with duplicate chassis names collapsed.
+     * <p>
+     * Split out from {@link #comparableUnits} so the choosing can be tested without a loaded Force Generator.
+     * </p>
+     *
+     * @param candidates the designs that are close enough to be worth showing
+     *
+     * @return up to {@link #COMPARABLE_UNIT_COUNT} chassis names
+     */
+    static List<String> pickComparable(List<ComparableChassis> candidates) {
+        List<ComparableChassis> sorted = new ArrayList<>(candidates);
+        sorted.sort(Comparator.comparingInt(ComparableChassis::difference)
+              .thenComparing(ComparableChassis::chassis));
+
+        List<String> names = new ArrayList<>();
+        for (ComparableChassis candidate : sorted) {
+            if (names.size() >= COMPARABLE_UNIT_COUNT) {
+                break;
+            }
+            if (!names.contains(candidate.chassis())) {
+                names.add(candidate.chassis());
+            }
+        }
+
+        return names;
+    }
+
+    /**
+     * Reads the chassis availability a canon design already has, so a player can start from a design they know rather
+     * than from a blank table.
+     *
+     * @param chassisKey the chassis key, as produced by {@code AbstractUnitRecord.getChassisKey()}
+     * @param year       the year to read in
+     *
+     * @return the design's ratings, or empty if the Force Generator has nothing for it
+     */
+    public static List<AvailabilityRating> ratingsOf(String chassisKey, int year) {
+        RATGenerator ratGenerator = RATGenerator.getInstance();
+        if (!ratGenerator.isInitialized()) {
+            return List.of();
+        }
+
+        int era = ratGenerator.eraForYear(year);
+        Collection<AvailabilityRating> ratings = ratGenerator.getChassisFactionRatings(era, chassisKey);
+
+        return (ratings == null) ? List.of() : new ArrayList<>(ratings);
+    }
+
+    /**
+     * A canon chassis and how far its rating is from the one being judged.
+     *
+     * @param chassis    the chassis name
+     * @param difference how many availability points away it is
+     */
+    record ComparableChassis(String chassis, int difference) {
+    }
+}

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -187,8 +187,9 @@ public final class CConfig {
         defaults.setProperty(MISC_SKIP_SAFETY_PROMPTS, Boolean.toString(false));
         defaults.setProperty(MISC_APPLICATION_EXIT_PROMPT, Boolean.toString(true));
         defaults.setProperty(MISC_INCLUDE_LICENSE, Boolean.toString(false));
-        // Off by default: the Force Generator Availability tab is an advanced feature, opt-in from Options - General.
-        defaults.setProperty(MISC_SHOW_AVAILABILITY_TAB, Boolean.toString(false));
+        // On by default so the Force Generator Availability tab is visible; it can be hidden from Options - General.
+        // The toggle is read when an editor is built, so a change takes effect on the next unit opened, not live.
+        defaults.setProperty(MISC_SHOW_AVAILABILITY_TAB, Boolean.toString(true));
         defaults.setProperty(RS_PROGRESS_BAR, Boolean.toString(true));
         defaults.setProperty(RS_COLOR, RecordSheetOptions.ColorMode.LOGO_ONLY.name());
         defaults.setProperty(RS_HEAT_SCALE_MARKER, RecordSheetOptions.HeatScaleMarker.ASTERISK.name());

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -89,6 +89,7 @@ public final class CConfig {
     public static final String MISC_APPLICATION_EXIT_PROMPT = "applicationExitPrompt";
     public static final String MISC_MUL_OPEN_BEHAVIOUR = "mulDndBehaviour";
     public static final String MISC_INCLUDE_LICENSE = "includeLicense";
+    public static final String MISC_SHOW_AVAILABILITY_TAB = "showAvailabilityTab";
 
     public static final String GUI_PLAF = "lookAndFeel";
     public static final String GUI_COLOR_WEAPONS = "Weapons";
@@ -186,6 +187,8 @@ public final class CConfig {
         defaults.setProperty(MISC_SKIP_SAFETY_PROMPTS, Boolean.toString(false));
         defaults.setProperty(MISC_APPLICATION_EXIT_PROMPT, Boolean.toString(true));
         defaults.setProperty(MISC_INCLUDE_LICENSE, Boolean.toString(false));
+        // Off by default: the Force Generator Availability tab is an advanced feature, opt-in from Options - General.
+        defaults.setProperty(MISC_SHOW_AVAILABILITY_TAB, Boolean.toString(false));
         defaults.setProperty(RS_PROGRESS_BAR, Boolean.toString(true));
         defaults.setProperty(RS_COLOR, RecordSheetOptions.ColorMode.LOGO_ONLY.name());
         defaults.setProperty(RS_HEAT_SCALE_MARKER, RecordSheetOptions.HeatScaleMarker.ASTERISK.name());
@@ -589,6 +592,10 @@ public final class CConfig {
 
     public static boolean includeLicense() {
         return CConfig.getBooleanParam(CConfig.MISC_INCLUDE_LICENSE);
+    }
+
+    public static boolean showAvailabilityTab() {
+        return CConfig.getBooleanParam(CConfig.MISC_SHOW_AVAILABILITY_TAB);
     }
 
     public static void resetWindowPositions() {

--- a/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java
+++ b/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.NavigableSet;
 import java.util.TreeSet;
@@ -142,6 +143,19 @@ class AvailabilityTabTest {
         assertTrue(tab.isRoleOffered(MissionRole.URBAN), "A Mek can be an urban unit");
         assertFalse(tab.isRoleOffered(MissionRole.MEK_CARRIER), "A Mek does not carry Meks");
         assertFalse(tab.isRoleOffered(MissionRole.PARATROOPER), "Paratrooper is an infantry role");
+    }
+
+    @Test
+    void theRoleGridHoldsOnlyTheOfferedRolesWithNoHoles() {
+        // Hiding non-fitting roles with setVisible left holes in the grid. Now only the offered roles are added, so
+        // the grid size equals the offered count and is well short of every role.
+        AvailabilityTab tab = new AvailabilityTab(new StubEntitySource(buildMek()));
+
+        long offered = Arrays.stream(MissionRole.values()).filter(tab::isRoleOffered).count();
+
+        assertEquals(offered, tab.missionRoleGridSize(), "The grid should hold exactly the offered roles");
+        assertTrue(tab.missionRoleGridSize() < MissionRole.values().length,
+              "A Mek does not fit every role, so the grid must be smaller than the full list");
     }
 
     @Test

--- a/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java
+++ b/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java
@@ -34,10 +34,13 @@ package megameklab.ui.generalUnit;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
+import megamek.client.ratgenerator.MissionRole;
 import megamek.common.equipment.Engine;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.interfaces.ITechManager;
@@ -124,6 +127,33 @@ class AvailabilityTabTest {
         mek.setYear(3150);
 
         assertDoesNotThrow(tab::refresh);
+    }
+
+    @Test
+    void onlyRolesThatMeanSomethingForTheUnitTypeAreOffered() {
+        // A Mek has no business being offered "mek carrier" or "paratrooper". MissionRole.fitsUnitType() already knows
+        // which roles apply where, so the tab asks it rather than showing all fifty.
+        AvailabilityTab tab = new AvailabilityTab(new StubEntitySource(buildMek()));
+
+        assertTrue(tab.isRoleOffered(MissionRole.FIRE_SUPPORT), "A Mek can be fire support");
+        assertTrue(tab.isRoleOffered(MissionRole.URBAN), "A Mek can be an urban unit");
+        assertFalse(tab.isRoleOffered(MissionRole.MEK_CARRIER), "A Mek does not carry Meks");
+        assertFalse(tab.isRoleOffered(MissionRole.PARATROOPER), "Paratrooper is an infantry role");
+    }
+
+    @Test
+    void aRoleTheFileDeclaresIsShownEvenIfItDoesNotFit() {
+        // Quietly dropping something out of somebody's file is not this tab's job. Show it, warn, let them decide.
+        Mek mek = buildMek();
+        mek.setMissionRoles("fire_support,paratrooper");
+
+        AvailabilityTab tab = new AvailabilityTab(new StubEntitySource(mek));
+
+        assertTrue(tab.isRoleOffered(MissionRole.PARATROOPER),
+              "A role the file declares must stay visible so the player can remove it");
+        assertTrue(tab.getMismatchedRoles().contains(MissionRole.PARATROOPER),
+              "It should be flagged as not applying to this unit type");
+        assertFalse(tab.getMismatchedRoles().contains(MissionRole.FIRE_SUPPORT));
     }
 
     @Test

--- a/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java
+++ b/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMekLab was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.ui.generalUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import megamek.common.equipment.Engine;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.interfaces.ITechManager;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Entity;
+import megamek.common.units.ForceGeneratorAvailability;
+import megamek.common.units.Mek;
+import megameklab.ui.EntitySource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Builds the real Availability tab against a real unit.
+ * <p>
+ * The table model and the save path are tested elsewhere, but neither would notice if the tab itself threw while being
+ * built or refreshed. Swing panels can be constructed without a display, so this runs headless and would catch exactly
+ * that.
+ * </p>
+ */
+class AvailabilityTabTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    /** The tab only ever asks its source for the unit. */
+    private record StubEntitySource(Entity entity) implements EntitySource {
+        @Override
+        public Entity getEntity() {
+            return entity;
+        }
+
+        @Override
+        public void createNewUnit(long entityType, boolean isPrimitive, boolean isIndustrial, Entity oldUnit) {
+            throw new UnsupportedOperationException("The Availability tab never creates units");
+        }
+
+        @Override
+        public ITechManager getTechManager() {
+            return null;
+        }
+    }
+
+    private static Mek buildMek() {
+        Mek mek = new BipedMek();
+        mek.setChassis("Grimjack");
+        mek.setModel("GRM-1A");
+        mek.setYear(3049);
+        mek.setWeight(20.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+
+        return mek;
+    }
+
+    @Test
+    void theTabBuildsForAUnitWithNoAvailability() {
+        // The common case: a unit that has never been near this tab
+        assertDoesNotThrow(() -> new AvailabilityTab(new StubEntitySource(buildMek())));
+    }
+
+    @Test
+    void theTabLoadsWhatTheUnitAlreadyDeclares() {
+        Mek mek = buildMek();
+        mek.setForceGeneratorAvailability(List.of(ForceGeneratorAvailability.parse("FS:5,LA:3")));
+        mek.setMissionRoles("fire_support");
+
+        AvailabilityTab tab = new AvailabilityTab(new StubEntitySource(mek));
+
+        assertNotNull(tab);
+        // The unit declared two factions, so the table should be showing two rows
+        assertEquals(2, tab.getTableModel().getRowCount());
+        assertEquals("FS", tab.getTableModel().getRow(0).factionCode());
+        assertEquals(5, tab.getTableModel().getRow(0).availability());
+    }
+
+    @Test
+    void refreshingAfterTheYearChangesDoesNotThrow() {
+        // The introduction year lives on Basic Info, so it can change under this tab at any time
+        Mek mek = buildMek();
+        mek.setForceGeneratorAvailability(List.of(ForceGeneratorAvailability.parse("FS:5")));
+        AvailabilityTab tab = new AvailabilityTab(new StubEntitySource(mek));
+
+        mek.setYear(3150);
+
+        assertDoesNotThrow(tab::refresh);
+    }
+
+    @Test
+    void theTabBuildsForAHandEditedFileItDoesNotOffer() {
+        // The tab has no +/- control, but a hand-edited file may carry those. Opening such a unit must not throw.
+        Mek mek = buildMek();
+        mek.setForceGeneratorAvailability(List.of(ForceGeneratorAvailability.parse("CJF:5+,CSA:2-")));
+
+        assertDoesNotThrow(() -> new AvailabilityTab(new StubEntitySource(mek)));
+    }
+}

--- a/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java
+++ b/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java
@@ -39,6 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 
 import megamek.client.ratgenerator.MissionRole;
 import megamek.common.equipment.Engine;
@@ -49,6 +51,7 @@ import megamek.common.units.Entity;
 import megamek.common.units.ForceGeneratorAvailability;
 import megamek.common.units.Mek;
 import megameklab.ui.EntitySource;
+import megameklab.ui.generalUnit.AvailabilityTableModel.AvailabilityRow;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -154,6 +157,43 @@ class AvailabilityTabTest {
         assertTrue(tab.getMismatchedRoles().contains(MissionRole.PARATROOPER),
               "It should be flagged as not applying to this unit type");
         assertFalse(tab.getMismatchedRoles().contains(MissionRole.FIRE_SUPPORT));
+    }
+
+    @Test
+    void aRangeThatEndsInsideAnEraIsFlagged() {
+        // The QA case: eras at 3055, 3060, 3067. A range ending at 3062 stops inside the 3060-3066 era, so the change
+        // is smeared across that era rather than happening at 3063.
+        NavigableSet<Integer> eras = new TreeSet<>(List.of(3050, 3055, 3060, 3067, 3075));
+        List<AvailabilityRow> rows = List.of(
+              new AvailabilityRow("FS", "Federated Suns", 2, 3055, 3062, false));
+
+        List<String> problems = AvailabilityTab.eraAlignmentProblems(rows, 3050, eras);
+
+        assertEquals(1, problems.size());
+        assertTrue(problems.getFirst().contains("3062"), problems.getFirst());
+        assertTrue(problems.getFirst().contains("3060-3066"), problems.getFirst());
+    }
+
+    @Test
+    void aRangeThatLinesUpWithErasIsNotFlagged() {
+        // 3055-3059 is the whole 3055 era (3055 up to the year before 3060), so it is crisp.
+        NavigableSet<Integer> eras = new TreeSet<>(List.of(3050, 3055, 3060, 3067, 3075));
+        List<AvailabilityRow> rows = List.of(
+              new AvailabilityRow("FS", "Federated Suns", 2, 3055, 3059, false));
+
+        assertTrue(AvailabilityTab.eraAlignmentProblems(rows, 3050, eras).isEmpty());
+    }
+
+    @Test
+    void theIntroYearIsNeverFlaggedAsAStartProblem() {
+        // A range starting at the unit's own introduction year is natural, even if that year is not an era boundary.
+        NavigableSet<Integer> eras = new TreeSet<>(List.of(3050, 3055, 3060));
+        List<AvailabilityRow> rows = List.of(
+              new AvailabilityRow("FS", "Federated Suns", 2,
+                    megamek.common.units.ForceGeneratorAvailability.UNSPECIFIED_YEAR,
+                    megamek.common.units.ForceGeneratorAvailability.UNSPECIFIED_YEAR, false));
+
+        assertTrue(AvailabilityTab.eraAlignmentProblems(rows, 3052, eras).isEmpty());
     }
 
     @Test

--- a/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java
+++ b/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java
@@ -159,6 +159,37 @@ class AvailabilityTabTest {
     }
 
     @Test
+    void aRoleNoLongerInTheFileIsNotWrittenBack() {
+        // A non-fitting role that was selected then removed must be deselected on reload, or missionRolesText would
+        // write it back even though it is no longer shown.
+        Mek mek = buildMek();
+        mek.setMissionRoles("paratrooper");
+        AvailabilityTab tab = new AvailabilityTab(new StubEntitySource(mek));
+        assertTrue(tab.getMismatchedRoles().contains(MissionRole.PARATROOPER));
+
+        mek.setMissionRoles("");
+        tab.refresh();
+
+        assertFalse(tab.currentMissionRolesText().contains("paratrooper"),
+              "A hidden, no-longer-declared role must not leak back into the unit");
+    }
+
+    @Test
+    void aFromYearAtTheIntroYearStaysTheSentinel() {
+        // "Start at the intro year" is stored as UNSPECIFIED so it tracks the intro year. Leaving the spinner at the
+        // intro year must not freeze it to a concrete value.
+        int intro = 3049;
+        assertEquals(ForceGeneratorAvailability.UNSPECIFIED_YEAR,
+              AvailabilityTab.resolveFromYear(intro, ForceGeneratorAvailability.UNSPECIFIED_YEAR, intro));
+        // Moving the spinner off the intro year makes it a real, concrete start year
+        assertEquals(3055,
+              AvailabilityTab.resolveFromYear(3055, ForceGeneratorAvailability.UNSPECIFIED_YEAR, intro));
+        // A row that already had a concrete year keeps it, even when that year equals the intro year
+        assertEquals(intro,
+              AvailabilityTab.resolveFromYear(intro, intro, intro));
+    }
+
+    @Test
     void aRoleTheFileDeclaresIsShownEvenIfItDoesNotFit() {
         // Quietly dropping something out of somebody's file is not this tab's job. Show it, warn, let them decide.
         Mek mek = buildMek();

--- a/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTableModelTest.java
+++ b/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTableModelTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMekLab was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.ui.generalUnit;
+
+import static megamek.common.units.ForceGeneratorAvailability.UNSPECIFIED_YEAR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import megamek.common.units.ForceGeneratorAvailability;
+import megameklab.ui.generalUnit.AvailabilityTableModel.AvailabilityRow;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AvailabilityTableModelTest {
+
+    /** In the tab this maps a code to a real faction name; the table's behaviour does not depend on it. */
+    private static final Function<String, String> NAMER = code -> "Name of " + code;
+
+    private AvailabilityTableModel model;
+
+    @BeforeEach
+    void setUp() {
+        model = new AvailabilityTableModel();
+    }
+
+    @Test
+    void loadSplitsEachFactionInAnEntryIntoItsOwnRow() {
+        model.loadFrom(List.of(ForceGeneratorAvailability.parse("FS:5,LA:3")), NAMER);
+
+        assertEquals(2, model.getRowCount());
+        assertEquals("FS", model.getRow(0).factionCode());
+        assertEquals(5, model.getRow(0).availability());
+        assertEquals("LA", model.getRow(1).factionCode());
+        assertEquals(3, model.getRow(1).availability());
+    }
+
+    @Test
+    void loadKeepsTheYearRange() {
+        model.loadFrom(List.of(ForceGeneratorAvailability.parse("3067-3085 FS:7")), NAMER);
+
+        assertEquals(3067, model.getRow(0).fromYear());
+        assertEquals(3085, model.getRow(0).toYear());
+    }
+
+    @Test
+    void aFileWrittenByHandSurvivesBeingOpened() {
+        // The tab does not offer the +/- suffixes, but a hand-edited file may carry them. Opening such a file must
+        // not silently mangle the number.
+        model.loadFrom(List.of(ForceGeneratorAvailability.parse("CJF:5+,CSA:2-")), NAMER);
+
+        assertEquals(5, model.getRow(0).availability());
+        assertEquals(2, model.getRow(1).availability());
+    }
+
+    @Test
+    void roundTripsThroughTheFileFormat() {
+        List<ForceGeneratorAvailability> original = List.of(
+              ForceGeneratorAvailability.parse("FS:5,LA:3"),
+              ForceGeneratorAvailability.parse("3067-3085 FS:7"));
+
+        model.loadFrom(original, NAMER);
+        List<ForceGeneratorAvailability> written = model.toAvailabilityEntries();
+
+        assertEquals(2, written.size());
+        assertEquals("FS:5,LA:3", written.get(0).availabilityCodes());
+        assertEquals(UNSPECIFIED_YEAR, written.get(0).startYear());
+        assertEquals("FS:7", written.get(1).availabilityCodes());
+        assertEquals(3067, written.get(1).startYear());
+        assertEquals(3085, written.get(1).endYear());
+    }
+
+    @Test
+    void factionsSharingAYearRangeAreWrittenAsOneLine() {
+        // A hand-written file would put them on one line, so the tab should too
+        model.addRow(new AvailabilityRow("FS", "Federated Suns", 5, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR, false));
+        model.addRow(new AvailabilityRow("LA", "Lyran Commonwealth", 3, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR, false));
+        model.addRow(new AvailabilityRow("CJF", "Clan Jade Falcon", 7, 3067, 3085, false));
+
+        List<ForceGeneratorAvailability> written = model.toAvailabilityEntries();
+
+        assertEquals(2, written.size());
+        assertEquals("FS:5,LA:3", written.get(0).availabilityCodes());
+        assertEquals("CJF:7", written.get(1).availabilityCodes());
+    }
+
+    @Test
+    void addingAFactionTwiceOnlyAddsItOnce() {
+        int first = model.addRow(new AvailabilityRow("FS", "Federated Suns", 5, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR,
+              false));
+        int second = model.addRow(new AvailabilityRow("FS", "Federated Suns", 9, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR,
+              false));
+
+        assertEquals(first, second);
+        assertEquals(1, model.getRowCount());
+        // The first value stands; the player edits it with the slider rather than by adding the faction again
+        assertEquals(5, model.getRow(0).availability());
+    }
+
+    @Test
+    void factionsThatDoNotExistInTheUnitsYearAreFlagged() {
+        // Clan Wolf is a real choice for a 3050 unit and a dead one for a 3150 unit. Changing the intro year on Basic
+        // Info after filling this tab in must not leave the player with a silently dead row.
+        model.addRow(new AvailabilityRow("CW", "Clan Wolf", 5, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR, false));
+        model.addRow(new AvailabilityRow("CWE", "Wolf Empire", 5, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR, false));
+
+        model.markStaleFactions(Set.of("CWE", "FS", "LA"));
+
+        assertTrue(model.getRow(0).stale());
+        assertFalse(model.getRow(1).stale());
+        assertTrue(model.hasStaleRows());
+    }
+
+    @Test
+    void anEmptyTableWritesNothing() {
+        assertTrue(model.toAvailabilityEntries().isEmpty());
+    }
+}

--- a/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTableModelTest.java
+++ b/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTableModelTest.java
@@ -128,16 +128,30 @@ class AvailabilityTableModelTest {
     }
 
     @Test
-    void addingAFactionTwiceOnlyAddsItOnce() {
+    void addingTheSameFactionAndRangeTwiceOnlyAddsItOnce() {
         int first = model.addRow(new AvailabilityRow("FS", "Federated Suns", 5, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR,
               false));
         int second = model.addRow(new AvailabilityRow("FS", "Federated Suns", 9, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR,
               false));
 
-        assertEquals(first, second);
+        assertEquals(first, second, "Same faction and same range is an exact duplicate and is ignored");
         assertEquals(1, model.getRowCount());
-        // The first value stands; the player edits it with the slider rather than by adding the faction again
         assertEquals(5, model.getRow(0).availability());
+    }
+
+    @Test
+    void oneFactionCanHaveDifferentAvailabilityInDifferentYearRanges() {
+        // The whole point of variable availability: the Federated Suns field this often early and rarely late.
+        model.addRow(new AvailabilityRow("FS", "Federated Suns", 8, 3050, 3060, false));
+        model.addRow(new AvailabilityRow("FS", "Federated Suns", 3, 3061, 3090, false));
+
+        assertEquals(2, model.getRowCount(), "Same faction, different ranges, must both be kept");
+        List<ForceGeneratorAvailability> entries = model.toAvailabilityEntries();
+        assertEquals(2, entries.size());
+        assertEquals("FS:8", entries.get(0).availabilityCodes());
+        assertEquals(3050, entries.get(0).startYear());
+        assertEquals("FS:3", entries.get(1).availabilityCodes());
+        assertEquals(3061, entries.get(1).startYear());
     }
 
     @Test

--- a/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTableModelTest.java
+++ b/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTableModelTest.java
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 
 import megamek.common.units.ForceGeneratorAvailability;
@@ -155,17 +154,27 @@ class AvailabilityTableModelTest {
     }
 
     @Test
-    void factionsThatDoNotExistInTheUnitsYearAreFlagged() {
-        // Clan Wolf is a real choice for a 3050 unit and a dead one for a 3150 unit. Changing the intro year on Basic
-        // Info after filling this tab in must not leave the player with a silently dead row.
+    void rowsAreFlaggedByTheSuppliedStaleCheck() {
+        // The check is supplied by the tab, which has the faction data. The model just applies it to each row.
         model.addRow(new AvailabilityRow("CW", "Clan Wolf", 5, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR, false));
         model.addRow(new AvailabilityRow("CWE", "Wolf Empire", 5, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR, false));
 
-        model.markStaleFactions(Set.of("CWE", "FS", "LA"));
+        model.markStaleRows(row -> row.factionCode().equals("CW"));
 
         assertTrue(model.getRow(0).stale());
         assertFalse(model.getRow(1).stale());
         assertTrue(model.hasStaleRows());
+    }
+
+    @Test
+    void aRowStartingAtIntroShowsTheIntroYearInTheFromColumn() {
+        model.setIntroYear(3050);
+        model.addRow(new AvailabilityRow("FS", "Federated Suns", 5, UNSPECIFIED_YEAR, UNSPECIFIED_YEAR, false));
+
+        assertEquals("3050", model.getValueAt(0, AvailabilityTableModel.COL_FROM),
+              "A blank From column reads as empty; showing the intro year is clearer");
+        assertEquals("", model.getValueAt(0, AvailabilityTableModel.COL_TO),
+              "An open end still shows blank, meaning never stops");
     }
 
     @Test

--- a/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTableModelTest.java
+++ b/megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTableModelTest.java
@@ -88,6 +88,15 @@ class AvailabilityTableModelTest {
     }
 
     @Test
+    void anUnreadableNumberDoesNotFailTheLoad() {
+        // A hand-edited value can overflow an int. Opening the file must not throw; the number reads as 0 instead.
+        model.loadFrom(List.of(ForceGeneratorAvailability.parse("FS:99999999999")), NAMER);
+
+        assertEquals(1, model.getRowCount());
+        assertEquals(0, model.getRow(0).availability());
+    }
+
+    @Test
     void roundTripsThroughTheFileFormat() {
         List<ForceGeneratorAvailability> original = List.of(
               ForceGeneratorAvailability.parse("FS:5,LA:3"),

--- a/megameklab/unittests/megameklab/util/AvailabilityCalibrationTest.java
+++ b/megameklab/unittests/megameklab/util/AvailabilityCalibrationTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMekLab was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import megameklab.util.AvailabilityCalibration.ComparableChassis;
+import org.junit.jupiter.api.Test;
+
+class AvailabilityCalibrationTest {
+
+    @Test
+    void describeGivesAWordForEveryStepOfTheScale() {
+        // The slider shows these, so a player never has to know the scale is logarithmic
+        assertEquals("none", AvailabilityCalibration.describe(0));
+        assertEquals("rare", AvailabilityCalibration.describe(3));
+        assertEquals("uncommon", AvailabilityCalibration.describe(5));
+        assertEquals("typical", AvailabilityCalibration.describe(6));
+        assertEquals("common", AvailabilityCalibration.describe(8));
+        assertEquals("ubiquitous", AvailabilityCalibration.describe(10));
+    }
+
+    @Test
+    void describeClampsOutOfRangeValues() {
+        // A hand-edited file can carry anything; the tab must not blow up on it
+        assertEquals("none", AvailabilityCalibration.describe(-4));
+        assertEquals("ubiquitous", AvailabilityCalibration.describe(99));
+    }
+
+    @Test
+    void comparableUnitsAreOrderedByHowCloseTheyAre() {
+        List<String> picked = AvailabilityCalibration.pickComparable(List.of(
+              new ComparableChassis("Zeus", 1),
+              new ComparableChassis("Wolverine", 0),
+              new ComparableChassis("Archer", 1)));
+
+        // Exact match first, then alphabetical among the equally-close ones
+        assertEquals(List.of("Wolverine", "Archer", "Zeus"), picked);
+    }
+
+    @Test
+    void comparableUnitsStopAtThree() {
+        List<String> picked = AvailabilityCalibration.pickComparable(List.of(
+              new ComparableChassis("Archer", 0),
+              new ComparableChassis("Banshee", 0),
+              new ComparableChassis("Catapult", 0),
+              new ComparableChassis("Dervish", 0),
+              new ComparableChassis("Enforcer", 0)));
+
+        assertEquals(AvailabilityCalibration.COMPARABLE_UNIT_COUNT, picked.size());
+        assertEquals(List.of("Archer", "Banshee", "Catapult"), picked);
+    }
+
+    @Test
+    void theSameChassisIsOnlyOfferedOnce() {
+        // One chassis can hold several models, and the player does not need to be told about the Archer three times
+        List<String> picked = AvailabilityCalibration.pickComparable(List.of(
+              new ComparableChassis("Archer", 0),
+              new ComparableChassis("Archer", 0),
+              new ComparableChassis("Banshee", 1)));
+
+        assertEquals(List.of("Archer", "Banshee"), picked);
+    }
+
+    @Test
+    void nothingComparableGivesAnEmptyList() {
+        assertTrue(AvailabilityCalibration.pickComparable(List.of()).isEmpty());
+    }
+}

--- a/megameklab/unittests/megameklab/util/AvailabilitySaveRoundTripTest.java
+++ b/megameklab/unittests/megameklab/util/AvailabilitySaveRoundTripTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMekLab was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megameklab.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import megamek.common.equipment.Engine;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.loaders.MtfFile;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Entity;
+import megamek.common.units.ForceGeneratorAvailability;
+import megamek.common.units.Mek;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Proves that what the Availability tab puts on a unit actually reaches the file MegaMekLab writes.
+ * <p>
+ * MegaMekLab does not write units itself; it hands them to {@code UnitUtil.saveUnitToString()}. The tab's own tests
+ * cover the table and the round-trip through the file format, but neither of them would notice if MegaMekLab's saver
+ * dropped the lines on the way out. This drives the real save path.
+ * </p>
+ */
+class AvailabilitySaveRoundTripTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    private static Mek buildMek() {
+        Mek mek = new BipedMek();
+        mek.setChassis("Grimjack");
+        mek.setModel("GRM-1A");
+        mek.setYear(3049);
+        mek.setWeight(20.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+
+        return mek;
+    }
+
+    @Test
+    void availabilitySetOnTheTabReachesTheSavedFile() {
+        Mek mek = buildMek();
+        mek.setForceGeneratorAvailability(List.of(
+              ForceGeneratorAvailability.parse("FS:5,LA:3"),
+              ForceGeneratorAvailability.parse("3067-3085 FS:7")));
+        mek.setMissionRoles("fire_support,urban");
+
+        String saved = UnitUtil.saveUnitToString(mek, false);
+
+        assertTrue(saved.contains("availability:FS:5,LA:3"),
+              "MegaMekLab's saver must write the availability line");
+        assertTrue(saved.contains("availability:3067-3085 FS:7"));
+        assertTrue(saved.contains("missionroles:fire_support,urban"));
+    }
+
+    @Test
+    void theSavedFileLoadsBackWithTheSameAvailability() throws Exception {
+        Mek mek = buildMek();
+        mek.setForceGeneratorAvailability(List.of(ForceGeneratorAvailability.parse("3067-3085 FS:7,LA:6")));
+        mek.setMissionRoles("fire_support");
+
+        String saved = UnitUtil.saveUnitToString(mek, false);
+        Entity reloaded = new MtfFile(new ByteArrayInputStream(saved.getBytes(StandardCharsets.UTF_8))).getEntity();
+
+        assertEquals(1, reloaded.getForceGeneratorAvailability().size());
+        ForceGeneratorAvailability entry = reloaded.getForceGeneratorAvailability().getFirst();
+        assertEquals(3067, entry.startYear());
+        assertEquals(3085, entry.endYear());
+        assertEquals("FS:7,LA:6", entry.availabilityCodes());
+        assertEquals("fire_support", reloaded.getMissionRoles());
+    }
+
+    @Test
+    void aUnitWithNoAvailabilityWritesNoAvailabilityLine() {
+        // Every existing unit goes through this saver. None of them should grow a new line.
+        String saved = UnitUtil.saveUnitToString(buildMek(), false);
+
+        assertFalse(saved.contains("availability:"));
+        assertFalse(saved.contains("missionroles:"));
+    }
+}


### PR DESCRIPTION
# ⚠️ Depends on MegaMek PR #8514 (https://github.com/MegaMek/megamek/pull/8514). Do not merge until that lands.

This branch composite-builds against megamek master. The tab reads and writes fields, an isCanonUnitName() check, and a year-gated availability lookup that only exist on #8514. It will not compile against current master.

Summary

Adds an Availability tab to the MegaMekLab unit editor. It lets a player say which factions field a custom unit, and how often, so it turns up in generated forces — the UI for the file fields added in MegaMek #8514. Until now that meant hand-editing the .mtf or .blk, where a bad faction code only showed up in the log.

(Add a screenshot or two here — the tab with a few factions, and the "Copy numbers from a unit" flow.)

Changes Made

- Availability tab on the 9 unit types the Force Generator supports (Mek, combat vehicle, support vehicle, aero, DropShip, WarShip, ProtoMek, battle armor, conventional infantry). Gun emplacements and handheld weapons are skipped — the generator does not build them.
- Faction picker filtered to the ~45 factions that exist in the unit's introduction year, not all 415. A faction that does not exist in that year cannot be picked, so Clan Wolf never appears for a 3150 unit. Umbrella keys (General / IS / CLAN / Periphery) get their own group.
- Availability as a slider with words (rare / uncommon / typical / common / ubiquitous), because the raw 0–10 log scale means nothing on its own.
- Calibration: "at FS:5 this is about as common as Wolverine, Vindicator, Enforcer", and a Copy numbers from a unit button that seeds the table from a canon design. Both anchor the number against units a player already knows.
- Mission roles filtered to those that apply to the unit type (a Mek is not offered "mek carrier").
- Warnings, not silent failures: canon unit (ignored by the generator), canon chassis (variant-split only), a year before the unit exists, a faction dead in the unit's year, and a year range that does not line up with the game's eras.
- Reads and writes through the existing Entity fields, so MegaMekLab's own saver carries it with no new persistence.

Changes

1. AvailabilityCalibration.java (NEW) — the number-to-meaning logic (word labels, comparable units, copy-from). No Swing, so it is unit-tested headless.
2. AvailabilityTableModel.java (NEW) — the faction rows, and the round-trip to and from the file format.
3. AddFactionsDialog.java (NEW) — multi-select faction picker with a filter and the umbrella-key group.
4. AvailabilityTab.java (NEW) — the tab: table, slider strip, roles, warnings.
5. 9 *MainUI.java — register the tab (6-line change each, mirroring how QuirksTab is wired).

Files Changed

- megameklab/src/megameklab/util/AvailabilityCalibration.java — NEW: word labels, comparable units, copy-from
- megameklab/src/megameklab/ui/generalUnit/AvailabilityTableModel.java — NEW: rows and file round-trip
- megameklab/src/megameklab/ui/generalUnit/AvailabilityTab.java — NEW: the tab
- megameklab/src/megameklab/ui/dialog/AddFactionsDialog.java — NEW: faction picker
- megameklab/src/megameklab/ui/mek/BMMainUI.java — register the tab
- megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java — register the tab
- megameklab/src/megameklab/ui/supportVehicle/SVMainUI.java — register the tab
- megameklab/src/megameklab/ui/fighterAero/ASMainUI.java — register the tab
- megameklab/src/megameklab/ui/largeAero/DSMainUI.java — register the tab
- megameklab/src/megameklab/ui/largeAero/WSMainUI.java — register the tab
- megameklab/src/megameklab/ui/protoMek/PMMainUI.java — register the tab
- megameklab/src/megameklab/ui/battleArmor/BAMainUI.java — register the tab
- megameklab/src/megameklab/ui/infantry/CIMainUI.java — register the tab
- megameklab/unittests/megameklab/util/AvailabilityCalibrationTest.java — NEW: 6 tests
- megameklab/unittests/megameklab/util/AvailabilitySaveRoundTripTest.java — NEW: 3 tests, MegaMekLab's own save path
- megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTableModelTest.java — NEW: 8 tests
- megameklab/unittests/megameklab/ui/generalUnit/AvailabilityTabTest.java — NEW: 9 tests

Testing

- Unit tests: 26 new, all headless (Swing panels build without a display).
  - AvailabilitySaveRoundTripTest: drives MegaMekLab's real saver (UnitUtil.saveUnitToString), not the MegaMek writers, and confirms a unit with no availability grows no new lines.
  - AvailabilityTabTest: builds the real tab against a real Mek, survives the intro year changing underneath it, copes with a hand-edited file carrying +/- suffixes the tab does not offer, and checks role gating.
  - AvailabilityTableModelTest / AvailabilityCalibrationTest: file round-trip, era logic, word labels, comparable-unit selection.
- Manual: MegaMekLab launches with the tab present; construction and refresh verified headless.

Notes

- Faction-only for now. No Command (FS.CMB) column. Commands are the long tail; the file format already takes them, so they can be added later without a rewrite.
- MekHQ needs nothing — it consumes the Force Generator through RATGeneratorConnector.
- The tab loads the Force Generator lazily on first show, so it does not slow MegaMekLab startup.