### PR TITLE
Fix: Ammo Linking to Weapons in Weapons Bay

### DIFF
--- a/megameklab/src/megameklab/ui/util/AeroBayTransferHandler.java
+++ b/megameklab/src/megameklab/ui/util/AeroBayTransferHandler.java
@@ -203,7 +203,6 @@ public class AeroBayTransferHandler extends TransferHandler {
                             UnitUtil.changeMountStatus(eSource.getEntity(), m.getLinkedBy(),
                                   Entity.LOC_NONE, Entity.LOC_NONE, false);
                             m.getLinkedBy().setLinked(null);
-                            m.setLinkedBy(null);
                         }
                     }
                     UnitUtil.compactCriticalSlots(eSource.getEntity());

--- a/megameklab/src/megameklab/ui/util/BayWeaponCriticalTree.java
+++ b/megameklab/src/megameklab/ui/util/BayWeaponCriticalTree.java
@@ -1075,6 +1075,13 @@ public class BayWeaponCriticalTree extends JTree {
                 } else if (eq instanceof AmmoMounted) {
                     bay.addAmmoToBay(eSource.getEntity().getEquipmentNum(eq));
                     updateAmmoCapacity((AmmoMounted) eq);
+                    final AmmoTypeEnum ammoTypeEnum = ((AmmoMounted) eq).getType().getAmmoType();
+                    for (WeaponMounted weapon : bay.getBayWeapons()) {
+                        if (weapon.getLinked() == null && weapon.getType().getAmmoType() == ammoTypeEnum) {
+                            weapon.setLinked(eq);
+                            break;
+                        }
+                    }
                 }
             } else {
                 logger.debug("{}[{}] not found in {}",

--- a/megameklab/src/megameklab/util/BattleArmorUtil.java
+++ b/megameklab/src/megameklab/util/BattleArmorUtil.java
@@ -166,7 +166,6 @@ public final class BattleArmorUtil {
             return;
         }
         removeMountFromDwp(dwp);
-        weapon.setLinkedBy(dwp);
         dwp.setLinked(weapon);
         weapon.setDWPMounted(true);
         weapon.setBaMountLoc(BattleArmor.MOUNT_LOC_NONE);
@@ -185,7 +184,6 @@ public final class BattleArmorUtil {
         }
         if (dwp.getLinked() != null) {
             Mounted<?> weapon = dwp.getLinked();
-            weapon.setLinkedBy(null);
             weapon.setDWPMounted(false);
             dwp.setLinked(null);
         }


### PR DESCRIPTION
Fix ammo linking to weapons in the weapons bay

Note for Reviewer: MERGE IMMEDIATELY AFTER MM side PR https://github.com/MegaMek/megamek/pull/8518

MML code removes privatized MM methods