### PR TITLE
Fix: Required Gunners on Fire Control Change

### DIFF
--- a/megameklab/src/megameklab/ui/supportVehicle/SVCrewView.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVCrewView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/ui/supportVehicle/SVCrewView.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVCrewView.java
@@ -341,7 +341,7 @@ public class SVCrewView extends BuildView implements ChangeListener {
     public void setFromEntity(Entity entity) {
         final int total = Compute.getFullCrewSize(entity);
         final int base = Compute.getSVBaseCrewNeeds(entity);
-        final int gunners = Compute.getSupportVehicleGunnerNeeds(entity);
+        final int gunners = Compute.getTotalGunnerNeeds(entity);
         final int other = Compute.getAdditionalNonGunner(entity);
         txtReqBaseCrew.setText(String.valueOf(base));
         txtReqGunners.setText(String.valueOf(gunners));

--- a/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVStructureTab.java
@@ -717,6 +717,7 @@ public class SVStructureTab extends ITab implements SVBuildListener {
             }
         }
         panChassis.setFromEntity(getSV());
+        panCrew.setFromEntity(getSV());
         panSummary.refresh();
         refresh.refreshStatus();
         refresh.refreshPreview();


### PR DESCRIPTION
Fix SV crew panel not updating on fire control change

Switch from Compute.getSupportVehicleGunnerNeeds to Compute.getTotalGunnerNeeds, as getSupportVehicleGunnerNeeds will be privatized as a getTotalGunnerNeeds helper in https://github.com/MegaMek/megamek/pull/8605

Note for Reviewer: MERGE BEFORE MM side https://github.com/MegaMek/megamek/pull/8605