### PR TITLE
Version the build with MegaMek's optional fourth version component

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,16 @@ subprojects {
     versionProperties.load(rootProject.file("../megamek/megamek/resources/Version.properties").newDataInputStream())
     def processedVersion = String.format("%d.%02d.%02d", Integer.parseInt(versionProperties.getProperty("major")), Integer.parseInt(versionProperties.getProperty("minor")), Integer.parseInt(versionProperties.getProperty("patch")))
 
+    // Optional fourth component, present only for a special point release such as 0.51.0.1. See the comment in
+    // MegaMek's megamek/resources/Version.properties, which is the file read above.
+    def revisionProperty = versionProperties.getProperty("revision")
+    if (revisionProperty != null && !revisionProperty.trim().isEmpty()) {
+        def parsedRevision = Integer.parseInt(revisionProperty.trim())
+        if (parsedRevision > 0) {
+            processedVersion = String.format("%s.%d", processedVersion, parsedRevision)
+        }
+    }
+
     if (project.hasProperty("extraVersion")) {
         processedVersion = String.format("%s-%s", processedVersion, project.getProperty('extraVersion'))
     }


### PR DESCRIPTION
## What this changes for you

Nothing, until someone cuts a special point release. This is the MegaMekLab half of a three-repo change.

MegaMek can now be given a version number like **0.51.0.1** for a point release that ships on top of an existing patch release (MegaMek/megamek#8690). The number lives in `megamek/resources/Version.properties` — and **MegaMekLab's build reads that exact file**, from the sibling checkout, to version itself (`build.gradle:19`).

So without this change, a point release would have produced a `MegaMekLab-0.51.01.tar.gz` sitting next to a `MegaMek-0.51.01.1.tar.gz` — two artifacts from one release, with different numbers on them.

Ten lines in `build.gradle` appends the fourth component when it is present. Most releases will not have one, and when it is absent the computed version is unchanged.

| | revision absent | `revision=1` set in MegaMek |
|---|---|---|
| MegaMekLab artifact | `0.51.01` | `0.51.01.1` |

## Why there is no Java change

`MMLConstants extends SuiteConstants`, so `MMLConstants.VERSION` *is* MegaMek's `Version` object, which now understands the optional component. And MegaMekLab builds with a composite `includeBuild` against local MegaMek source rather than a published jar, so the change is live here the moment it lands in MegaMek.

MegaMekLab only ever displays or writes the version — the About dialog, the startup screen, the Sentry release tag, and the `# Saved from version ...` header on unit files. It never parses a version into its components, so there is nothing on this side to teach. I checked every use in `megameklab/src` to confirm that.

## Changes

1. `build.gradle` - appends MegaMek's optional revision component to the computed project version, when present.

## Files Changed

- `build.gradle` - artifact version

## Testing

Verified against the real build rather than by inspection. With no revision set, `:megameklab:properties` reports `version: 0.51.01` — unchanged. With `revision=1` set in MegaMek's `Version.properties`, it reports `version: 0.51.01.1`. Reverted and re-checked: back to `0.51.01`.

`:megameklab:compileJava` is green against a MegaMek with a four-part version set.

## What is NOT proven yet

- **MegaMekLab was not launched**, so the version shown in the About dialog and written into saved unit file headers is inferred from `MMLConstants` inheriting `SuiteConstants.VERSION`, not observed. That same inherited value was confirmed in the real MegaMek application on the companion PR.
- **No tests added.** There is no MegaMekLab Java change to regress; the behaviour lives in MegaMek's `Version` and is covered by 26 tests in `VersionTest` on that PR.
- **Setting a revision versions the whole suite**, since all three projects read the one file. For a MegaMek-only release, it should be set on the release branch rather than main.

## Companion PRs

- MegaMek: MegaMek/megamek#8690 (the actual implementation — **merge first**)
- MekHQ: MegaMek/mekhq#9760

All three branches share a name so CI resolves them against each other.
