### PR TITLE
Fix: Armor Tonnage on Armor Type Change

### DIFF
--- a/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
@@ -504,14 +504,14 @@ public class CVStructureTab extends ITab implements CVBuildListener, ArmorAlloca
     @Override
     public void armorTypeChanged(int at, int aTechLevel) {
         if (at != EquipmentType.T_ARMOR_PATCHWORK) {
-            double initialArmor = getTank().getArmorWeight();
+            double initialArmorTonnage = getTank().getArmorWeight();
             UnitUtil.removeISorArmorMounts(getTank(), false);
             UnitUtil.compactCriticalSlots(getTank());
             getTank().setArmorTechLevel(aTechLevel);
             getTank().setArmorType(at);
-            double maxArmor = UnitUtil.getMaximumArmorTonnage(getTank());
-            if (initialArmor > maxArmor) {
-                getTank().setArmorTonnage(maxArmor);
+            double maxArmorTonnage = UnitUtil.getMaximumArmorTonnage(getTank());
+            if (initialArmorTonnage > maxArmorTonnage) {
+                getTank().setArmorTonnage(maxArmorTonnage);
             }
             panArmorAllocation.showPatchwork(false);
             panPatchwork.setVisible(false);

--- a/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
@@ -504,10 +504,15 @@ public class CVStructureTab extends ITab implements CVBuildListener, ArmorAlloca
     @Override
     public void armorTypeChanged(int at, int aTechLevel) {
         if (at != EquipmentType.T_ARMOR_PATCHWORK) {
+            double initialArmor = getTank().getArmorWeight();
             UnitUtil.removeISorArmorMounts(getTank(), false);
             UnitUtil.compactCriticalSlots(getTank());
             getTank().setArmorTechLevel(aTechLevel);
             getTank().setArmorType(at);
+            double maxArmor = UnitUtil.getMaximumArmorTonnage(getTank());
+            if (initialArmor > maxArmor) {
+                getTank().setArmorTonnage(maxArmor);
+            }
             panArmorAllocation.showPatchwork(false);
             panPatchwork.setVisible(false);
         } else {

--- a/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASStructureTab.java
@@ -473,10 +473,15 @@ public class ASStructureTab extends ITab implements AeroBuildListener, ArmorAllo
     @Override
     public void armorTypeChanged(int at, int aTechLevel) {
         if (at != EquipmentType.T_ARMOR_PATCHWORK) {
+            double initialArmorTonnage = getAero().getArmorWeight();
             UnitUtil.removeISorArmorMounts(getAero(), false);
             UnitUtil.compactCriticalSlots(getAero());
             getAero().setArmorTechLevel(aTechLevel);
             getAero().setArmorType(at);
+            double maxArmorTonnage = UnitUtil.getMaximumArmorTonnage(getAero());
+            if (initialArmorTonnage > maxArmorTonnage) {
+                getAero().setArmorTonnage(maxArmorTonnage);
+            }
             panArmorAllocation.showPatchwork(false);
             panPatchwork.setVisible(false);
         } else {

--- a/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/WSStructureTab.java
@@ -367,8 +367,6 @@ public class WSStructureTab extends ITab implements AdvancedAeroBuildListener, A
     public void armorTypeChanged(int at, int aTechLevel) {
         getJumpship().setArmorTechLevel(aTechLevel);
         getJumpship().setArmorType(at);
-        // recalculate tonnage
-        getJumpship().setArmorTonnage(getJumpship().getArmorWeight());
         panArmorAllocation.setFromEntity(getJumpship());
         panSummary.refresh();
         refresh.refreshStatus();

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -1436,8 +1436,13 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
     @Override
     public void armorTypeChanged(int at, int aTechLevel) {
         if (at != EquipmentType.T_ARMOR_PATCHWORK) {
+            double initialArmorTonnage = getMek().getArmorWeight();
             UnitUtil.removeISorArmorMounts(getMek(), false);
             createArmorMountsAndSetArmorType(at, aTechLevel);
+            double maxArmorTonnage = UnitUtil.getMaximumArmorTonnage(getMek());
+            if (initialArmorTonnage > maxArmorTonnage) {
+                getMek().setArmorTonnage(maxArmorTonnage);
+            }
             panArmorAllocation.showPatchwork(false);
             panPatchwork.setVisible(false);
         } else {

--- a/megameklab/src/megameklab/ui/supportVehicle/SVArmorTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVArmorTab.java
@@ -131,12 +131,17 @@ public class SVArmorTab extends ITab implements ArmorAllocationListener {
     @Override
     public void armorTypeChanged(int at, int armorTechLevel) {
         if (at != EquipmentType.T_ARMOR_PATCHWORK) {
+            double initialArmorTonnage = getEntity().getArmorWeight();
             UnitUtil.removeISorArmorMounts(getEntity(), false);
             getEntity().setArmorTechLevel(armorTechLevel);
             getEntity().setArmorType(at);
             ArmorType armor = ArmorType.of(at, TechConstants.isClan(armorTechLevel));
             getEntity().setBARRating(armor.getBAR());
             getEntity().setArmorTechRating(panArmor.getTechRating());
+            double maxArmorTonnage = UnitUtil.getMaximumArmorTonnage(getEntity());
+            if (initialArmorTonnage > maxArmorTonnage) {
+                getEntity().setArmorTonnage(maxArmorTonnage);
+            }
             panArmorAllocation.showPatchwork(false);
             panPatchwork.setVisible(false);
         } else {


### PR DESCRIPTION
Fix armor tonnage on armor type change for CV, SV, BM, AS, and Advanced Aerospace

For CV, SV, BM, and AS, armor tonnage is now set to maximum tonnage on armor type change if the previous armor tonnage is greater than the maximum tonnage

For Advanced Aerospace, armor tonnage is no longer incorrectly set on armor type change

Note for Reviewer: MERGE AFTER https://github.com/MegaMek/megamek/pull/8689