### PR TITLE
Fix: Add Control Systems When CV Trailer Unchecked

### DIFF
--- a/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVStructureTab.java
@@ -638,8 +638,14 @@ public class CVStructureTab extends ITab implements CVBuildListener, ArmorAlloca
     @Override
     public void trailerChanged(boolean trailer) {
         getTank().setTrailer(trailer);
+        if (!trailer) {
+            getTank().setHasNoControlSystems(false);
+        }
         panChassis.setFromEntity(getTank());
         panMovement.setFromEntity(getTank());
+        refresh.refreshSummary();
+        refresh.refreshPreview();
+        refresh.refreshStatus();
     }
 
     @Override


### PR DESCRIPTION
Add control systems when combat vehicle trailer checkbox is unchecked