### PR TITLE
GameRules and shield/charge printing

### DIFF
--- a/megameklab/resources/megameklab/resources/Dialogs.properties
+++ b/megameklab/resources/megameklab/resources/Dialogs.properties
@@ -143,6 +143,10 @@ ConfigurationDialog.chkShowAvailabilityTab.tooltip=<html>Shows an Availability t
   See docs/Customization/RAT and Force Generator Stuff/custom-unit-availability.txt for how to use it.</html>
 ConfigurationDialog.startup.text=MML Startup:
 ConfigurationDialog.startup.tooltip=<html>Depending on the startup type selected, MML will start in the main menu or, alternatively, directly load the most recent unit or start with a new unit instead of the main menu, or restore all of your opened tabs.<br>Restoring tabs restores the state of the entities as they were in the editor, not as you saved them!</html>
+ConfigurationDialog.gameRules.text=Game Rules:
+ConfigurationDialog.gameRules.tooltip=<html>Selects the rules used for MegaMekLab calculations and generated record sheets.<br>This setting takes effect immediately after selecting OK.</html>
+ConfigurationDialog.gameRules.core=Core Rules (2026)
+ConfigurationDialog.gameRules.totalWarfare=Total Warfare
 ConfigurationDialog.mekChassis.text=Mek Chassis Arrangement:
 ConfigurationDialog.mekChassis.tooltip=Meks with a Clan and an IS chassis name will print their chassis in the selected arrangement. Meks with no clan chassis name will always just print their chassis.
 ConfigurationDialog.cbMulOpenBehaviour.text=MUL file open behaviour:

--- a/megameklab/src/megameklab/printing/IntrinsicPhysicalInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/IntrinsicPhysicalInventoryEntry.java
@@ -39,10 +39,12 @@ import java.util.List;
 
 import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.equipment.enums.MiscTypeFlag;
+import megamek.common.game.Game;
 import megamek.common.units.Entity;
 import megamek.common.units.LandAirMek;
 import megamek.common.units.Mek;
 import megamek.common.units.ProtoMek;
+import megameklab.util.CConfig;
 
 public record IntrinsicPhysicalInventoryEntry(String name, String location, String damage, String mod, boolean optional)
       implements InventoryEntry {
@@ -103,8 +105,7 @@ public record IntrinsicPhysicalInventoryEntry(String name, String location, Stri
 
             return new ArrayList<>(List.of(e("Frenzy", DASH, String.valueOf(dmg), "*")));
         } else if (entity.canCharge()) {
-            return new ArrayList<>(List.of(e("Charge", DASH, doubleFormat.format(entity.getWeight() / 10) + "/hex",
-                  "*", true)));
+            return new ArrayList<>(List.of(e("Charge", DASH, formatChargeDamage(entity, 1, 0), "*", true)));
         }
 
         return new ArrayList<>();
@@ -130,8 +131,12 @@ public record IntrinsicPhysicalInventoryEntry(String name, String location, Stri
                 baseDmg /= 2;
             }
 
-            var lDmg = formatDamage(hasLLowerActuator ? baseDmg : Math.floor(baseDmg / 2), hasTsm);
-            var rDmg = formatDamage(hasRLowerActuator ? baseDmg : Math.floor(baseDmg / 2), hasTsm);
+            var leftBaseDamage = baseDmg
+                  + Game.rulesManager.getRulesPhysical().getShieldDamageBoost(mek, Mek.LOC_LEFT_ARM);
+            var rightBaseDamage = baseDmg
+                  + Game.rulesManager.getRulesPhysical().getShieldDamageBoost(mek, Mek.LOC_RIGHT_ARM);
+            var lDmg = formatDamage(hasLLowerActuator ? leftBaseDamage : Math.floor(leftBaseDamage / 2), hasTsm);
+            var rDmg = formatDamage(hasRLowerActuator ? rightBaseDamage : Math.floor(rightBaseDamage / 2), hasTsm);
 
             int mod;
             boolean explicitZero;
@@ -219,17 +224,9 @@ public record IntrinsicPhysicalInventoryEntry(String name, String location, Stri
 
         // Charge
         {
-            var baseDmg = mek.getWeight() / 10;
-            if (mek.hasMisc(MiscTypeFlag.F_RAM_PLATE)) {
-                baseDmg *= 1.5;
-            }
+            double damageMultiplier = mek.hasMisc(MiscTypeFlag.F_RAM_PLATE) ? 1.5 : 1;
             var spikesDmg = mek.getMiscEquipment(MiscTypeFlag.F_SPIKES).size() * 2;
-            String dmg;
-            if (spikesDmg > 0) {
-                dmg = "%s/hex+%d".formatted(doubleFormat.format(baseDmg), spikesDmg);
-            } else {
-                dmg = "%s/hex".formatted(doubleFormat.format(baseDmg));
-            }
+            String dmg = formatChargeDamage(mek, damageMultiplier, spikesDmg);
             entries.add(e("Charge", DASH, dmg, "Vs", true));
         }
         if (mek instanceof LandAirMek) {
@@ -248,6 +245,16 @@ public record IntrinsicPhysicalInventoryEntry(String name, String location, Stri
         }
 
         return entries;
+    }
+
+    private static String formatChargeDamage(Entity entity, double damageMultiplier, int spikesDamage) {
+        if (CConfig.usesTotalWarfareRules()) {
+            String damage = doubleFormat.format(entity.getWeight() / 10 * damageMultiplier) + "/hex";
+            return spikesDamage > 0 ? damage + "+" + spikesDamage : damage;
+        }
+
+        String damage = doubleFormat.format(entity.getWeight() / 5 * damageMultiplier) + "×(TMM+1)";
+        return spikesDamage > 0 ? damage + "+" + spikesDamage : damage;
     }
 
     /**

--- a/megameklab/src/megameklab/printing/IntrinsicPhysicalInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/IntrinsicPhysicalInventoryEntry.java
@@ -131,10 +131,12 @@ public record IntrinsicPhysicalInventoryEntry(String name, String location, Stri
                 baseDmg /= 2;
             }
 
-            var leftBaseDamage = baseDmg
-                  + Game.rulesManager.getRulesPhysical().getShieldDamageBoost(mek, Mek.LOC_LEFT_ARM);
-            var rightBaseDamage = baseDmg
-                  + Game.rulesManager.getRulesPhysical().getShieldDamageBoost(mek, Mek.LOC_RIGHT_ARM);
+            var leftBaseDamage = baseDmg;
+            var rightBaseDamage = baseDmg;
+            if (mek.hasShield()) {
+                leftBaseDamage += Game.rulesManager.getRulesPhysical().getShieldDamageBoost(mek, Mek.LOC_LEFT_ARM);
+                rightBaseDamage += Game.rulesManager.getRulesPhysical().getShieldDamageBoost(mek, Mek.LOC_RIGHT_ARM);
+            }
             var lDmg = formatDamage(hasLLowerActuator ? leftBaseDamage : Math.floor(leftBaseDamage / 2), hasTsm);
             var rDmg = formatDamage(hasRLowerActuator ? rightBaseDamage : Math.floor(rightBaseDamage / 2), hasTsm);
 

--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -372,7 +372,8 @@ public class InventoryWriter {
             ) {
                 continue;
             }
-            StandardInventoryEntry entry = new StandardInventoryEntry(m);
+            // When Punch rows are hidden, let the shield row carry Core's shield-bash modifier instead.
+            StandardInventoryEntry entry = new StandardInventoryEntry(m, includeIntrinsicPhysicals);
             // If the unit is a Mek, we check for the merge equipment option.
             // If is not a mek, we always merge if possible.
             if (this.mergeInventoryAllowed) {

--- a/megameklab/src/megameklab/printing/InventoryWriter.java
+++ b/megameklab/src/megameklab/printing/InventoryWriter.java
@@ -1041,9 +1041,7 @@ public class InventoryWriter {
                     rowGroup.setAttributeNS(null, "iPhysAtk", line.getNameField(0).toLowerCase());
                 }
                 if (line instanceof StandardInventoryEntry sie) {
-                    if (sie.getMounted().isSquadSupportWeapon()) {
-                        rowGroup.setAttributeNS(null, "SSW", "1");
-                    }
+                    writeInventoryMountNameMetadata(rowGroup, sie.getMounted());
                 }
             }
             canvas.appendChild(rowGroup);
@@ -1273,6 +1271,29 @@ public class InventoryWriter {
             }
         }
         return yPosition;
+    }
+
+    private void writeInventoryMountNameMetadata(Element rowGroup, Mounted<?> mount) {
+        setBooleanAttribute(rowGroup, "rearMounted", mount.isRearMounted());
+        setBooleanAttribute(rowGroup, "mekTurretMounted", mount.isMekTurretMounted());
+        setBooleanAttribute(rowGroup, "sponsonTurretMounted", mount.isSponsonTurretMounted());
+        setBooleanAttribute(rowGroup, "pintleTurretMounted", mount.isPintleTurretMounted());
+        setBooleanAttribute(rowGroup, "SSW", mount.isSquadSupportWeapon());
+        setBooleanAttribute(rowGroup, "dwpMounted", mount.isDWPMounted());
+        if (mount.getBaMountLoc() == BattleArmor.MOUNT_LOC_BODY) {
+            rowGroup.setAttributeNS(null, "baMountLoc", "body");
+        } else if (mount.getBaMountLoc() == BattleArmor.MOUNT_LOC_TURRET) {
+            rowGroup.setAttributeNS(null, "baMountLoc", "turret");
+        }
+        if (mount.getSize() != 1) {
+            rowGroup.setAttributeNS(null, "mountSize", String.valueOf(mount.getSize()));
+        }
+    }
+
+    private void setBooleanAttribute(Element element, String name, boolean value) {
+        if (value) {
+            element.setAttributeNS(null, name, "1");
+        }
     }
 
     private double printCapitalHeader(double currY) {

--- a/megameklab/src/megameklab/printing/SVGMassPrinter.java
+++ b/megameklab/src/megameklab/printing/SVGMassPrinter.java
@@ -2416,7 +2416,17 @@ public class SVGMassPrinter {
                     case "--save-unit-files" -> SKIP_UNIT_FILES = !parseBool(inlineValue);
                     case "--save-calculations" -> SKIP_DETAILED_CALCULATIONS = !parseBool(inlineValue);
                     case "--calculations-as-text" -> EXPORT_CALCULATIONS_AS_TEXT = parseBool(inlineValue);
-                    case "--rules" -> RULES_SYSTEM = parseRulesSystem(inlineValue != null ? inlineValue : args[++i]);
+                    case "--rules" -> {
+                        String rulesValue = inlineValue;
+                        if (rulesValue == null) {
+                            if (i + 1 >= args.length) {
+                                throw new IllegalArgumentException("missing value for argument --rules");
+                            }
+                            i++;
+                            rulesValue = args[i];
+                        }
+                        RULES_SYSTEM = parseRulesSystem(rulesValue);
+                    }
                     case "--units", "--unit" -> {
                         unitOverrideRequested = true;
                         if (inlineValue != null) {

--- a/megameklab/src/megameklab/printing/SVGMassPrinter.java
+++ b/megameklab/src/megameklab/printing/SVGMassPrinter.java
@@ -791,7 +791,7 @@ public class SVGMassPrinter {
                         }
                     }
                     if (mtype.hasFlag(MiscType.F_CLUB) || mtype.hasFlag(MiscType.F_HAND_WEAPON) || mtype.hasFlag(
-                          MiscType.F_TALON)) {
+                          MiscType.F_TALON) || mtype.hasFlag(MiscType.F_SHIELD)) {
                         if (mtype.isVibroblade()) {
                             // manually set vibros to active to get correct damage
                             m.setMode(1);
@@ -982,21 +982,23 @@ public class SVGMassPrinter {
           private void addPhysicalWeapon(Map<String, ExportInventoryEntry> list, Entity entity, MiscMounted mounted,
               String location, int locId) {
             MiscType type = mounted.getType();
-            String damage;
-            String maxDamage;
-            if (type.hasFlag(MiscType.F_TALON)) {
-                damage = Integer.toString(KickAttackAction.getDamageFor(entity, Mek.LOC_LEFT_LEG, false));
-                maxDamage = damage;
-            } else if (type.hasAnyFlag(MiscTypeFlag.S_CLAW, MiscTypeFlag.S_CLAW_THB)) {
-                damage = Integer.toString((int) Math.ceil(entity.getWeight() / 7.0));
-                maxDamage = damage;
-            } else {
-                damage = Integer.toString(ClubAttackAction.getDamageFor(entity, (MiscMounted) mounted, false, false));
-                if ((entity instanceof BipedMek) && ((BipedMek) entity).canZweihander()) {
-                    maxDamage = Integer.toString(ClubAttackAction.getDamageFor(entity, (MiscMounted) mounted, false,
-                          true));
-                } else {
+            String damage = null;
+            String maxDamage = null;
+            // Shields remain physical components for export, but are not standalone attacks under Core rules.
+            if (!type.hasFlag(MiscType.F_SHIELD)) {
+                if (type.hasFlag(MiscType.F_TALON)) {
+                    damage = Integer.toString(KickAttackAction.getDamageFor(entity, Mek.LOC_LEFT_LEG, false));
                     maxDamage = damage;
+                } else if (type.hasAnyFlag(MiscTypeFlag.S_CLAW, MiscTypeFlag.S_CLAW_THB)) {
+                    damage = Integer.toString((int) Math.ceil(entity.getWeight() / 7.0));
+                    maxDamage = damage;
+                } else {
+                    damage = Integer.toString(ClubAttackAction.getDamageFor(entity, mounted, false, false));
+                    if ((entity instanceof BipedMek) && ((BipedMek) entity).canZweihander()) {
+                        maxDamage = Integer.toString(ClubAttackAction.getDamageFor(entity, mounted, false, true));
+                    } else {
+                        maxDamage = damage;
+                    }
                 }
             }
             final String name = type.getShortName();

--- a/megameklab/src/megameklab/printing/SVGMassPrinter.java
+++ b/megameklab/src/megameklab/printing/SVGMassPrinter.java
@@ -791,7 +791,7 @@ public class SVGMassPrinter {
                         }
                     }
                     if (mtype.hasFlag(MiscType.F_CLUB) || mtype.hasFlag(MiscType.F_HAND_WEAPON) || mtype.hasFlag(
-                          MiscType.F_TALON) || mtype.hasFlag(MiscType.F_SHIELD)) {
+                          MiscType.F_TALON)) {
                         if (mtype.isVibroblade()) {
                             // manually set vibros to active to get correct damage
                             m.setMode(1);

--- a/megameklab/src/megameklab/printing/SVGMassPrinter.java
+++ b/megameklab/src/megameklab/printing/SVGMassPrinter.java
@@ -2404,11 +2404,11 @@ public class SVGMassPrinter {
                         System.exit(0);
                     }
                     case "-o", "--output", "--root" -> {
-                        ROOT_FOLDER = inlineValue != null ? inlineValue : args[++i];
+                        ROOT_FOLDER = inlineValue != null ? inlineValue : requireArgumentValue(args, ++i);
                     }
-                    case "--sheets-dir" -> SHEETS_DIR = inlineValue != null ? inlineValue : args[++i];
-                    case "--unit-files-dir" -> UNIT_FILES_DIR = inlineValue != null ? inlineValue : args[++i];
-                    case "--typeface" -> TYPEFACE = inlineValue != null ? inlineValue : args[++i];
+                    case "--sheets-dir" -> SHEETS_DIR = inlineValue != null ? inlineValue : requireArgumentValue(args, ++i);
+                    case "--unit-files-dir" -> UNIT_FILES_DIR = inlineValue != null ? inlineValue : requireArgumentValue(args, ++i);
+                    case "--typeface" -> TYPEFACE = inlineValue != null ? inlineValue : requireArgumentValue(args, ++i);
                     case "--skip-svg" -> SKIP_SVG = parseBool(inlineValue);
                     case "--skip-units" -> SKIP_UNITS = parseBool(inlineValue);
                     case "--skip-equipment" -> SKIP_EQUIPMENT = parseBool(inlineValue);
@@ -2419,11 +2419,8 @@ public class SVGMassPrinter {
                     case "--rules" -> {
                         String rulesValue = inlineValue;
                         if (rulesValue == null) {
-                            if (i + 1 >= args.length) {
-                                throw new IllegalArgumentException("missing value for argument --rules");
-                            }
                             i++;
-                            rulesValue = args[i];
+                            rulesValue = requireArgumentValue(args, i);
                         }
                         RULES_SYSTEM = parseRulesSystem(rulesValue);
                     }
@@ -2434,7 +2431,7 @@ public class SVGMassPrinter {
                         }
                         // Consume all following non-option tokens as file/directory paths.
                         while ((i + 1 < args.length) && !args[i + 1].startsWith("-")) {
-                            collectUnitFiles(args[++i]);
+                            collectUnitFiles(requireArgumentValue(args, ++i));
                         }
                     }
                     default -> {
@@ -2454,6 +2451,13 @@ public class SVGMassPrinter {
             }
         }
         return true;
+    }
+
+    private static String requireArgumentValue(String[] args, int index) {
+        if (index >= args.length) {
+            throw new ArrayIndexOutOfBoundsException();
+        }
+        return args[index];
     }
 
     private static boolean parseBool(String value) {

--- a/megameklab/src/megameklab/printing/SVGMassPrinter.java
+++ b/megameklab/src/megameklab/printing/SVGMassPrinter.java
@@ -151,6 +151,7 @@ public class SVGMassPrinter {
     private static boolean SKIP_DETAILED_CALCULATIONS = true; // Set to true to skip the detailed BV/Cost calculations
     private static final boolean EXPORT_CALCULATION_DETAILS_TO_FILES = true; // Set to true to not embed the detailed BV/Cost calculations into the units.json but in a subfolder keyed by name
     private static boolean EXPORT_CALCULATIONS_AS_TEXT = false;
+    private static String RULES_SYSTEM = OptionsConstants.RULES_CORE;
 
     private static final MMLogger logger = MMLogger.create(SVGMassPrinter.class);
     private static final int SUSTAINED_TURNS = 10; // Number of turns for sustained DPT calculation
@@ -984,8 +985,13 @@ public class SVGMassPrinter {
             MiscType type = mounted.getType();
             String damage = null;
             String maxDamage = null;
-            // Shields remain physical components for export, but are not standalone attacks under Core rules.
-            if (!type.hasFlag(MiscType.F_SHIELD)) {
+            if (type.hasFlag(MiscType.F_SHIELD)) {
+                // Core treats shields as punch modifiers. Total Warfare retains the historical standalone value.
+                if (CConfig.usesTotalWarfareRules()) {
+                    damage = Integer.toString(mounted.getDamageAbsorption(entity, locId));
+                    maxDamage = damage;
+                }
+            } else {
                 if (type.hasFlag(MiscType.F_TALON)) {
                     damage = Integer.toString(KickAttackAction.getDamageFor(entity, Mek.LOC_LEFT_LEG, false));
                     maxDamage = damage;
@@ -2410,6 +2416,7 @@ public class SVGMassPrinter {
                     case "--save-unit-files" -> SKIP_UNIT_FILES = !parseBool(inlineValue);
                     case "--save-calculations" -> SKIP_DETAILED_CALCULATIONS = !parseBool(inlineValue);
                     case "--calculations-as-text" -> EXPORT_CALCULATIONS_AS_TEXT = parseBool(inlineValue);
+                    case "--rules" -> RULES_SYSTEM = parseRulesSystem(inlineValue != null ? inlineValue : args[++i]);
                     case "--units", "--unit" -> {
                         unitOverrideRequested = true;
                         if (inlineValue != null) {
@@ -2447,6 +2454,14 @@ public class SVGMassPrinter {
             case "true", "1", "yes", "on" -> true;
             case "false", "0", "no", "off" -> false;
             default -> throw new IllegalArgumentException("expected a boolean, got '" + value + "'");
+        };
+    }
+
+    private static String parseRulesSystem(String value) {
+        return switch (value.toLowerCase(Locale.ROOT)) {
+            case "core", "core2026", "core-rules" -> OptionsConstants.RULES_CORE;
+            case "tw", "total-warfare" -> OptionsConstants.RULES_TW;
+            default -> throw new IllegalArgumentException("expected 'core' or 'tw', got '" + value + "'");
         };
     }
 
@@ -2554,6 +2569,7 @@ public class SVGMassPrinter {
                 --save-unit-files[=bool]      Enable BLK/MTF re-save (inverse of --skip-unit-files)
                 --save-calculations[=bool]    Export calculation details (default: %s)
                 --calculations-as-text[=bool] Export calculation details as .txt rather than structured .json (default: %s)
+                --rules <core|tw>              Rules used for sheets and metadata (default: core)
                 --units <file|dir> [...]      Export only these .blk/.mtf files (or all such files in a
                                               directory, scanned recursively) instead of the whole unit cache.
                                               May be repeated; accepts multiple paths.
@@ -2640,6 +2656,8 @@ public class SVGMassPrinter {
         Locale.setDefault(new MMLOptions().getLocale());
         EquipmentType.initializeTypes();
         CConfig.load();
+        CConfig.setParam(CConfig.MISC_RULES_SYSTEM, RULES_SYSTEM);
+        CConfig.applyRulesSystem();
         CConfig.setParam(CConfig.RS_FONT, TYPEFACE);
 
         int processedCount = 0;

--- a/megameklab/src/megameklab/printing/StandardInventoryEntry.java
+++ b/megameklab/src/megameklab/printing/StandardInventoryEntry.java
@@ -53,6 +53,7 @@ import megamek.common.equipment.Sensor;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.equipment.WeaponType;
 import megamek.common.equipment.enums.MiscTypeFlag;
+import megamek.common.game.Game;
 import megamek.common.options.IOption;
 import megamek.common.options.WeaponQuirks;
 import megamek.common.units.Entity;
@@ -90,6 +91,7 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
     private final boolean hasArtemisV;
     private final boolean hasApollo;
     private final boolean hasCapacitor;
+    private final int shieldDamageModifier;
     // Saved as member fields for hash and equals
     private final String name;
     private final String location;
@@ -138,6 +140,11 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
     }
 
     public StandardInventoryEntry(Mounted<?> m) {
+        this(m, RecordSheetOptions.IntrinsicPhysicalAttacksStyle.EQUIPMENT);
+    }
+
+    StandardInventoryEntry(Mounted<?> m,
+          RecordSheetOptions.IntrinsicPhysicalAttacksStyle intrinsicPhysicalAttacks) {
         this.mount = m;
         name = formatName();
         location = formatLocation();
@@ -153,6 +160,10 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
         hasArtemisV = hasLinkedEquipment(m, MiscType.F_ARTEMIS_V);
         hasApollo = hasLinkedEquipment(m, MiscType.F_APOLLO);
         hasCapacitor = hasLinkedEquipment(m, MiscType.F_PPC_CAPACITOR);
+        shieldDamageModifier = intrinsicPhysicalAttacks.equals(RecordSheetOptions.IntrinsicPhysicalAttacksStyle.NONE)
+              && m.getType().hasFlag(MiscType.F_SHIELD)
+              ? Game.rulesManager.getRulesPhysical().getShieldDamageBoost(m.getEntity(), m.getLocation())
+              : 0;
         ranges = setRanges();
     }
 
@@ -547,6 +558,9 @@ public class StandardInventoryEntry implements InventoryEntry, Comparable<Standa
             // TODO : corrected to allow capacity to be assigned
             return "";
         } else if (row == 0) {
+            if (shieldDamageModifier > 0) {
+                return "%+d".formatted(shieldDamageModifier);
+            }
             return StringUtils.getEquipmentInfo(mount.getEntity(), mount);
         } else if (row == 1 && hasCapacitor) {
             return StringUtils.getEquipmentInfo(mount.getEntity(), mount, true);

--- a/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
+++ b/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
@@ -107,10 +107,12 @@ public class PhysicalAttacks extends ReferenceTable {
         int left = countActuators(entity, Mek.LOC_LEFT_ARM);
         int right = countActuators(entity, Mek.LOC_RIGHT_ARM);
         int baseDamage = (int) Math.ceil(entity.getWeight() / 10.0);
-        int leftDamage = baseDamage
-              + Game.rulesManager.getRulesPhysical().getShieldDamageBoost(entity, Mek.LOC_LEFT_ARM);
-        int rightDamage = baseDamage
-              + Game.rulesManager.getRulesPhysical().getShieldDamageBoost(entity, Mek.LOC_RIGHT_ARM);
+        int leftDamage = baseDamage;
+        int rightDamage = baseDamage;
+        if (entity.hasShield()) {
+            leftDamage += Game.rulesManager.getRulesPhysical().getShieldDamageBoost(entity, Mek.LOC_LEFT_ARM);
+            rightDamage += Game.rulesManager.getRulesPhysical().getShieldDamageBoost(entity, Mek.LOC_RIGHT_ARM);
+        }
         boolean hasTSM = entity.hasWorkingMisc(MiscType.F_TSM);
         if ((left == right) && (leftDamage == rightDamage)) {
             addPunchAttack(bundle.getString("punch"), left, leftDamage, hasTSM);

--- a/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
+++ b/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
@@ -155,8 +155,6 @@ public class PhysicalAttacks extends ReferenceTable {
                     logger.error("Unknown hand weapon {}!", mounted.getName());
                     addRow(mounted.getName(), "???", StringUtils.getEquipmentInfo(entity, mounted));
                 }
-            } else if (mounted.getType().hasFlag(MiscType.F_SHIELD)) {
-                addRow(mounted.getName(), "", StringUtils.getEquipmentInfo(entity, mounted));
             }
         }
     }

--- a/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
+++ b/megameklab/src/megameklab/printing/reference/PhysicalAttacks.java
@@ -36,6 +36,7 @@ import megamek.common.actions.ClubAttackAction;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.enums.MiscTypeFlag;
+import megamek.common.game.Game;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
 import megamek.common.units.QuadMek;
@@ -106,12 +107,16 @@ public class PhysicalAttacks extends ReferenceTable {
         int left = countActuators(entity, Mek.LOC_LEFT_ARM);
         int right = countActuators(entity, Mek.LOC_RIGHT_ARM);
         int baseDamage = (int) Math.ceil(entity.getWeight() / 10.0);
+        int leftDamage = baseDamage
+              + Game.rulesManager.getRulesPhysical().getShieldDamageBoost(entity, Mek.LOC_LEFT_ARM);
+        int rightDamage = baseDamage
+              + Game.rulesManager.getRulesPhysical().getShieldDamageBoost(entity, Mek.LOC_RIGHT_ARM);
         boolean hasTSM = entity.hasWorkingMisc(MiscType.F_TSM);
-        if (left == right) {
-            addPunchAttack(bundle.getString("punch"), left, baseDamage, hasTSM);
+        if ((left == right) && (leftDamage == rightDamage)) {
+            addPunchAttack(bundle.getString("punch"), left, leftDamage, hasTSM);
         } else {
-            addPunchAttack(bundle.getString("punch") + " (LA)", left, baseDamage, hasTSM);
-            addPunchAttack(bundle.getString("punch") + " (RA)", right, baseDamage, hasTSM);
+            addPunchAttack(bundle.getString("punch") + " (LA)", left, leftDamage, hasTSM);
+            addPunchAttack(bundle.getString("punch") + " (RA)", right, rightDamage, hasTSM);
         }
     }
 

--- a/megameklab/src/megameklab/ui/combatVehicle/CVWeaponView.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVWeaponView.java
@@ -306,8 +306,8 @@ public class CVWeaponView extends IView implements ActionListener, MouseListener
                 } else if (weapon instanceof ArtilleryWeapon) {
                     masterArtilleryWeaponList.add(eq);
                 }
-            } else if ((eq instanceof MiscType) && (eq.hasFlag(MiscType.F_CLUB) || eq.hasFlag(MiscType.F_HAND_WEAPON))
-                  && eq.hasFlag(MiscType.F_TALON) || eq.hasFlag(MiscType.F_SHIELD)) {
+            } else if ((eq instanceof MiscType) && (eq.hasFlag(MiscType.F_CLUB) || eq.hasFlag(MiscType.F_HAND_WEAPON) || eq.hasFlag(MiscType.F_SHIELD))
+                  && eq.hasFlag(MiscType.F_TALON)) {
                 if (eq.hasFlag(MiscType.F_CLUB)
                       && (eq.hasAnyFlag(MiscTypeFlag.S_CLUB, MiscTypeFlag.S_TREE_CLUB))) {
                     continue;

--- a/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/MiscSettingsPanel.java
@@ -51,6 +51,7 @@ import megamek.client.ui.comboBoxes.MMComboBox;
 import megamek.client.ui.dialogs.buttonDialogs.CommonSettingsDialog;
 import megamek.client.ui.dialogs.helpDialogs.HelpDialog;
 import megamek.common.preference.PreferenceManager;
+import megamek.common.options.OptionsConstants;
 import megamek.logging.MMLogger;
 import megameklab.ui.MMLStartUp;
 import megameklab.ui.MulDndBehaviour;
@@ -66,6 +67,8 @@ public class MiscSettingsPanel extends JPanel {
     private static final ResourceBundle resources = ResourceBundle.getBundle("megameklab.resources.Dialogs");
 
     private final MMComboBox<MMLStartUp> startUpMMComboBox = new MMComboBox<>("StartUp", MMLStartUp.values());
+    private final MMComboBox<String> gameRulesComboBox = new MMComboBox<>("Game Rules",
+          new String[] { OptionsConstants.RULES_CORE, OptionsConstants.RULES_TW });
     private final JCheckBox chkSummaryFormatTRO = new JCheckBox();
     private final JCheckBox chkApplicationExitPrompt = new JCheckBox();
     private final JCheckBox chkSkipSavePrompts = new JCheckBox();
@@ -88,6 +91,17 @@ public class MiscSettingsPanel extends JPanel {
         startUpLine.add(startUpLabel);
         startUpLine.add(Box.createHorizontalStrut(5));
         startUpLine.add(startUpMMComboBox);
+
+        gameRulesComboBox.setRenderer(miscComboBoxRenderer);
+        gameRulesComboBox.setSelectedItem(CConfig.getRulesSystem());
+        gameRulesComboBox.setToolTipText(resources.getString("ConfigurationDialog.gameRules.tooltip"));
+        JLabel gameRulesLabel = new JLabel(resources.getString("ConfigurationDialog.gameRules.text"));
+        gameRulesLabel.setToolTipText(resources.getString("ConfigurationDialog.gameRules.tooltip"));
+
+        JPanel gameRulesLine = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        gameRulesLine.add(gameRulesLabel);
+        gameRulesLine.add(Box.createHorizontalStrut(5));
+        gameRulesLine.add(gameRulesComboBox);
 
         cbMulOpenBehaviour.setRenderer(miscComboBoxRenderer);
         cbMulOpenBehaviour.setToolTipText(resources.getString("ConfigurationDialog.cbMulOpenBehaviour.tooltip"));
@@ -170,6 +184,7 @@ public class MiscSettingsPanel extends JPanel {
 
         JPanel gridPanel = new JPanel(new SpringLayout());
         gridPanel.add(startUpLine);
+        gridPanel.add(gameRulesLine);
         gridPanel.add(userDirLine);
         gridPanel.add(mulOpenLine);
         gridPanel.add(chkApplicationExitPrompt);
@@ -179,7 +194,7 @@ public class MiscSettingsPanel extends JPanel {
         gridPanel.add(chkShowAvailabilityTab);
         gridPanel.add(scaleLine);
 
-        SpringUtilities.makeCompactGrid(gridPanel, 9, 1, 0, 0, 15, 10);
+        SpringUtilities.makeCompactGrid(gridPanel, 10, 1, 0, 0, 15, 10);
         gridPanel.setBorder(new EmptyBorder(20, 30, 20, 30));
         setLayout(new FlowLayout(FlowLayout.LEFT));
         add(gridPanel);
@@ -192,6 +207,9 @@ public class MiscSettingsPanel extends JPanel {
         miscSettings.put(CConfig.MISC_SKIP_SAFETY_PROMPTS, String.valueOf(chkSkipSavePrompts.isSelected()));
         miscSettings.put(CConfig.MISC_INCLUDE_LICENSE, String.valueOf(chkIncludeLicense.isSelected()));
         miscSettings.put(CConfig.MISC_SHOW_AVAILABILITY_TAB, String.valueOf(chkShowAvailabilityTab.isSelected()));
+        String selectedRules = gameRulesComboBox.getSelectedItem();
+        miscSettings.put(CConfig.MISC_RULES_SYSTEM,
+              selectedRules == null ? OptionsConstants.RULES_CORE : selectedRules);
         MMLStartUp startUp = startUpMMComboBox.getSelectedItem() == null
               ? MMLStartUp.SPLASH_SCREEN
               : startUpMMComboBox.getSelectedItem();
@@ -226,6 +244,10 @@ public class MiscSettingsPanel extends JPanel {
             return su.getDisplayName();
         } else if (value instanceof MulDndBehaviour mdb) {
             return mdb.getDisplayName();
+        } else if (OptionsConstants.RULES_CORE.equals(value)) {
+            return resources.getString("ConfigurationDialog.gameRules.core");
+        } else if (OptionsConstants.RULES_TW.equals(value)) {
+            return resources.getString("ConfigurationDialog.gameRules.totalWarfare");
         }
         return "";
     }

--- a/megameklab/src/megameklab/ui/dialog/settings/SettingsDialog.java
+++ b/megameklab/src/megameklab/ui/dialog/settings/SettingsDialog.java
@@ -95,6 +95,7 @@ public class SettingsDialog extends AbstractMMLButtonDialog {
         techSettings.getTechSettings().forEach(CConfig::setParam);
         exportSettingsPanel.getRecordSheetSettings().forEach(CConfig::setParam);
         miscSettingsPanel.getMiscSettings().forEach(CConfig::setParam);
+        CConfig.applyRulesSystem();
         CConfig.saveConfig();
         PreferenceManager.getClientPreferences().setUserDir(miscSettingsPanel.getUserDir());
         if (miscSettingsPanel.guiScale() != GUIPreferences.getInstance().getGUIScale()) {

--- a/megameklab/src/megameklab/util/CConfig.java
+++ b/megameklab/src/megameklab/util/CConfig.java
@@ -54,6 +54,10 @@ import javax.swing.JFrame;
 
 import megamek.common.Configuration;
 import megamek.common.enums.WeaponSortOrder;
+import megamek.common.game.Game;
+import megamek.common.options.OptionsConstants;
+import megamek.common.rules.core.CoreRulesManager;
+import megamek.common.rules.totalwarfare.TWRulesManager;
 import megamek.logging.MMLogger;
 import megameklab.printing.MekChassisArrangement;
 import megameklab.printing.PrintRecordSheet;
@@ -90,6 +94,7 @@ public final class CConfig {
     public static final String MISC_MUL_OPEN_BEHAVIOUR = "mulDndBehaviour";
     public static final String MISC_INCLUDE_LICENSE = "includeLicense";
     public static final String MISC_SHOW_AVAILABILITY_TAB = "showAvailabilityTab";
+    public static final String MISC_RULES_SYSTEM = OptionsConstants.RULES_SYSTEM;
 
     public static final String GUI_PLAF = "lookAndFeel";
     public static final String GUI_COLOR_WEAPONS = "Weapons";
@@ -187,6 +192,7 @@ public final class CConfig {
         defaults.setProperty(MISC_SKIP_SAFETY_PROMPTS, Boolean.toString(false));
         defaults.setProperty(MISC_APPLICATION_EXIT_PROMPT, Boolean.toString(true));
         defaults.setProperty(MISC_INCLUDE_LICENSE, Boolean.toString(false));
+        defaults.setProperty(MISC_RULES_SYSTEM, OptionsConstants.RULES_CORE);
         // On by default so the Force Generator Availability tab is visible; it can be hidden from Options - General.
         // The toggle is read when an editor is built, so a change takes effect on the next unit opened, not live.
         defaults.setProperty(MISC_SHOW_AVAILABILITY_TAB, Boolean.toString(true));
@@ -273,6 +279,7 @@ public final class CConfig {
         } catch (Exception ex) {
             logger.error("", ex);
         }
+        applyRulesSystem();
     }
 
     /**
@@ -587,6 +594,27 @@ public final class CConfig {
         return MMLStartUp.parse(CConfig.getParam(CConfig.MISC_STARTUP));
     }
 
+    /**
+     * Returns the selected game rules system. Unknown or missing values use MegaMek's default Core rules.
+     */
+    public static String getRulesSystem() {
+        return OptionsConstants.RULES_TW.equals(getParam(MISC_RULES_SYSTEM))
+              ? OptionsConstants.RULES_TW
+              : OptionsConstants.RULES_CORE;
+    }
+
+    /** Applies MML's selected game rules to MegaMek's global rules manager. */
+    public static void applyRulesSystem() {
+        Game.rulesManager = OptionsConstants.RULES_TW.equals(getRulesSystem())
+              ? new TWRulesManager()
+              : new CoreRulesManager();
+    }
+
+    /** @return whether MML is currently calculating with Total Warfare rules. */
+    public static boolean usesTotalWarfareRules() {
+        return Game.rulesManager instanceof TWRulesManager;
+    }
+
     public static MekChassisArrangement getMekNameArrangement() {
         return MekChassisArrangement.parse(CConfig.getParam(CConfig.RS_MEK_NAMES));
     }
@@ -689,6 +717,7 @@ public final class CConfig {
     }
 
     private static void applyImportedSettings(MenuBarOwner menuBarOwner) {
+        applyRulesSystem();
         menuBarOwner.changeTheme(getParam(GUI_PLAF));
         menuBarOwner.refreshAll();
     }

--- a/megameklab/src/megameklab/util/StringUtils.java
+++ b/megameklab/src/megameklab/util/StringUtils.java
@@ -282,8 +282,11 @@ public class StringUtils {
                 info = info.substring(0, info.length() - 1) + "]";
 
             }
+        } else if ((mount instanceof MiscMounted) && mount.getType().hasFlag(MiscType.F_SHIELD)) {
+            // Shields modify punch attacks under Core rules; they are not standalone physical attacks.
+            info = "";
         } else if ((mount instanceof MiscMounted) && (mount.getType().hasFlag(MiscType.F_CLUB)
-              || mount.getType().hasFlag(MiscType.F_HAND_WEAPON) || mount.getType().hasFlag(MiscType.F_SHIELD))) {
+              || mount.getType().hasFlag(MiscType.F_HAND_WEAPON))) {
             if (((MiscType) mount.getType()).isVibroblade()) {
                 // manually set vibro to active to get correct damage
                 mount.setMode(1);

--- a/megameklab/src/megameklab/util/StringUtils.java
+++ b/megameklab/src/megameklab/util/StringUtils.java
@@ -283,8 +283,10 @@ public class StringUtils {
 
             }
         } else if ((mount instanceof MiscMounted) && mount.getType().hasFlag(MiscType.F_SHIELD)) {
-            // Shields modify punch attacks under Core rules; they are not standalone physical attacks.
-            info = "";
+            // Core treats shields as punch modifiers; Total Warfare displays their historical standalone damage.
+            info = CConfig.usesTotalWarfareRules()
+                  ? Integer.toString(((MiscMounted) mount).getDamageAbsorption(unit, mount.getLocation()))
+                  : "\u2014";
         } else if ((mount instanceof MiscMounted) && (mount.getType().hasFlag(MiscType.F_CLUB)
               || mount.getType().hasFlag(MiscType.F_HAND_WEAPON))) {
             if (((MiscType) mount.getType()).isVibroblade()) {

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -488,7 +488,8 @@ public class UnitUtil {
             // construction options
             return !eq.hasAnyFlag(MiscTypeFlag.S_CLUB, MiscTypeFlag.S_TREE_CLUB);
         }
-        return eq.hasFlag(MiscType.F_HAND_WEAPON) || eq.hasFlag(MiscType.F_TALON) || eq.hasFlag(MiscType.F_RAM_PLATE);
+        return eq.hasFlag(MiscType.F_HAND_WEAPON) || eq.hasFlag(MiscType.F_TALON) || eq.hasFlag(MiscType.F_SHIELD)
+              || eq.hasFlag(MiscType.F_RAM_PLATE);
     }
 
     public static String getHeatSinkType(String type, boolean clan) {

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -488,7 +488,7 @@ public class UnitUtil {
             // construction options
             return !eq.hasAnyFlag(MiscTypeFlag.S_CLUB, MiscTypeFlag.S_TREE_CLUB);
         }
-        return eq.hasFlag(MiscType.F_HAND_WEAPON) || eq.hasFlag(MiscType.F_TALON) || eq.hasFlag(MiscType.F_SHIELD) || eq.hasFlag(MiscType.F_RAM_PLATE);
+        return eq.hasFlag(MiscType.F_HAND_WEAPON) || eq.hasFlag(MiscType.F_TALON) || eq.hasFlag(MiscType.F_RAM_PLATE);
     }
 
     public static String getHeatSinkType(String type, boolean clan) {

--- a/megameklab/unittests/megameklab/printing/ChargeRecordSheetRulesTest.java
+++ b/megameklab/unittests/megameklab/printing/ChargeRecordSheetRulesTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ */
+package megameklab.printing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import megamek.common.equipment.EquipmentType;
+import megamek.common.game.Game;
+import megamek.common.rules.RulesManager;
+import megamek.common.rules.core.CoreRulesManager;
+import megamek.common.rules.totalwarfare.TWRulesManager;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Mek;
+import megameklab.testing.util.InitializeTypes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(value = InitializeTypes.class)
+class ChargeRecordSheetRulesTest {
+
+    private RulesManager originalRulesManager;
+
+    @BeforeEach
+    void rememberRulesManager() {
+        originalRulesManager = Game.rulesManager;
+    }
+
+    @AfterEach
+    void restoreRulesManager() {
+        Game.rulesManager = originalRulesManager;
+    }
+
+    @Test
+    void coreDisplaysWeightMultiplierAndSeparatesSpikesFromTmm() throws Exception {
+        BipedMek mek = chargeMek(true);
+        Game.rulesManager = new CoreRulesManager();
+
+        assertEquals("14×(TMM+1)+2", chargeEntry(mek).getDamageField(0));
+    }
+
+    @Test
+    void totalWarfareRetainsDamagePerHex() throws Exception {
+        BipedMek mek = chargeMek(true);
+        Game.rulesManager = new TWRulesManager();
+
+        assertEquals("7/hex+2", chargeEntry(mek).getDamageField(0));
+    }
+
+    @Test
+    void coreOmitsTheSpikesTermWhenNoneAreInstalled() throws Exception {
+        BipedMek mek = chargeMek(false);
+        Game.rulesManager = new CoreRulesManager();
+
+        assertEquals("14×(TMM+1)", chargeEntry(mek).getDamageField(0));
+    }
+
+    private BipedMek chargeMek(boolean withSpikes) throws Exception {
+        BipedMek mek = new BipedMek();
+        mek.setWeight(70);
+        if (withSpikes) {
+            mek.initializeInternal(20, Mek.LOC_CENTER_TORSO);
+            mek.addEquipment(EquipmentType.get("Spikes"), Mek.LOC_CENTER_TORSO);
+        }
+        return mek;
+    }
+
+    private IntrinsicPhysicalInventoryEntry chargeEntry(BipedMek mek) {
+        return IntrinsicPhysicalInventoryEntry.getEntriesFor(mek).stream()
+              .filter(IntrinsicPhysicalInventoryEntry.class::isInstance)
+              .map(IntrinsicPhysicalInventoryEntry.class::cast)
+              .filter(entry -> entry.name().equals("Charge"))
+              .findFirst()
+              .orElseThrow();
+    }
+}

--- a/megameklab/unittests/megameklab/printing/ShieldRecordSheetRulesTest.java
+++ b/megameklab/unittests/megameklab/printing/ShieldRecordSheetRulesTest.java
@@ -20,6 +20,9 @@ package megameklab.printing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static megameklab.printing.RecordSheetOptions.IntrinsicPhysicalAttacksStyle.EQUIPMENT;
+import static megameklab.printing.RecordSheetOptions.IntrinsicPhysicalAttacksStyle.FOOTER;
+import static megameklab.printing.RecordSheetOptions.IntrinsicPhysicalAttacksStyle.NONE;
 
 import java.util.List;
 
@@ -67,6 +70,9 @@ class ShieldRecordSheetRulesTest {
         MiscMounted shield = shield(mek);
         assertEquals("\u2014", StringUtils.getEquipmentInfo(mek, shield));
         assertEquals("\u2014", new StandardInventoryEntry(shield).getDamageField(0));
+        assertEquals("\u2014", new StandardInventoryEntry(shield, EQUIPMENT).getDamageField(0));
+        assertEquals("\u2014", new StandardInventoryEntry(shield, FOOTER).getDamageField(0));
+        assertEquals("+2", new StandardInventoryEntry(shield, NONE).getDamageField(0));
         SVGMassPrinter.ExportInventoryEntry exportedShield = exportedShield(mek);
         assertEquals("P", exportedShield.t);
         assertNull(exportedShield.d);
@@ -85,10 +91,20 @@ class ShieldRecordSheetRulesTest {
         MiscMounted shield = shield(mek);
         assertEquals("5", StringUtils.getEquipmentInfo(mek, shield));
         assertEquals("5", new StandardInventoryEntry(shield).getDamageField(0));
+        assertEquals("5", new StandardInventoryEntry(shield, NONE).getDamageField(0));
         SVGMassPrinter.ExportInventoryEntry exportedShield = exportedShield(mek);
         assertEquals("P", exportedShield.t);
         assertEquals("5", exportedShield.d);
         assertEquals("5", exportedShield.md);
+    }
+
+    @Test
+    void coreStandaloneShieldRowsShowSignedBashModifierForEverySize() throws Exception {
+        Game.rulesManager = new CoreRulesManager();
+
+        assertEquals("+1", standaloneShieldDamage("ISSmallShield"));
+        assertEquals("+2", standaloneShieldDamage("ISMediumShield"));
+        assertEquals("+3", standaloneShieldDamage("ISLargeShield"));
     }
 
     private BipedMek mekWithMediumShieldAndTsm() throws Exception {
@@ -99,6 +115,13 @@ class ShieldRecordSheetRulesTest {
         mek.addEquipment(EquipmentType.get("ISMediumShield"), Mek.LOC_LEFT_ARM);
         mek.addEquipment(EquipmentType.get(EquipmentTypeLookup.TSM), Entity.LOC_NONE);
         return mek;
+    }
+
+    private String standaloneShieldDamage(String equipmentId) throws Exception {
+        BipedMek mek = new BipedMek();
+        mek.initializeInternal(10, Mek.LOC_LEFT_ARM);
+        mek.addEquipment(EquipmentType.get(equipmentId), Mek.LOC_LEFT_ARM);
+        return new StandardInventoryEntry(shield(mek), NONE).getDamageField(0);
     }
 
     private IntrinsicPhysicalInventoryEntry punchAt(List<InventoryEntry> entries, String location) {

--- a/megameklab/unittests/megameklab/printing/ShieldRecordSheetRulesTest.java
+++ b/megameklab/unittests/megameklab/printing/ShieldRecordSheetRulesTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ */
+package megameklab.printing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.equipment.MiscMounted;
+import megamek.common.game.Game;
+import megamek.common.rules.RulesManager;
+import megamek.common.rules.core.CoreRulesManager;
+import megamek.common.rules.totalwarfare.TWRulesManager;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Entity;
+import megamek.common.units.Mek;
+import megameklab.testing.util.InitializeTypes;
+import megameklab.util.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(value = InitializeTypes.class)
+class ShieldRecordSheetRulesTest {
+
+    private RulesManager originalRulesManager;
+
+    @BeforeEach
+    void rememberRulesManager() {
+        originalRulesManager = Game.rulesManager;
+    }
+
+    @AfterEach
+    void restoreRulesManager() {
+        Game.rulesManager = originalRulesManager;
+    }
+
+    @Test
+    void coreAddsShieldBonusBeforeTsmAndOmitsStandaloneExportDamage() throws Exception {
+        BipedMek mek = mekWithMediumShieldAndTsm();
+        Game.rulesManager = new CoreRulesManager();
+
+        List<InventoryEntry> physicals = IntrinsicPhysicalInventoryEntry.getEntriesFor(mek);
+        assertEquals("9 [18]", punchAt(physicals, "LA").getDamageField(0));
+        assertEquals("7 [14]", punchAt(physicals, "RA").getDamageField(0));
+
+        MiscMounted shield = shield(mek);
+        assertEquals("\u2014", StringUtils.getEquipmentInfo(mek, shield));
+        assertEquals("\u2014", new StandardInventoryEntry(shield).getDamageField(0));
+        SVGMassPrinter.ExportInventoryEntry exportedShield = exportedShield(mek);
+        assertEquals("P", exportedShield.t);
+        assertNull(exportedShield.d);
+        assertNull(exportedShield.md);
+    }
+
+    @Test
+    void totalWarfareLeavesPunchUnmodifiedAndExportsHistoricalShieldDamage() throws Exception {
+        BipedMek mek = mekWithMediumShieldAndTsm();
+        Game.rulesManager = new TWRulesManager();
+
+        List<InventoryEntry> physicals = IntrinsicPhysicalInventoryEntry.getEntriesFor(mek);
+        assertEquals("7 [14]", punchAt(physicals, "LA").getDamageField(0));
+        assertEquals("7 [14]", punchAt(physicals, "RA").getDamageField(0));
+
+        MiscMounted shield = shield(mek);
+        assertEquals("5", StringUtils.getEquipmentInfo(mek, shield));
+        assertEquals("5", new StandardInventoryEntry(shield).getDamageField(0));
+        SVGMassPrinter.ExportInventoryEntry exportedShield = exportedShield(mek);
+        assertEquals("P", exportedShield.t);
+        assertEquals("5", exportedShield.d);
+        assertEquals("5", exportedShield.md);
+    }
+
+    private BipedMek mekWithMediumShieldAndTsm() throws Exception {
+        BipedMek mek = new BipedMek();
+        mek.setWeight(70);
+        mek.initializeInternal(10, Mek.LOC_LEFT_ARM);
+        mek.initializeInternal(10, Mek.LOC_RIGHT_ARM);
+        mek.addEquipment(EquipmentType.get("ISMediumShield"), Mek.LOC_LEFT_ARM);
+        mek.addEquipment(EquipmentType.get(EquipmentTypeLookup.TSM), Entity.LOC_NONE);
+        return mek;
+    }
+
+    private IntrinsicPhysicalInventoryEntry punchAt(List<InventoryEntry> entries, String location) {
+        return entries.stream()
+              .filter(IntrinsicPhysicalInventoryEntry.class::isInstance)
+              .map(IntrinsicPhysicalInventoryEntry.class::cast)
+              .filter(entry -> entry.name().equals("Punch") && entry.location().equals(location))
+              .findFirst()
+              .orElseThrow();
+    }
+
+    private MiscMounted shield(BipedMek mek) {
+        return mek.getMisc().stream()
+              .filter(mounted -> mounted.getType().hasFlag(megamek.common.equipment.MiscType.F_SHIELD))
+              .findFirst()
+              .orElseThrow();
+    }
+
+    private SVGMassPrinter.ExportInventoryEntry exportedShield(BipedMek mek) {
+        return new SVGMassPrinter.Components(mek).getComp().stream()
+              .filter(entry -> "ISMediumShield".equals(entry.id))
+              .findFirst()
+              .orElseThrow();
+    }
+}

--- a/megameklab/unittests/megameklab/util/CConfigTest.java
+++ b/megameklab/unittests/megameklab/util/CConfigTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMekLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMekLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ */
+package megameklab.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import megamek.common.game.Game;
+import megamek.common.options.OptionsConstants;
+import megamek.common.rules.RulesManager;
+import megamek.common.rules.core.CoreRulesManager;
+import megamek.common.rules.totalwarfare.TWRulesManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CConfigTest {
+
+    private String originalRulesSystem;
+    private RulesManager originalRulesManager;
+
+    @BeforeEach
+    void rememberRulesConfiguration() {
+        originalRulesSystem = CConfig.getParam(CConfig.MISC_RULES_SYSTEM);
+        originalRulesManager = Game.rulesManager;
+    }
+
+    @AfterEach
+    void restoreRulesConfiguration() {
+        CConfig.setParam(CConfig.MISC_RULES_SYSTEM, originalRulesSystem);
+        Game.rulesManager = originalRulesManager;
+    }
+
+    @Test
+    void unknownRulesSystemFallsBackToMegaMekCoreDefault() {
+        CConfig.setParam(CConfig.MISC_RULES_SYSTEM, "Unknown Rules");
+
+        assertEquals(OptionsConstants.RULES_CORE, CConfig.getRulesSystem());
+        CConfig.applyRulesSystem();
+        assertInstanceOf(CoreRulesManager.class, Game.rulesManager);
+    }
+
+    @Test
+    void totalWarfareSelectionChangesTheActiveRulesManager() {
+        CConfig.setParam(CConfig.MISC_RULES_SYSTEM, OptionsConstants.RULES_TW);
+
+        CConfig.applyRulesSystem();
+
+        assertEquals(OptionsConstants.RULES_TW, CConfig.getRulesSystem());
+        assertInstanceOf(TWRulesManager.class, Game.rulesManager);
+    }
+}


### PR DESCRIPTION
This PR implements game rules selection and updated printing for shields and charge.

in core 2026:
Charge will use `Nx(TTM+1)` format
Shield will be backed inside the punch damage

in TW: remains the old format.