### PR TITLE
Fix: restore the issue forms to the MegaMekLab tracker

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,9 +10,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please attach the unit you were working on - the `.mtf` or `.blk` file itself - along with
-        `megameklab.log` from the `logs` folder. A unit that reproduces the problem is worth more than
-        any description of it.
+        Please attach the unit you were working on, along with `megameklab.log` from the `logs`
+        folder. GitHub will not accept a bare `.mtf` or `.blk` file, so put the unit in a ZIP first.
+        A unit that reproduces the problem is worth more than any description of it.
 
         **Help > Report a Bug** fills in the version fields below for you.
 
@@ -53,11 +53,11 @@ body:
     attributes:
       label: "Attach your files"
       description: >
-        The unit file, and megameklab.log from the logs folder. Archives up to 25 MB, video up to
-        100 MB.
+        The unit file zipped up, and megameklab.log from the logs folder. Archives up to 25 MB,
+        video up to 100 MB.
     validations:
       required: false
-      accept: ".zip,.gz,.log,.txt,.csv,.mtf,.blk,.png,.jpg,.jpeg,.gif,.mp4,.mov"
+      accept: ".zip,.gz,.log,.txt,.csv,.png,.jpg,.jpeg,.gif,.mp4,.mov"
 
   - type: textarea
     id: log-excerpt

--- a/.github/ISSUE_TEMPLATE/request_for_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/request_for_enhancement.yml
@@ -1,8 +1,7 @@
 name: "Request an Enhancement"
 description: >
   Suggest a new feature, an improvement to an existing one, or a construction rule we have not
-  implemented yet.
-  Please check that you are on the right repository and that nobody has asked for this already.
+  implemented yet. Please check that nobody has asked for this already.
 type: "Feature"
 labels:
   - (RFE) Enhancement


### PR DESCRIPTION
## What this changes

Nobody can open an issue on the MegaMekLab tracker right now. Both forms are missing from the
"Choose an Issue Template" page, and because blank issues are restricted to maintainers, a
reporter arriving there sees three links to Discord and the wiki and no way to file anything at
all.

GitHub throws away an issue form entirely when any part of it fails validation, and it does so
silently - the form simply disappears from the chooser. Two separate faults caused this. The bug
report asked for `.mtf` and `.blk` attachments, which are not file types GitHub accepts, and the
enhancement request's description ran to 203 characters against a 200 limit. The only place either
fault is visible is the .yml file's own page on github.com, which shows a red banner reading
"body[4]: contains invalid file extensions: .mtf, .blk".

Since GitHub will not take a bare unit file anywhere, the instructions now ask reporters to put
the unit in a ZIP first, rather than asking for something the site refuses.

No issue number: the tracker this restores is the one that could not accept the report.

## Testing

- Reproduced live. The chooser lists no forms, and going straight to
  `?template=request_for_enhancement.yml` falls back to a blank issue.
- Checked all seven forms across the four repositories against GitHub's published supported-file
  list and its form schema. The check agrees with GitHub on every file: the three it calls broken
  are exactly the three missing from their choosers, and the four it passes are the four that
  render.
- Both files here pass after the change. The enhancement description is now 162 characters.
- GitHub itself now passes both files. On the PR branch, the red "There is a problem with this
  template" banner is gone from each .yml page and GitHub renders the full form preview instead,
  upload field included.

## What is not proven yet

- The chooser will not list the form until this merges, because GitHub builds that page from the
  default branch. GitHub validating the file on the branch is as far as it can be taken before
  then.
- Nobody has pushed a file through the upload field yet. GitHub accepts the extension list, but
  the attachment itself was never exercised end to end.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a construction rule or changes what a unit file contains (not applicable - this changes GitHub issue forms only)
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text (not applicable - no Java in this PR)
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
