### PR TITLE
Fix: MML #2306 Move Screen Launcher to Capital category

### DIFF
--- a/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
+++ b/megameklab/src/megameklab/ui/util/EquipmentDatabaseCategory.java
@@ -83,8 +83,7 @@ public enum EquipmentDatabaseCategory {
           (eq, en) -> (eq instanceof WeaponType) && !((WeaponType) eq).isCapital() && eq.hasFlag(F_BALLISTIC)),
 
     MISSILE("Missile",
-          (eq, en) -> ((eq instanceof WeaponType) && !((WeaponType) eq).isCapital() && eq.hasFlag(F_MISSILE))
-                || eq.is("Screen Launcher")),
+          (eq, en) -> (eq instanceof WeaponType) && !((WeaponType) eq).isCapital() && eq.hasFlag(F_MISSILE)),
 
     ARTILLERY("Artillery",
           (eq, en) -> (eq instanceof WeaponType) && eq.hasFlag(F_ARTILLERY),
@@ -92,7 +91,7 @@ public enum EquipmentDatabaseCategory {
                 && (!(e instanceof Infantry) || (e instanceof BattleArmor))),
 
     CAPITAL("Capital",
-          (eq, en) -> (eq instanceof WeaponType) && ((WeaponType) eq).isCapital(),
+          (eq, en) -> (eq instanceof WeaponType) && ((WeaponType) eq).isCapital() || eq.is("Screen Launcher"),
           Entity::isLargeCraft),
 
     PHYSICAL("Physical",
@@ -133,8 +132,7 @@ public enum EquipmentDatabaseCategory {
                 || eq.is(COOLANT_POD)
                 || eq.is(BattleArmor.MINE_LAUNCHER)
                 || (eq instanceof TAGWeapon)
-                || (eq instanceof WeaponType && eq.hasFlag(F_AMS))
-                || eq.is("Screen Launcher")),
+                || (eq instanceof WeaponType && eq.hasFlag(F_AMS))),
 
     AP("Anti-Personnel",
           (eq, en) -> BattleArmorUtil.isBattleArmorAPWeapon(eq),


### PR DESCRIPTION
## What this changes

Fix https://github.com/MegaMek/megameklab/issues/2306

Move Screen Launcher from Missile and Other categories to the Capital category.

## Testing

Built and tested in MML

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a construction rule or changes what a unit file contains
- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result