### PR TITLE
PR: Move CI Ref Col to Stats View

### DIFF
--- a/megameklab/src/megameklab/ui/infantry/CIArmorView.java
+++ b/megameklab/src/megameklab/ui/infantry/CIArmorView.java
@@ -406,7 +406,7 @@ public class CIArmorView extends IView implements ActionListener, ChangeListener
             columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_BV), false);
             columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_TON), false);
             columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_CRIT), false);
-            columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_REF), !tableMode);
+            columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_REF), tableMode);
         }
     }
 

--- a/megameklab/src/megameklab/ui/infantry/CIEquipmentView.java
+++ b/megameklab/src/megameklab/ui/infantry/CIEquipmentView.java
@@ -339,7 +339,7 @@ public class CIEquipmentView extends IView implements ActionListener {
         columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_BV), tableMode);
         columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_TON), tableMode);
         columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_CRIT), false);
-        columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_REF), !tableMode);
+        columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_REF), tableMode);
     }
 
     /** Creates the control panel with the filters and buttons. */

--- a/megameklab/src/megameklab/ui/infantry/CIFieldGunTableView.java
+++ b/megameklab/src/megameklab/ui/infantry/CIFieldGunTableView.java
@@ -306,7 +306,7 @@ public class CIFieldGunTableView extends IView implements ActionListener {
         columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_BV), tableMode);
         columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_TON), tableMode);
         columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_CRIT), false);
-        columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_REF), !tableMode);
+        columnModel.setColumnVisible(columnModel.getColumnByModelIndex(EquipmentTableModel.COL_REF), tableMode);
     }
 
     /** Creates the control panel with the filters and buttons. */


### PR DESCRIPTION
## What this changes

Move CI Reference column to stats view from fluff view for Equipment (Weapons), Field Guns, and Armor Kit tables to standardize with other Equipment table views

## Testing

Reviewed in build

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a construction rule or changes what a unit file contains
- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result