### PR TITLE
Fix: CI SCUBA and TAG Addition and Removal

### DIFF
--- a/megameklab/src/megameklab/ui/infantry/CIEquipmentView.java
+++ b/megameklab/src/megameklab/ui/infantry/CIEquipmentView.java
@@ -234,8 +234,11 @@ public class CIEquipmentView extends IView implements ActionListener {
             if (weapon.hasFlag(WeaponType.F_TAG)) {
                 getInfantry().setSpecializations(getInfantry().getSpecializations() | ConvInfantry.TAG_TROOPS);
                 getInfantry().setSecondaryWeaponsPerSquad(2);
-            } else if (isSecondary && (getInfantry().getSecondaryWeaponsPerSquad() == 0)) {
-                getInfantry().setSecondaryWeaponsPerSquad(1);
+            } else if (isSecondary) {
+                getInfantry().setSpecializations(getInfantry().getSpecializations() & ~ConvInfantry.TAG_TROOPS);
+                if (getInfantry().getSecondaryWeaponsPerSquad() == 0) {
+                    getInfantry().setSecondaryWeaponsPerSquad(1);
+                }
             }
         }
     }

--- a/megameklab/src/megameklab/ui/infantry/CISpecializationView.java
+++ b/megameklab/src/megameklab/ui/infantry/CISpecializationView.java
@@ -56,7 +56,6 @@ import megamek.common.verifier.TestInfantry;
 import megameklab.ui.EntitySource;
 import megameklab.ui.listeners.InfantryBuildListener;
 import megameklab.ui.util.IView;
-import megameklab.util.InfantryUtil;
 
 /**
  * View for selecting infantry specializations, including Xeno-Planetary conditions training (XCT).

--- a/megameklab/src/megameklab/ui/infantry/CISpecializationView.java
+++ b/megameklab/src/megameklab/ui/infantry/CISpecializationView.java
@@ -253,16 +253,10 @@ public class CISpecializationView extends IView implements TableModelListener {
             if ((ConvInfantry.TAG_TROOPS != spec)
                   && getInfantry().hasSpecialization(ConvInfantry.TAG_TROOPS)
                   && TestInfantry.maxSecondaryWeapons(getInfantry()) < 2) {
-                InfantryUtil.replaceMainWeapon(getInfantry(), null, true);
-                getInfantry().setSecondaryWeaponsPerSquad(0);
                 getInfantry().setSpecializations(getInfantry().getSpecializations() & ~ConvInfantry.TAG_TROOPS);
-            } else if (TestInfantry.maxSecondaryWeapons(getInfantry()) > getInfantry().getSecondaryWeaponsPerSquad()) {
-                getInfantry().setSecondaryWeaponsPerSquad(TestInfantry.maxSecondaryWeapons(getInfantry()));
-                if (getInfantry().getSecondaryWeaponsPerSquad() == 0) {
-                    InfantryUtil.replaceMainWeapon(getInfantry(), null, true);
-                }
             }
             fireTableCellUpdated(row, col);
+            refresh();
         }
 
         public int getColumnWidth(int c) {

--- a/megameklab/src/megameklab/ui/infantry/CIStructureTab.java
+++ b/megameklab/src/megameklab/ui/infantry/CIStructureTab.java
@@ -261,6 +261,14 @@ public class CIStructureTab extends ITab implements InfantryBuildListener {
             InfantryUtil.replaceMainWeapon(getInfantry(),
                   (InfantryWeapon) EquipmentType.get(EquipmentTypeLookup.INFANTRY_TAG), true);
             getInfantry().setSecondaryWeaponsPerSquad(2);
+        } else if (!getInfantry().hasSpecialization(ConvInfantry.TAG_TROOPS) && getInfantry().getSecondaryWeapon() != null && getInfantry().getSecondaryWeapon().hasFlag(WeaponType.F_TAG)) {
+            InfantryUtil.replaceMainWeapon(getInfantry(), null, true);
+            getInfantry().setSecondaryWeaponsPerSquad(0);
+        } else if (TestInfantry.maxSecondaryWeapons(getInfantry()) < getInfantry().getSecondaryWeaponsPerSquad()) {
+            getInfantry().setSecondaryWeaponsPerSquad(TestInfantry.maxSecondaryWeapons(getInfantry()));
+            if (getInfantry().getSecondaryWeaponsPerSquad() == 0) {
+                InfantryUtil.replaceMainWeapon(getInfantry(), null, true);
+            }
         }
     }
 
@@ -416,6 +424,13 @@ public class CIStructureTab extends ITab implements InfantryBuildListener {
             getInfantry().setMovementMode(movementMode);
             getInfantry().setMount(null);
         }
+
+        if (movementMode == EntityMovementMode.INF_UMU || movementMode == EntityMovementMode.SUBMARINE) {
+            getInfantry().setSpecializations(getInfantry().getSpecializations() | ConvInfantry.SCUBA);
+        } else {
+            getInfantry().setSpecializations(getInfantry().getSpecializations() & ~ConvInfantry.SCUBA);
+        }
+
         getInfantry().setMicrolite(alt && (movementMode == EntityMovementMode.VTOL));
 
         if (getInfantry().getMovementMode() != EntityMovementMode.INF_MOTORIZED
@@ -423,8 +438,14 @@ public class CIStructureTab extends ITab implements InfantryBuildListener {
               && getInfantry().getMovementMode() != EntityMovementMode.WHEELED) {
             InfantryUtil.replaceFieldGun(getInfantry(), null, 0);
         }
+
+        if (getInfantry().hasSpecialization(ConvInfantry.TAG_TROOPS) && TestInfantry.maxSecondaryWeapons(getInfantry()) < 2) {
+            getInfantry().setSpecializations(getInfantry().getSpecializations() & ~ConvInfantry.TAG_TROOPS);
+        }
+
         enableTabs();
         TestInfantry.adaptAntiMekAttacks(getInfantry());
+        updateSpecializations();
         platoonTypeView.setFromEntity(getInfantry());
         weaponView.setFromEntity(getInfantry());
         specializationChoiceTable.refresh();
@@ -461,6 +482,8 @@ public class CIStructureTab extends ITab implements InfantryBuildListener {
             if (count == 0) {
                 InfantryUtil.replaceMainWeapon(getInfantry(), null, true);
                 getInfantry().setSpecializations(getInfantry().getSpecializations() & ~ConvInfantry.TAG_TROOPS);
+                updateSpecializations();
+                specializationChoiceTable.refresh();
             }
             getInfantry().setSecondaryWeaponsPerSquad(count);
         }


### PR DESCRIPTION
## What this changes

Fix SCUBA specialization addition and removal when CI type with SCUBA is selected or deselected

Fix TAG specialization removal when a non-TAG support weapon is added, all support weapons are removed, and CI type or specialization is applied with fewer than 2 support weapon slots available

Fix the number of non-TAG secondaries when a CI type or specialization with fewer available secondaries than current is applied

## Testing

Tested on build

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a construction rule or changes what a unit file contains
- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result