### PR TITLE
Fix: MML #2281 Switch Prototype Double to Single Heat Sinks

### DIFF
--- a/megameklab/resources/megameklab/resources/Views.properties
+++ b/megameklab/resources/megameklab/resources/Views.properties
@@ -341,8 +341,7 @@ HeatSinkView.spnBaseCount.tooltip=The number of heat sinks that are part of the 
 HeatSinkView.spnPrototypeCount.text=DHS-P / DHS-F:
 HeatSinkView.spnPrototypeCount.tooltip=IO:AE p.65 (DHS-P) / p.96 (Freezers)\nThe number of prototype double heat sinks \
   on the unit. \nIf the "Number" field is higher, the difference is the number \nof additional single heat sinks on the unit
-HeatSinkView.spnPrototypeCount.info={0,choice,0#no single heat sinks|1#1 single heat sink|1<{0} single \
-  heat sinks}
+HeatSinkView.spnPrototypeCount.info={0,choice,0#No Single Heat Sinks|1#1 Single Heat Sink|1<{0} Single Heat Sinks}
 HeatSinkView.lblCritFree.text=Engine Free:
 HeatSinkView.lblCritFree.tooltip=The number of heat sinks that are an integral part of the engine and do not have to \
   be assigned critical space.

--- a/megameklab/src/megameklab/ui/mek/BMStructureTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMStructureTab.java
@@ -1347,7 +1347,7 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
 
     @Override
     public void heatSinksChanged(EquipmentType hsType, int count) {
-        // if we have the same type of heat sink, then we should not remove the existing
+        // If we have the same type of heat sink, then we should not remove the existing
         // heat sinks
         int currentSinks = MekUtil.countActualHeatSinks(getMek());
         if (getMek().hasWorkingMisc(hsType.getInternalName())) {
@@ -1355,6 +1355,11 @@ public class BMStructureTab extends ITab implements MekBuildListener, ArmorAlloc
                 MekUtil.removeHeatSinks(getMek(), currentSinks - count);
             } else if (count > currentSinks) {
                 MekUtil.addHeatSinkMounts(getMek(), count - currentSinks, hsType);
+            }
+            // Replace prototype doubles if new heat sink type is not prototype doubles
+            if (!hsType.hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)
+                  && getMek().hasWorkingMisc(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)) {
+                redistributePrototypeHS(0);
             }
         } else {
             MekUtil.removeHeatSinks(getMek(), count);


### PR DESCRIPTION
## What this changes

Fix https://github.com/MegaMek/megameklab/issues/2281

Fix switch prototype double to single heat sinks
Capitalize heatSinksChanged() note
Capitalize HeatSinkView.spnPrototypeCount.info

## Testing

Tested on build

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a construction rule or changes what a unit file contains
- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result