### PR TITLE
Follow MegaMek's Pilot Implants option merge (needs MegaMek/megamek#8884)

### DIFF
--- a/megameklab/src/megameklab/util/UnitPrintManager.java
+++ b/megameklab/src/megameklab/util/UnitPrintManager.java
@@ -32,7 +32,8 @@
  */
 package megameklab.util;
 
-import static megamek.common.options.OptionsConstants.RPG_MANEI_DOMINI;
+import static megamek.common.options.OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE;
+import static megamek.common.options.OptionsConstants.NEURAL_INTERFACE_MODE_PILOT_ONLY;
 import static megamek.common.options.OptionsConstants.RPG_PILOT_ADVANTAGES;
 
 import java.awt.Frame;
@@ -112,7 +113,8 @@ public class UnitPrintManager {
         try {
             var options = new GameOptions();
             options.initialize();
-            options.getOption(RPG_MANEI_DOMINI).setValue(true);
+            // Pilot implants are one three-way option; any setting but Off lets a MUL's implants load
+            options.getOption(ADVANCED_NEURAL_INTERFACE_MODE).setValue(NEURAL_INTERFACE_MODE_PILOT_ONLY);
             options.getOption(RPG_PILOT_ADVANTAGES).setValue(true);
             MULParser parser = new MULParser(file, options);
             if (!MULVersionValidator.isCorrectVersion(parent, parser)) {

--- a/megameklab/src/megameklab/util/UnitPrintManager.java
+++ b/megameklab/src/megameklab/util/UnitPrintManager.java
@@ -113,7 +113,7 @@ public class UnitPrintManager {
         try {
             var options = new GameOptions();
             options.initialize();
-            // Pilot implants are one three-way option; any setting but Off lets a MUL's implants load
+            // Pilot implants are a three-way option; any setting but Off lets a MUL's implants load
             options.getOption(ADVANCED_NEURAL_INTERFACE_MODE).setValue(NEURAL_INTERFACE_MODE_PILOT_ONLY);
             options.getOption(RPG_PILOT_ADVANTAGES).setValue(true);
             MULParser parser = new MULParser(file, options);

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -111,7 +111,9 @@ public class UnitUtil {
         final Game game = dummyClient.getGame();
         game.getOptions().getOption(OptionsConstants.ADVANCED_STRATOPS_QUIRKS).setValue(true);
         game.getOptions().getOption(OptionsConstants.RPG_PILOT_ADVANTAGES).setValue(true);
-        game.getOptions().getOption(OptionsConstants.RPG_MANEI_DOMINI).setValue(true);
+        // Pilot implants are one three-way option; any setting but Off allows every implant
+        game.getOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE)
+              .setValue(OptionsConstants.NEURAL_INTERFACE_MODE_PILOT_ONLY);
         game.addPlayer(1, dummyPlayer);
         dummyClient.setLocalPlayerNumber(1);
     }

--- a/megameklab/src/megameklab/util/UnitUtil.java
+++ b/megameklab/src/megameklab/util/UnitUtil.java
@@ -111,7 +111,7 @@ public class UnitUtil {
         final Game game = dummyClient.getGame();
         game.getOptions().getOption(OptionsConstants.ADVANCED_STRATOPS_QUIRKS).setValue(true);
         game.getOptions().getOption(OptionsConstants.RPG_PILOT_ADVANTAGES).setValue(true);
-        // Pilot implants are one three-way option; any setting but Off allows every implant
+        // Pilot implants are a three-way option; any setting but Off lets a unit's implants load
         game.getOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE)
               .setValue(OptionsConstants.NEURAL_INTERFACE_MODE_PILOT_ONLY);
         game.addPlayer(1, dummyPlayer);


### PR DESCRIPTION
## What this changes

Follows MegaMek/megamek#8884, which removes the Manei Domini game option. The record sheet printer and the shared dummy game switched that option on so implants in a MUL would load; both now set the Pilot Implants dropdown to Pilot Abilities Only instead.

Depends on MegaMek/megamek#8884 and must merge after it. Without it, reading the removed option returns null and printing a MUL crashes.

## Testing

- Compiles against the MegaMek branch.
- MegaMekLab has no test touching these two call sites; the behaviour is the engine's, covered in the MegaMek PR.

## What is not proven yet

- Printing a MUL that carries implants has not been run in the app after the change.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a construction rule or changes what a unit file contains
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
