### PR TITLE
Fix: MML #2310 Remove Heat Sinks Removes OmniPod-Mounted Heat Sinks First

### DIFF
--- a/megameklab/src/megameklab/ui/util/BAASBMDropTargetCriticalList.java
+++ b/megameklab/src/megameklab/ui/util/BAASBMDropTargetCriticalList.java
@@ -222,7 +222,7 @@ public class BAASBMDropTargetCriticalList extends JList<String> implements Mouse
                       && mount.getLocation() == BattleArmor.LOC_SQUAD
                       && (getUnit() instanceof BattleArmor)
                       && ((BattleArmor) getUnit()).getChassisType() != BattleArmor.CHASSIS_TYPE_QUAD) {
-                    menuItem = new JMenuItem("Mount as squad support weapon");
+                    menuItem = new JMenuItem("Mount as Squad Support Weapon");
                     menuItem.addActionListener(evt -> {
                         mount.setSquadSupportWeapon(true);
                         if (refresh != null) {
@@ -246,7 +246,7 @@ public class BAASBMDropTargetCriticalList extends JList<String> implements Mouse
                             enabled = true;
                         }
                     }
-                    menuItem = new JMenuItem("Mount as squad support weapon");
+                    menuItem = new JMenuItem("Mount as Squad Support Weapon");
                     menuItem.setEnabled(enabled);
                     menuItem.setToolTipText("Ammo can only be squad mounted along with a weapon that uses it");
                     menuItem.addActionListener(evt -> {
@@ -260,7 +260,7 @@ public class BAASBMDropTargetCriticalList extends JList<String> implements Mouse
 
                 // Allow removing squad support weapon
                 if (mount.isSquadSupportWeapon()) {
-                    menuItem = new JMenuItem("Remove squad support weapon mount");
+                    menuItem = new JMenuItem("Remove Squad Support Weapon Mount");
                     menuItem.addActionListener(evt -> {
                         mount.setSquadSupportWeapon(false);
                         // Can't have squad support weapon ammo with no
@@ -277,7 +277,7 @@ public class BAASBMDropTargetCriticalList extends JList<String> implements Mouse
 
                 // Unattach from a DWP
                 if (mount.is(EquipmentTypeLookup.BA_DWP) && (mount.getLinked() != null)) {
-                    menuItem = new JMenuItem("Remove attached weapon");
+                    menuItem = new JMenuItem("Remove Attached Weapon");
                     menuItem.addActionListener(evt -> {
                         BattleArmorUtil.emptyDwpApm(mount);
                         doRefresh();
@@ -287,7 +287,7 @@ public class BAASBMDropTargetCriticalList extends JList<String> implements Mouse
 
                 // Right-clicked on an AP Mount (can also be an armored glove) that has an attached weapon
                 if (mount.getType().hasFlag(MiscType.F_AP_MOUNT) && (mount.getLinked() != null)) {
-                    menuItem = new JMenuItem("Remove attached weapon");
+                    menuItem = new JMenuItem("Remove Attached Weapon");
                     menuItem.addActionListener(evt -> {
                         BattleArmorUtil.emptyDwpApm(mount);
                         doRefresh();
@@ -361,11 +361,11 @@ public class BAASBMDropTargetCriticalList extends JList<String> implements Mouse
 
                 if (getUnit().isOmni() && !mount.getType().isOmniFixedOnly()) {
                     if (mount.isOmniPodMounted()) {
-                        menuItem = new JMenuItem("Change to fixed mount");
+                        menuItem = new JMenuItem("Change to Fixed Mount");
                         menuItem.addActionListener(ev -> changeOmniMounting(false));
                         popup.add(menuItem);
                     } else if (UnitUtil.canPodMount(getUnit(), mount)) {
-                        menuItem = new JMenuItem("Change to pod mount");
+                        menuItem = new JMenuItem("Change to Pod Mount");
                         menuItem.addActionListener(ev -> changeOmniMounting(true));
                         popup.add(menuItem);
                     }

--- a/megameklab/src/megameklab/ui/util/DropTargetCriticalList.java
+++ b/megameklab/src/megameklab/ui/util/DropTargetCriticalList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -170,11 +170,11 @@ public class DropTargetCriticalList<E> extends JList<E> implements MouseListener
 
                     if (getUnit().isOmni() && !mount.getType().isOmniFixedOnly()) {
                         if (mount.isOmniPodMounted()) {
-                            info = new JMenuItem("Change to fixed mount");
+                            info = new JMenuItem("Change to Fixed Mount");
                             info.addActionListener(evt2 -> changeOmniMounting(false));
                             popup.add(info);
                         } else if (UnitUtil.canPodMount(getUnit(), mount)) {
-                            info = new JMenuItem("Change to pod mount");
+                            info = new JMenuItem("Change to Pod Mount");
                             info.addActionListener(evt2 -> changeOmniMounting(true));
                             popup.add(info);
                         }

--- a/megameklab/src/megameklab/util/MekUtil.java
+++ b/megameklab/src/megameklab/util/MekUtil.java
@@ -118,21 +118,21 @@ public final class MekUtil {
         int base = UnitUtil.getCriticalFreeHeatSinks(unit, unit.hasCompactHeatSinks());
         boolean splitCompact = false;
         if (unit.hasCompactHeatSinks()) {
-            // first check to see if there is a single compact heat sink outside the
-            // engine and
-            // remove this first if so
+            // First check to see if there is a single compact heat sink outside the
+            // engine and remove this first if so
             Mounted<?> mount = getSingleCompactHeatSink(unit);
             if ((null != mount) && (number > 0)) {
                 UnitUtil.removeMounted(unit, mount);
                 number--;
             }
-            // if number is now uneven, then note that we will need to split a compact
+            // If number is now uneven, then note that we will need to split a compact
             if ((number % 2) == 1) {
                 splitCompact = true;
                 number--;
             }
         }
         Vector<Mounted<?>> unassigned = new Vector<>();
+        Vector<Mounted<?>> omniAssigned = new Vector<>();
         Vector<Mounted<?>> assigned = new Vector<>();
         Vector<Mounted<?>> free = new Vector<>();
         for (Mounted<?> m : unit.getMisc()) {
@@ -145,20 +145,23 @@ public final class MekUtil {
                         unassigned.add(m);
                     }
                 } else {
-                    assigned.add(m);
+                    if (m.isOmniPodMounted()) {
+                        omniAssigned.add(m);
+                    } else {
+                        assigned.add(m);
+                    }
                 }
             }
         }
         toRemove.addAll(unassigned);
+        toRemove.addAll(omniAssigned);
         toRemove.addAll(assigned);
         toRemove.addAll(free);
         if (unit.hasCompactHeatSinks()) {
-            // need to do some number magic here. The unassigned and assigned slots should
-            // each
-            // contain two heat sinks, but if we dip into the free then we are looking at
-            // one heat
-            // sink.
-            int numberDouble = Math.min(number / 2, unassigned.size() + assigned.size());
+            // Need to do some number magic here. The unassigned, omniAssigned, and assigned slots
+            // should each contain two heat sinks, but if we dip into the free then we are looking
+            // at one heat sink.
+            int numberDouble = Math.min(number / 2, unassigned.size() + omniAssigned.size() + assigned.size());
             int numberSingle = Math.max(0, number - (2 * numberDouble));
             number = numberDouble + numberSingle;
         }
@@ -171,7 +174,7 @@ public final class MekUtil {
         if (splitCompact) {
             Mounted<?> eq = toRemove.get(number);
             int loc = eq.getLocation();
-            // remove singleCompact mount and replace with a double
+            // Remove singleCompact mount and replace with a double
             UnitUtil.removeMounted(unit, eq);
             if (!eq.getType().hasFlag(MiscType.F_HEAT_SINK)) {
                 try {


### PR DESCRIPTION
## What this changes

Fixes https://github.com/MegaMek/megameklab/issues/2310

Update removeHeatSinks() to remove OmniPod-mounted heat sinks first
Capitalize removeHeatSinks() notes
Capitalize drop down menu labels

## Testing

Tested in build (including OmniPod-mounted compact heat sinks)

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a construction rule or changes what a unit file contains
- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result