### PR TITLE
PR: Update Default CV Movement Mode and Reorder SV Types

### DIFF
--- a/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVMainUI.java
@@ -252,20 +252,21 @@ public class CVMainUI extends MegaMekLabMainUI implements BFSLinkedEditor {
         if (entityType == Entity.ETYPE_VTOL) {
             newUnit = new VTOL();
             newUnit.setTechLevel(TechConstants.T_INTRO_BOX_SET);
-            newUnit.setWeight(20);
             newUnit.setMovementMode(EntityMovementMode.VTOL);
         } else if (entityType == Entity.ETYPE_SUPER_HEAVY_TANK) {
             newUnit = new SuperHeavyTank();
             newUnit.setTechLevel(TechConstants.T_IS_ADVANCED);
-            newUnit.setWeight(51);
-            newUnit.setMovementMode(EntityMovementMode.HOVER);
+            newUnit.setWeight(101);
+            newUnit.setMovementMode(EntityMovementMode.TRACKED);
         } else {
             newUnit = new Tank();
             newUnit.setTechLevel(TechConstants.T_INTRO_BOX_SET);
-            newUnit.setWeight(20);
-            newUnit.setMovementMode(EntityMovementMode.HOVER);
+            newUnit.setMovementMode(EntityMovementMode.TRACKED);
         }
-        newUnit.setYear(3145);
+        if (entityType != Entity.ETYPE_SUPER_HEAVY_TANK) {
+            newUnit.setWeight(20);
+        }
+
         newUnit.setEngine(new Engine(Math.max(10, (int) newUnit.getWeight()
               - newUnit.getSuspensionFactor()), Engine.NORMAL_ENGINE,
               Engine.TANK_ENGINE));

--- a/megameklab/src/megameklab/ui/supportVehicle/SVChassisView.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVChassisView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2019-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *

--- a/megameklab/src/megameklab/ui/supportVehicle/SVChassisView.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVChassisView.java
@@ -36,7 +36,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;

--- a/megameklab/src/megameklab/ui/supportVehicle/SVChassisView.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVChassisView.java
@@ -87,9 +87,16 @@ public class SVChassisView extends BuildView implements ActionListener, ChangeLi
     }
 
     /** Subset of possible types that does not include those that are not yet supported */
-    private final List<TestSupportVehicle.SVType> SV_TYPES = Arrays.stream(TestSupportVehicle.SVType.values())
-          .filter(t -> !t.equals(TestSupportVehicle.SVType.AIRSHIP)
-                && !t.equals(TestSupportVehicle.SVType.SATELLITE)).toList();
+    private final List<TestSupportVehicle.SVType> SV_TYPES = List.of(
+          TestSupportVehicle.SVType.WHEELED,
+          TestSupportVehicle.SVType.TRACKED,
+          TestSupportVehicle.SVType.HOVERCRAFT,
+          TestSupportVehicle.SVType.VTOL,
+          TestSupportVehicle.SVType.WIGE,
+          TestSupportVehicle.SVType.FIXED_WING,
+          TestSupportVehicle.SVType.NAVAL,
+          TestSupportVehicle.SVType.RAIL
+    );
     private final Map<TestSupportVehicle.SVType, String> typeNames = new EnumMap<>(TestSupportVehicle.SVType.class);
 
     private final static TechAdvancement TA_DUAL_TURRET = Tank.getDualTurretTA();


### PR DESCRIPTION
## What this changes

Set default CV movement mode to tracked
Reorder SV types to match TechManual 6e p11-12 order

## Testing

Tested on build

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a construction rule or changes what a unit file contains
- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result