### PR TITLE
PR: Update Assign Crit UI Layout

### DIFF
--- a/megameklab/src/megameklab/ui/battleArmor/BABuildTab.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BABuildTab.java
@@ -33,6 +33,7 @@
 
 package megameklab.ui.battleArmor;
 
+import java.awt.BorderLayout;
 import java.util.ArrayList;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -69,7 +70,12 @@ public class BABuildTab extends ITab {
 
     public BABuildTab(EntitySource eSource) {
         super(eSource);
-        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
+        setLayout(new BorderLayout());
+        JPanel buildPanel = new JPanel();
+        buildPanel.setLayout(new BoxLayout(buildPanel, BoxLayout.Y_AXIS));
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
+
         createCriticalViews();
         buildView = new BABuildView(eSource);
 
@@ -79,16 +85,14 @@ public class BABuildTab extends ITab {
         JButton resetButton = new JButton("Reset");
         resetButton.setMnemonic('R');
         resetButton.addActionListener(ev -> resetCrits());
-
-        JPanel buttonPanel = new JPanel();
         buttonPanel.add(autoFillButton);
         buttonPanel.add(resetButton);
 
-        Box mainPanel = Box.createVerticalBox();
-        mainPanel.add(buildView);
-        mainPanel.add(buttonPanel);
-        add(critPanel);
-        add(mainPanel);
+        buildPanel.add(buildView);
+        buildPanel.add(buttonPanel);
+
+        this.add(critPanel, BorderLayout.CENTER);
+        this.add(buildPanel, BorderLayout.EAST);
         refresh();
     }
 

--- a/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
@@ -43,7 +43,6 @@ import java.util.Vector;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JMenuItem;
-import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
@@ -97,8 +96,6 @@ public class BABuildView extends IView implements ActionListener, MouseListener 
     public BABuildView(EntitySource eSource) {
         super(eSource);
 
-        JPanel mainPanel = new JPanel();
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
         equipmentList = new CriticalTableModel(getBattleArmor(),
               CriticalTableModel.BUILD_TABLE);
 
@@ -106,29 +103,23 @@ public class BABuildView extends IView implements ActionListener, MouseListener 
         equipmentTable.setDragEnabled(true);
         transferHandler = new CriticalTransferHandler(eSource, null);
         equipmentTable.setTransferHandler(transferHandler);
-
-        equipmentList.initColumnSizes(equipmentTable);
-        TableColumn column;
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
-            column = equipmentTable.getColumnModel().getColumn(i);
+            TableColumn column = equipmentTable.getColumnModel().getColumn(i);
             if (i == 0) {
-                column.setPreferredWidth(350);
+                column.setPreferredWidth(250);
             }
             column.setCellRenderer(equipmentList.getRenderer());
         }
-
         equipmentTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         equipmentTable.setDoubleBuffered(true);
-        JScrollPane equipmentScroll = new JScrollPane();
-        equipmentScroll.setViewportView(equipmentTable);
-        equipmentScroll.setMinimumSize(new Dimension(450, 450));
-        equipmentScroll.setPreferredSize(new Dimension(450, 450));
+        equipmentTable.addMouseListener(this);
+        JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
+        equipmentScroll.setMinimumSize(new Dimension(300, 200));
+        equipmentScroll.setPreferredSize(new Dimension(300, 200));
         equipmentScroll.setTransferHandler(transferHandler);
 
-        mainPanel.add(equipmentScroll);
-        equipmentTable.addMouseListener(this);
-
-        this.add(mainPanel);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        this.add(equipmentScroll);
         setBorder(BorderFactory.createTitledBorder(
               BorderFactory.createEmptyBorder(), "Unallocated Equipment",
               TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));

--- a/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
+++ b/megameklab/src/megameklab/ui/battleArmor/BABuildView.java
@@ -32,7 +32,6 @@
  */
 package megameklab.ui.battleArmor;
 
-import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -50,6 +49,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.border.TitledBorder;
 import javax.swing.table.TableColumn;
 
+import megamek.client.ui.util.UIUtil;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.EquipmentType;
@@ -106,7 +106,7 @@ public class BABuildView extends IView implements ActionListener, MouseListener 
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
             TableColumn column = equipmentTable.getColumnModel().getColumn(i);
             if (i == 0) {
-                column.setPreferredWidth(250);
+                column.setPreferredWidth(UIUtil.scaleForGUI(250));
             }
             column.setCellRenderer(equipmentList.getRenderer());
         }
@@ -114,8 +114,8 @@ public class BABuildView extends IView implements ActionListener, MouseListener 
         equipmentTable.setDoubleBuffered(true);
         equipmentTable.addMouseListener(this);
         JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
-        equipmentScroll.setMinimumSize(new Dimension(300, 200));
-        equipmentScroll.setPreferredSize(new Dimension(300, 200));
+        equipmentScroll.setMinimumSize(UIUtil.scaleForGUI(300, 200));
+        equipmentScroll.setPreferredSize(UIUtil.scaleForGUI(300, 200));
         equipmentScroll.setTransferHandler(transferHandler);
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));

--- a/megameklab/src/megameklab/ui/combatVehicle/CVBuildTab.java
+++ b/megameklab/src/megameklab/ui/combatVehicle/CVBuildTab.java
@@ -32,9 +32,11 @@
  */
 package megameklab.ui.combatVehicle;
 
+import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -72,16 +74,20 @@ public class CVBuildTab extends ITab implements ActionListener {
 
     public CVBuildTab(EntitySource eSource) {
         super(eSource);
-        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
-        JPanel mainPanel = new JPanel();
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+        setLayout(new BorderLayout());
+        JPanel critPanel = new JPanel();
+        critPanel.setLayout(new BoxLayout(critPanel, BoxLayout.Y_AXIS));
+        JPanel buildPanel = new JPanel();
+        buildPanel.setLayout(new BoxLayout(buildPanel, BoxLayout.Y_AXIS));
         JPanel buttonPanel = new JPanel();
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
 
         critView = new CVCriticalView(eSource, refresh);
         unallocatedView = new UnallocatedView(eSource, () -> refresh);
 
-        mainPanel.add(unallocatedView);
+        critPanel.add(Box.createVerticalGlue());
+        critPanel.add(critView);
+        critPanel.add(Box.createVerticalGlue());
 
         autoFillButton.setMnemonic('A');
         autoFillButton.setActionCommand(AUTO_FILL_COMMAND);
@@ -90,10 +96,11 @@ public class CVBuildTab extends ITab implements ActionListener {
         buttonPanel.add(autoFillButton);
         buttonPanel.add(resetButton);
 
-        mainPanel.add(buttonPanel);
+        buildPanel.add(unallocatedView);
+        buildPanel.add(buttonPanel);
 
-        this.add(critView);
-        this.add(mainPanel);
+        this.add(critPanel, BorderLayout.CENTER);
+        this.add(buildPanel, BorderLayout.EAST);
         refresh();
     }
 

--- a/megameklab/src/megameklab/ui/fighterAero/ASBuildTab.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASBuildTab.java
@@ -34,10 +34,10 @@
 package megameklab.ui.fighterAero;
 
 import java.awt.BorderLayout;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 
@@ -56,26 +56,30 @@ public class ASBuildTab extends ITab implements ActionListener {
 
     public ASBuildTab(EntitySource eSource) {
         super(eSource);
+        setLayout(new BorderLayout());
+        JPanel critPanel = new JPanel();
+        critPanel.setLayout(new BoxLayout(critPanel, BoxLayout.Y_AXIS));
+        JPanel buildPanel = new JPanel();
+        buildPanel.setLayout(new BoxLayout(buildPanel, BoxLayout.Y_AXIS));
+        JPanel buttonPanel = new JPanel();
+        buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
 
         critView = new ASCriticalView(eSource, refresh);
         buildView = new ASBuildView(eSource, refresh, critView);
+
+        critPanel.add(Box.createVerticalGlue());
+        critPanel.add(critView);
+        critPanel.add(Box.createVerticalGlue());
+
+        resetButton.setMnemonic('R');
         resetButton.setActionCommand(RESET_COMMAND);
+        buttonPanel.add(resetButton);
 
-        JPanel unallocatedEquipmentBlock = new JPanel(new GridBagLayout());
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.gridx = 0;
-        gbc.fill = GridBagConstraints.VERTICAL;
-        gbc.weightx = 1;
-        gbc.weighty = 1;
-        unallocatedEquipmentBlock.add(buildView, gbc);
-        gbc.fill = GridBagConstraints.NONE;
-        gbc.weighty = 0;
-        unallocatedEquipmentBlock.add(resetButton, gbc);
+        buildPanel.add(buildView);
+        buildPanel.add(buttonPanel);
 
-        setLayout(new BorderLayout(5, 5));
-        add(critView, BorderLayout.CENTER);
-        add(unallocatedEquipmentBlock, BorderLayout.EAST);
-
+        this.add(critPanel, BorderLayout.CENTER);
+        this.add(buildPanel, BorderLayout.EAST);
         refresh();
     }
 

--- a/megameklab/src/megameklab/ui/fighterAero/ASBuildView.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASBuildView.java
@@ -32,7 +32,6 @@
  */
 package megameklab.ui.fighterAero;
 
-import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -42,6 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
@@ -102,29 +102,23 @@ public class ASBuildView extends IView implements ActionListener, MouseListener 
         equipmentTable.setDragEnabled(true);
         cth = new CriticalTransferHandler(eSource, refresh, critView);
         equipmentTable.setTransferHandler(cth);
-        TableColumn column;
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
-            column = equipmentTable.getColumnModel().getColumn(i);
+            TableColumn column = equipmentTable.getColumnModel().getColumn(i);
             if (i == 0) {
-                column.setPreferredWidth(350);
+                column.setPreferredWidth(200);
             }
             column.setCellRenderer(equipmentList.getRenderer());
-
         }
-        equipmentTable.setIntercellSpacing(new Dimension(0, 0));
-        equipmentTable.setShowGrid(false);
         equipmentTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         equipmentTable.setDoubleBuffered(true);
-        JScrollPane equipmentScroll = new JScrollPane();
-        equipmentScroll.setViewportView(equipmentTable);
-        equipmentScroll.setMinimumSize(new Dimension(400, 400));
-        equipmentScroll.setPreferredSize(new Dimension(400, 400));
+        equipmentTable.addMouseListener(this);
+        JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
+        equipmentScroll.setMinimumSize(new Dimension(300, 200));
+        equipmentScroll.setPreferredSize(new Dimension(300, 200));
         equipmentScroll.setTransferHandler(cth);
 
-        equipmentTable.addMouseListener(this);
-
-        setLayout(new BorderLayout());
-        this.add(equipmentScroll, BorderLayout.CENTER);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        this.add(equipmentScroll);
         setBorder(BorderFactory.createTitledBorder(
               BorderFactory.createEmptyBorder(), "Unallocated Equipment",
               TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));

--- a/megameklab/src/megameklab/ui/fighterAero/ASBuildView.java
+++ b/megameklab/src/megameklab/ui/fighterAero/ASBuildView.java
@@ -32,7 +32,6 @@
  */
 package megameklab.ui.fighterAero;
 
-import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -50,6 +49,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.border.TitledBorder;
 import javax.swing.table.TableColumn;
 
+import megamek.client.ui.util.UIUtil;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
@@ -105,7 +105,7 @@ public class ASBuildView extends IView implements ActionListener, MouseListener 
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
             TableColumn column = equipmentTable.getColumnModel().getColumn(i);
             if (i == 0) {
-                column.setPreferredWidth(200);
+                column.setPreferredWidth(UIUtil.scaleForGUI(250));
             }
             column.setCellRenderer(equipmentList.getRenderer());
         }
@@ -113,8 +113,8 @@ public class ASBuildView extends IView implements ActionListener, MouseListener 
         equipmentTable.setDoubleBuffered(true);
         equipmentTable.addMouseListener(this);
         JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
-        equipmentScroll.setMinimumSize(new Dimension(300, 200));
-        equipmentScroll.setPreferredSize(new Dimension(300, 200));
+        equipmentScroll.setMinimumSize(UIUtil.scaleForGUI(300, 200));
+        equipmentScroll.setPreferredSize(UIUtil.scaleForGUI(300, 200));
         equipmentScroll.setTransferHandler(cth);
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));

--- a/megameklab/src/megameklab/ui/generalUnit/UnallocatedView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/UnallocatedView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2009-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -32,6 +32,7 @@
  */
 package megameklab.ui.generalUnit;
 
+import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -39,13 +40,15 @@ import java.awt.event.MouseListener;
 import java.util.List;
 import java.util.Vector;
 import java.util.function.Supplier;
+import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JMenuItem;
-import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
+import javax.swing.border.TitledBorder;
+import javax.swing.table.TableColumn;
 
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.MiscType;
@@ -84,31 +87,32 @@ public class UnallocatedView extends IView implements ActionListener, MouseListe
         super(eSource);
         this.refresh = refresh;
 
-        JPanel mainPanel = new JPanel();
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
         equipmentList = new CriticalTableModel(getEntity(), CriticalTableModel.BUILD_TABLE);
 
         equipmentTable.setModel(equipmentList);
         equipmentTable.setDragEnabled(true);
         cth = new CriticalTransferHandler(eSource, refresh.get());
         equipmentTable.setTransferHandler(cth);
-
-        equipmentList.initColumnSizes(equipmentTable);
-
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
-            equipmentTable.getColumnModel().getColumn(i).setCellRenderer(equipmentList.getRenderer());
+            TableColumn column = equipmentTable.getColumnModel().getColumn(i);
+            if (i == 0) {
+                column.setPreferredWidth(250);
+            }
+            column.setCellRenderer(equipmentList.getRenderer());
         }
-
         equipmentTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         equipmentTable.setDoubleBuffered(true);
-        JScrollPane equipmentScroll = new JScrollPane();
-        equipmentScroll.setViewportView(equipmentTable);
+        equipmentTable.addMouseListener(this);
+        JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
+        equipmentScroll.setMinimumSize(new Dimension(300, 200));
+        equipmentScroll.setPreferredSize(new Dimension(300, 200));
         equipmentScroll.setTransferHandler(cth);
 
-        mainPanel.add(equipmentScroll);
-        equipmentTable.addMouseListener(this);
-
-        this.add(mainPanel);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        this.add(equipmentScroll);
+        setBorder(BorderFactory.createTitledBorder(
+              BorderFactory.createEmptyBorder(), "Unallocated Equipment",
+              TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
     }
 
     public void addRefreshedListener(RefreshListener l) {

--- a/megameklab/src/megameklab/ui/generalUnit/UnallocatedView.java
+++ b/megameklab/src/megameklab/ui/generalUnit/UnallocatedView.java
@@ -32,7 +32,6 @@
  */
 package megameklab.ui.generalUnit;
 
-import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -50,6 +49,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.border.TitledBorder;
 import javax.swing.table.TableColumn;
 
+import megamek.client.ui.util.UIUtil;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
@@ -96,7 +96,7 @@ public class UnallocatedView extends IView implements ActionListener, MouseListe
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
             TableColumn column = equipmentTable.getColumnModel().getColumn(i);
             if (i == 0) {
-                column.setPreferredWidth(250);
+                column.setPreferredWidth(UIUtil.scaleForGUI(250));
             }
             column.setCellRenderer(equipmentList.getRenderer());
         }
@@ -104,8 +104,8 @@ public class UnallocatedView extends IView implements ActionListener, MouseListe
         equipmentTable.setDoubleBuffered(true);
         equipmentTable.addMouseListener(this);
         JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
-        equipmentScroll.setMinimumSize(new Dimension(300, 200));
-        equipmentScroll.setPreferredSize(new Dimension(300, 200));
+        equipmentScroll.setMinimumSize(UIUtil.scaleForGUI(300, 200));
+        equipmentScroll.setPreferredSize(UIUtil.scaleForGUI(300, 200));
         equipmentScroll.setTransferHandler(cth);
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));

--- a/megameklab/src/megameklab/ui/largeAero/LABuildTab.java
+++ b/megameklab/src/megameklab/ui/largeAero/LABuildTab.java
@@ -32,12 +32,12 @@
  */
 package megameklab.ui.largeAero;
 
+import java.awt.BorderLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
-import javax.swing.JComponent;
 import javax.swing.JPanel;
 
 import megameklab.ui.EntitySource;
@@ -46,7 +46,7 @@ import megameklab.ui.util.RefreshListener;
 import megameklab.util.UnitUtil;
 
 /**
- * Build tab for Small Craft and Dropships
+ * Build tab for Small Craft and DropShips
  *
  * @author Neoancient
  */
@@ -66,9 +66,11 @@ public class LABuildTab extends ITab implements ActionListener {
 
     public LABuildTab(EntitySource eSource) {
         super(eSource);
-        setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
-        JPanel mainPanel = new JPanel();
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.PAGE_AXIS));
+        setLayout(new BorderLayout());
+        JPanel critPanel = new JPanel();
+        critPanel.setLayout(new BoxLayout(critPanel, BoxLayout.Y_AXIS));
+        JPanel buildPanel = new JPanel();
+        buildPanel.setLayout(new BoxLayout(buildPanel, BoxLayout.Y_AXIS));
         JPanel buttonPanel = new JPanel();
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
 
@@ -76,20 +78,19 @@ public class LABuildTab extends ITab implements ActionListener {
         critView = new LACriticalView(eSource, refresh);
         critView.addAllocationListeners(buildView);
 
+        critPanel.add(Box.createVerticalGlue());
+        critPanel.add(critView);
+        critPanel.add(Box.createVerticalGlue());
+
         resetButton.setMnemonic('R');
         resetButton.setActionCommand(RESET_COMMAND);
         buttonPanel.add(resetButton);
 
-        buildView.setAlignmentX(JComponent.LEFT_ALIGNMENT);
-        buttonPanel.setAlignmentX(JComponent.LEFT_ALIGNMENT);
-        mainPanel.add(buildView);
-        mainPanel.add(buttonPanel);
+        buildPanel.add(buildView);
+        buildPanel.add(buttonPanel);
 
-        add(Box.createHorizontalGlue());
-        add(critView);
-        add(Box.createHorizontalGlue());
-        add(mainPanel);
-        add(Box.createHorizontalGlue());
+        this.add(critPanel, BorderLayout.CENTER);
+        this.add(buildPanel, BorderLayout.EAST);
         refresh();
     }
 

--- a/megameklab/src/megameklab/ui/largeAero/LABuildView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LABuildView.java
@@ -32,7 +32,6 @@
  */
 package megameklab.ui.largeAero;
 
-import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -44,6 +43,7 @@ import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import javax.swing.table.TableColumn;
 
+import megamek.client.ui.util.UIUtil;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.EquipmentType;
@@ -104,7 +104,7 @@ public class LABuildView extends IView implements MouseListener {
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
             TableColumn column = equipmentTable.getColumnModel().getColumn(i);
             if (i == 0) {
-                column.setPreferredWidth(250);
+                column.setPreferredWidth(UIUtil.scaleForGUI(250));
             }
             column.setCellRenderer(equipmentList.getRenderer());
         }
@@ -112,8 +112,8 @@ public class LABuildView extends IView implements MouseListener {
         equipmentTable.setDoubleBuffered(true);
         equipmentTable.addMouseListener(this);
         JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
-        equipmentScroll.setMinimumSize(new Dimension(300, 200));
-        equipmentScroll.setPreferredSize(new Dimension(300, 200));
+        equipmentScroll.setMinimumSize(UIUtil.scaleForGUI(300, 200));
+        equipmentScroll.setPreferredSize(UIUtil.scaleForGUI(300, 200));
         equipmentScroll.setTransferHandler(cth);
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));

--- a/megameklab/src/megameklab/ui/largeAero/LABuildView.java
+++ b/megameklab/src/megameklab/ui/largeAero/LABuildView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -32,9 +32,7 @@
  */
 package megameklab.ui.largeAero;
 
-import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -42,15 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 import java.util.concurrent.CopyOnWriteArrayList;
-import javax.swing.BorderFactory;
-import javax.swing.JFrame;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import javax.swing.table.TableColumn;
 
@@ -111,27 +101,23 @@ public class LABuildView extends IView implements MouseListener {
             }
         };
         equipmentTable.setTransferHandler(cth);
-        TableColumn column;
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
-            column = equipmentTable.getColumnModel().getColumn(i);
+            TableColumn column = equipmentTable.getColumnModel().getColumn(i);
             if (i == 0) {
-                column.setPreferredWidth(350);
+                column.setPreferredWidth(250);
             }
             column.setCellRenderer(equipmentList.getRenderer());
-
         }
-        equipmentTable.setIntercellSpacing(new Dimension(0, 0));
-        equipmentTable.setShowGrid(false);
         equipmentTable.setSelectionMode(ListSelectionModel.SINGLE_INTERVAL_SELECTION);
         equipmentTable.setDoubleBuffered(true);
-        JScrollPane equipmentScroll = new JScrollPane();
-        equipmentScroll.setViewportView(equipmentTable);
+        equipmentTable.addMouseListener(this);
+        JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
+        equipmentScroll.setMinimumSize(new Dimension(300, 200));
+        equipmentScroll.setPreferredSize(new Dimension(300, 200));
         equipmentScroll.setTransferHandler(cth);
 
-        equipmentTable.addMouseListener(this);
-
-        setLayout(new GridLayout(1, 1));
-        this.add(equipmentScroll, BorderLayout.CENTER);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        this.add(equipmentScroll);
         setBorder(BorderFactory.createTitledBorder(
               BorderFactory.createEmptyBorder(), "Unallocated Equipment",
               TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));

--- a/megameklab/src/megameklab/ui/mek/BMBuildTab.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildTab.java
@@ -32,6 +32,7 @@
  */
 package megameklab.ui.mek;
 
+import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.event.KeyEvent;
 import java.util.ResourceBundle;
@@ -73,19 +74,27 @@ public class BMBuildTab extends ITab {
 
     public BMBuildTab(EntitySource eSource) {
         super(eSource);
+        setLayout(new BorderLayout());
+        JPanel critPanel = new JPanel();
+        critPanel.setLayout(new BoxLayout(critPanel, BoxLayout.Y_AXIS));
+        JPanel buildPanel = new JPanel();
+        buildPanel.setLayout(new BoxLayout(buildPanel, BoxLayout.Y_AXIS));
+
         autoFillUnHitTables.setSelected(CConfig.getBooleanParam(CConfig.MEK_AUTOFILL));
         autoSort.setSelected(CConfig.getBooleanParam(CConfig.MEK_AUTO_SORT));
         autoCompact.setSelected(CConfig.getBooleanParam(CConfig.MEK_AUTO_COMPACT));
         critView = new BMCriticalView(eSource, refresh);
         buildView = new BMBuildView(eSource, refresh, critView);
 
-        Box leftSide = Box.createVerticalBox();
-        leftSide.add(createButtonPanel());
-        leftSide.add(critView);
+        critPanel.add(createButtonPanel());
+        critPanel.add(Box.createVerticalGlue());
+        critPanel.add(critView);
+        critPanel.add(Box.createVerticalGlue());
 
-        setLayout(new BoxLayout(this, BoxLayout.LINE_AXIS));
-        add(leftSide);
-        add(buildView);
+        buildPanel.add(buildView);
+
+        this.add(critPanel, BorderLayout.CENTER);
+        this.add(buildPanel, BorderLayout.EAST);
         refresh();
     }
 

--- a/megameklab/src/megameklab/ui/mek/BMBuildView.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildView.java
@@ -32,7 +32,6 @@
  */
 package megameklab.ui.mek;
 
-import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -41,6 +40,7 @@ import java.awt.event.MouseListener;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
@@ -94,19 +94,20 @@ public class BMBuildView extends IView implements ActionListener, MouseListener 
                 column.setPreferredWidth(250);
             }
             column.setCellRenderer(equipmentList.getRenderer());
-
         }
-        equipmentTable.setIntercellSpacing(new Dimension(0, 0));
-        equipmentTable.setShowGrid(false);
         equipmentTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         equipmentTable.setDoubleBuffered(true);
         equipmentTable.addMouseListener(this);
         JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
+        equipmentScroll.setMinimumSize(new Dimension(300, 200));
+        equipmentScroll.setPreferredSize(new Dimension(300, 200));
         equipmentScroll.setTransferHandler(transferHandler);
-        setLayout(new BorderLayout());
-        this.add(equipmentScroll, BorderLayout.CENTER);
-        setBorder(BorderFactory.createTitledBorder(BorderFactory.createEmptyBorder(),
-              "Unallocated Equipment", TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
+
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        this.add(equipmentScroll);
+        setBorder(BorderFactory.createTitledBorder(
+              BorderFactory.createEmptyBorder(), "Unallocated Equipment",
+              TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
     }
 
     public void addRefreshedListener(RefreshListener l) {

--- a/megameklab/src/megameklab/ui/mek/BMBuildView.java
+++ b/megameklab/src/megameklab/ui/mek/BMBuildView.java
@@ -32,7 +32,6 @@
  */
 package megameklab.ui.mek;
 
-import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
@@ -50,6 +49,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.border.TitledBorder;
 import javax.swing.table.TableColumn;
 
+import megamek.client.ui.util.UIUtil;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponType;
@@ -91,7 +91,7 @@ public class BMBuildView extends IView implements ActionListener, MouseListener 
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
             TableColumn column = equipmentTable.getColumnModel().getColumn(i);
             if (i == 0) {
-                column.setPreferredWidth(250);
+                column.setPreferredWidth(UIUtil.scaleForGUI(250));
             }
             column.setCellRenderer(equipmentList.getRenderer());
         }
@@ -99,8 +99,8 @@ public class BMBuildView extends IView implements ActionListener, MouseListener 
         equipmentTable.setDoubleBuffered(true);
         equipmentTable.addMouseListener(this);
         JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
-        equipmentScroll.setMinimumSize(new Dimension(300, 200));
-        equipmentScroll.setPreferredSize(new Dimension(300, 200));
+        equipmentScroll.setMinimumSize(UIUtil.scaleForGUI(300, 200));
+        equipmentScroll.setPreferredSize(UIUtil.scaleForGUI(300, 200));
         equipmentScroll.setTransferHandler(transferHandler);
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));

--- a/megameklab/src/megameklab/ui/protoMek/PMBuildTab.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMBuildTab.java
@@ -32,9 +32,11 @@
  */
 package megameklab.ui.protoMek;
 
+import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -73,16 +75,20 @@ public class PMBuildTab extends ITab implements ActionListener {
     public PMBuildTab(EntitySource eSource, RefreshListener refresh) {
         super(eSource);
         this.refresh = refresh;
-        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
-        JPanel mainPanel = new JPanel();
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+        setLayout(new BorderLayout());
+        JPanel critPanel = new JPanel();
+        critPanel.setLayout(new BoxLayout(critPanel, BoxLayout.Y_AXIS));
+        JPanel buildPanel = new JPanel();
+        buildPanel.setLayout(new BoxLayout(buildPanel, BoxLayout.Y_AXIS));
         JPanel buttonPanel = new JPanel();
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
 
         critView = new PMCriticalView(eSource, refresh);
         buildView = new PMBuildView(eSource, refresh, critView);
 
-        mainPanel.add(buildView);
+        critPanel.add(Box.createVerticalGlue());
+        critPanel.add(critView);
+        critPanel.add(Box.createVerticalGlue());
 
         autoFillButton.setMnemonic('A');
         autoFillButton.setActionCommand(AUTO_FILL_COMMAND);
@@ -91,10 +97,11 @@ public class PMBuildTab extends ITab implements ActionListener {
         buttonPanel.add(autoFillButton);
         buttonPanel.add(resetButton);
 
-        mainPanel.add(buttonPanel);
+        buildPanel.add(buildView);
+        buildPanel.add(buttonPanel);
 
-        this.add(critView);
-        this.add(mainPanel);
+        this.add(critPanel, BorderLayout.CENTER);
+        this.add(buildPanel, BorderLayout.EAST);
         refresh();
     }
 

--- a/megameklab/src/megameklab/ui/protoMek/PMBuildView.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMBuildView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMekLab.
  *
@@ -39,13 +39,15 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.List;
 import java.util.Vector;
+import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JMenuItem;
-import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
+import javax.swing.border.TitledBorder;
+import javax.swing.table.TableColumn;
 
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.MiscType;
@@ -83,34 +85,32 @@ public class PMBuildView extends IView implements ActionListener, MouseListener 
     public PMBuildView(EntitySource eSource, RefreshListener refresh, CriticalSlotsView criticalSlotsView) {
         super(eSource);
 
-        JPanel mainPanel = new JPanel();
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
         equipmentList = new CriticalTableModel(getProtoMek(), CriticalTableModel.BUILD_TABLE);
 
         equipmentTable.setModel(equipmentList);
         equipmentTable.setDragEnabled(true);
         cth = new CriticalTransferHandler(eSource, refresh, criticalSlotsView);
         equipmentTable.setTransferHandler(cth);
-        equipmentTable.setIntercellSpacing(new Dimension(0, 0));
-        equipmentTable.setShowGrid(false);
-        equipmentTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-
-        equipmentList.initColumnSizes(equipmentTable);
-
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
-            equipmentTable.getColumnModel().getColumn(i).setCellRenderer(equipmentList.getRenderer());
+            TableColumn column = equipmentTable.getColumnModel().getColumn(i);
+            if (i == 0) {
+                column.setPreferredWidth(250);
+            }
+            column.setCellRenderer(equipmentList.getRenderer());
         }
-
         equipmentTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         equipmentTable.setDoubleBuffered(true);
-        JScrollPane equipmentScroll = new JScrollPane();
-        equipmentScroll.setViewportView(equipmentTable);
+        equipmentTable.addMouseListener(this);
+        JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
+        equipmentScroll.setMinimumSize(new Dimension(300, 200));
+        equipmentScroll.setPreferredSize(new Dimension(300, 200));
         equipmentScroll.setTransferHandler(cth);
 
-        mainPanel.add(equipmentScroll);
-        equipmentTable.addMouseListener(this);
-
-        this.add(mainPanel);
+        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+        this.add(equipmentScroll);
+        setBorder(BorderFactory.createTitledBorder(
+              BorderFactory.createEmptyBorder(), "Unallocated Equipment",
+              TitledBorder.TOP, TitledBorder.DEFAULT_POSITION));
     }
 
     public void addRefreshedListener(RefreshListener l) {

--- a/megameklab/src/megameklab/ui/protoMek/PMBuildView.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMBuildView.java
@@ -49,6 +49,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.border.TitledBorder;
 import javax.swing.table.TableColumn;
 
+import megamek.client.ui.util.UIUtil;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
@@ -94,7 +95,7 @@ public class PMBuildView extends IView implements ActionListener, MouseListener 
         for (int i = 0; i < equipmentList.getColumnCount(); i++) {
             TableColumn column = equipmentTable.getColumnModel().getColumn(i);
             if (i == 0) {
-                column.setPreferredWidth(250);
+                column.setPreferredWidth(UIUtil.scaleForGUI(250));
             }
             column.setCellRenderer(equipmentList.getRenderer());
         }
@@ -102,8 +103,8 @@ public class PMBuildView extends IView implements ActionListener, MouseListener 
         equipmentTable.setDoubleBuffered(true);
         equipmentTable.addMouseListener(this);
         JScrollPane equipmentScroll = new JScrollPane(equipmentTable);
-        equipmentScroll.setMinimumSize(new Dimension(300, 200));
-        equipmentScroll.setPreferredSize(new Dimension(300, 200));
+        equipmentScroll.setMinimumSize(UIUtil.scaleForGUI(300, 200));
+        equipmentScroll.setPreferredSize(UIUtil.scaleForGUI(300, 200));
         equipmentScroll.setTransferHandler(cth);
 
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));

--- a/megameklab/src/megameklab/ui/protoMek/PMBuildView.java
+++ b/megameklab/src/megameklab/ui/protoMek/PMBuildView.java
@@ -32,7 +32,6 @@
  */
 package megameklab.ui.protoMek;
 
-import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;

--- a/megameklab/src/megameklab/ui/supportVehicle/SVBuildTab.java
+++ b/megameklab/src/megameklab/ui/supportVehicle/SVBuildTab.java
@@ -32,9 +32,11 @@
  */
 package megameklab.ui.supportVehicle;
 
+import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -79,16 +81,20 @@ public class SVBuildTab extends ITab implements ActionListener {
 
     public SVBuildTab(EntitySource eSource) {
         super(eSource);
-        setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
-        JPanel mainPanel = new JPanel();
-        mainPanel.setLayout(new BoxLayout(mainPanel, BoxLayout.Y_AXIS));
+        setLayout(new BorderLayout());
+        JPanel critPanel = new JPanel();
+        critPanel.setLayout(new BoxLayout(critPanel, BoxLayout.Y_AXIS));
+        JPanel buildPanel = new JPanel();
+        buildPanel.setLayout(new BoxLayout(buildPanel, BoxLayout.Y_AXIS));
         JPanel buttonPanel = new JPanel();
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.X_AXIS));
 
         critView = new SVCriticalView(eSource, refresh);
         unallocatedView = new UnallocatedView(eSource, () -> refresh);
 
-        mainPanel.add(unallocatedView);
+        critPanel.add(Box.createVerticalGlue());
+        critPanel.add(critView);
+        critPanel.add(Box.createVerticalGlue());
 
         autoFillButton.setMnemonic('A');
         autoFillButton.setActionCommand(AUTO_FILL_COMMAND);
@@ -97,10 +103,11 @@ public class SVBuildTab extends ITab implements ActionListener {
         buttonPanel.add(autoFillButton);
         buttonPanel.add(resetButton);
 
-        mainPanel.add(buttonPanel);
+        buildPanel.add(unallocatedView);
+        buildPanel.add(buttonPanel);
 
-        this.add(critView);
-        this.add(mainPanel);
+        this.add(critPanel, BorderLayout.CENTER);
+        this.add(buildPanel, BorderLayout.EAST);
         refresh();
     }
 


### PR DESCRIPTION
## What this changes

Update Assign Criticals UI layouts so that crits are centred, and the Unallocated Equipment table is consistent across entity builders

Center crits and auto assign/reset buttons
Add Unallocated Equipment labels
Update table min size

## Testing

Tested in build

<img width="1194" height="571" alt="Screenshot 2026-09-10 at 2 39 19 AM" src="https://github.com/user-attachments/assets/25626f04-fda2-454c-881c-128f510e88ec" />

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a construction rule or changes what a unit file contains
- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result