### PR TITLE
Fix: MML 2329 Fix Auto-Fill Freezer

### DIFF
--- a/megameklab/src/megameklab/util/MekUtil.java
+++ b/megameklab/src/megameklab/util/MekUtil.java
@@ -924,12 +924,14 @@ public final class MekUtil {
      * any.
      */
     public static void fillInAllEquipment(Mek mek) {
-        int externalEngineHS = UnitUtil.getCriticalFreeHeatSinks(mek, mek.hasCompactHeatSinks());
+        int engineFreeHS = UnitUtil.getCriticalFreeHeatSinks(mek, mek.hasCompactHeatSinks());
         // Create a copy of the equipment list to iterate over
         List<Mounted<?>> equipmentList = new ArrayList<>(mek.getEquipment());
         for (Mounted<?> mount : equipmentList) {
             if ((mount.getLocation() != Entity.LOC_NONE)
-                  || (UnitUtil.isHeatSink(mount) && (externalEngineHS-- > 0))) {
+                  || (UnitUtil.isHeatSink(mount)
+                  && !mount.getType().hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)
+                  && (engineFreeHS-- > 0))) {
                 continue;
             }
             for (int location = Mek.LOC_HEAD; location < mek.locations(); location++) {


### PR DESCRIPTION
## What this changes

Fix https://github.com/MegaMek/megameklab/issues/2329

Fix freezers not autofilling due to being erroneously counted as engine free heat sinks

## Testing

Tested in build

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a construction rule or changes what a unit file contains
- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result